### PR TITLE
Add more env vars and minor tweaks to the effort type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Settings are environment variables on the proxy process, not a config file.
 | `CCP_LOG_VERBOSE` | unset                            | Log full request/response bodies + every SSE event |
 | `KIMI_OAUTH_HOST` | `https://auth.kimi.com`          | Override Kimi's OAuth host (debugging only)        |
 | `KIMI_BASE_URL`   | `https://api.kimi.com/coding/v1` | Override Kimi's API base URL                       |
+| `CCP_CODEX_MODEL` | unset                            | Force all Codex requests to this model (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.4-mini`) |
+| `CCP_CODEX_EFFORT`| unset                            | Force all Codex requests to this reasoning effort (`none`, `low`, `medium`, `high`, `xhigh`) |
 
 ### Files
 

--- a/src/anthropic/schema.ts
+++ b/src/anthropic/schema.ts
@@ -61,7 +61,7 @@ export interface AnthropicRequest {
   stream?: boolean
   thinking?: { type: string; [k: string]: unknown }
   output_config?: {
-    effort?: "low" | "medium" | "high"
+    effort?: "low" | "medium" | "high" | "xhigh"
     format?: { type: "json_schema"; schema: unknown; name?: string; strict?: boolean }
   }
   context_management?: unknown

--- a/src/anthropic/schema.ts
+++ b/src/anthropic/schema.ts
@@ -61,7 +61,7 @@ export interface AnthropicRequest {
   stream?: boolean
   thinking?: { type: string; [k: string]: unknown }
   output_config?: {
-    effort?: "low" | "medium" | "high" | "xhigh"
+    effort?: "low" | "medium" | "high" | "max"
     format?: { type: "json_schema"; schema: unknown; name?: string; strict?: boolean }
   }
   context_management?: unknown

--- a/src/providers/codex/translate/model-allowlist.ts
+++ b/src/providers/codex/translate/model-allowlist.ts
@@ -16,6 +16,20 @@ export const MODEL_ALIASES = new Map<string, string>([
 ])
 
 export function resolveModel(model: string): string {
+  // The CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE environment variable allows
+  // for the model that's used to be overridden so that regardless of whatever
+  // model is being requested by the harness, the model which is provided in
+  // that env var is always returned.
+  //
+  // This is useful in cases where you just want the claude-code harness to use
+  // a specific model all across the way.
+  if (
+    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE !== undefined &&
+    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE !== ""
+  ) {
+    return process.env.CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE
+  }
+
   return MODEL_ALIASES.get(model) ?? model
 }
 

--- a/src/providers/codex/translate/model-allowlist.ts
+++ b/src/providers/codex/translate/model-allowlist.ts
@@ -16,18 +16,14 @@ export const MODEL_ALIASES = new Map<string, string>([
 ])
 
 export function resolveModel(model: string): string {
-  // The CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE environment variable allows
-  // for the model that's used to be overridden so that regardless of whatever
-  // model is being requested by the harness, the model which is provided in
-  // that env var is always returned.
-  //
-  // This is useful in cases where you just want the claude-code harness to use
-  // a specific model all across the way.
+  // The CCP_CODEX_MODEL environment variable overrides the model so that
+  // regardless of whatever model is requested by the harness, the provided
+  // model is always used.
   if (
-    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE !== undefined &&
-    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE !== ""
+    process.env.CCP_CODEX_MODEL !== undefined &&
+    process.env.CCP_CODEX_MODEL !== ""
   ) {
-    return process.env.CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE
+    return process.env.CCP_CODEX_MODEL
   }
 
   return MODEL_ALIASES.get(model) ?? model

--- a/src/providers/codex/translate/request.ts
+++ b/src/providers/codex/translate/request.ts
@@ -7,6 +7,8 @@ import type {
   AnthropicTool,
 } from "../../../anthropic/schema.ts"
 
+export type Effort = "none" | "low" | "medium" | "high" | "xhigh"
+
 // Keep this aligned to the upstream Codex ResponsesApiRequest field set.
 // Do not add plausible-looking top-level fields without source support or a confirmed live test.
 export interface ResponsesRequest {
@@ -20,7 +22,7 @@ export interface ResponsesRequest {
     | "required"
     | { type: "function"; name: string }
   parallel_tool_calls?: boolean
-  reasoning?: { effort?: "low" | "medium" | "high"; summary?: unknown }
+  reasoning?: { effort?: Effort; summary?: unknown }
   store: false
   stream: true
   include?: string[]
@@ -71,6 +73,24 @@ export interface TranslateOptions {
   sessionId?: string
 }
 
+function resolveEffort(effort?: Effort): Effort | undefined {
+  // The CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE environment variable allows
+  // for the effort that's used to be overridden so that regardless of whatever
+  // effort is being requested by the harness, the effort which is provided in
+  // that env var is always returned.
+  //
+  // This is useful in cases where you just want the claude-code harness to use
+  // a specific effort all across the way.
+  if (
+    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE !== undefined &&
+    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE !== ""
+  ) {
+    return process.env.CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE as Effort
+  }
+
+  return effort
+}
+
 export function translateRequest(req: AnthropicRequest, opts: TranslateOptions = {}): ResponsesRequest {
   const instructions = buildInstructions(req.system)
   const input = buildInput(req.messages)
@@ -99,7 +119,7 @@ export function translateRequest(req: AnthropicRequest, opts: TranslateOptions =
   if (instructions) out.instructions = instructions
   if (tools && tools.length) out.tools = tools
   if (opts.sessionId) out.prompt_cache_key = opts.sessionId
-  const effort = req.output_config?.effort
+  const effort = resolveEffort(req.output_config?.effort)
   if (effort) {
     out.reasoning = { effort }
     out.include = ["reasoning.encrypted_content"]

--- a/src/providers/codex/translate/request.ts
+++ b/src/providers/codex/translate/request.ts
@@ -75,6 +75,16 @@ export interface TranslateOptions {
 
 const VALID_EFFORTS = new Set<Effort>(["none", "low", "medium", "high", "xhigh"])
 
+const ANTHROPIC_EFFORTS = new Set(["low", "medium", "high", "max"])
+
+function assertValidEffort(effort: unknown): void {
+  if (effort !== undefined && !ANTHROPIC_EFFORTS.has(effort as string)) {
+    throw new Error(
+      `Invalid output_config.effort: "${effort}". Must be one of: ${Array.from(ANTHROPIC_EFFORTS).join(", ")}`,
+    )
+  }
+}
+
 function toCodexEffort(
   effort: NonNullable<AnthropicRequest["output_config"]>["effort"],
 ): Effort | undefined {
@@ -123,6 +133,7 @@ export function translateRequest(req: AnthropicRequest, opts: TranslateOptions =
   if (instructions) out.instructions = instructions
   if (tools && tools.length) out.tools = tools
   if (opts.sessionId) out.prompt_cache_key = opts.sessionId
+  assertValidEffort(req.output_config?.effort)
   const effort = resolveEffort(toCodexEffort(req.output_config?.effort))
   if (effort) {
     out.reasoning = { effort }

--- a/src/providers/codex/translate/request.ts
+++ b/src/providers/codex/translate/request.ts
@@ -73,22 +73,26 @@ export interface TranslateOptions {
   sessionId?: string
 }
 
-function resolveEffort(effort?: Effort): Effort | undefined {
-  // The CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE environment variable allows
-  // for the effort that's used to be overridden so that regardless of whatever
-  // effort is being requested by the harness, the effort which is provided in
-  // that env var is always returned.
-  //
-  // This is useful in cases where you just want the claude-code harness to use
-  // a specific effort all across the way.
-  if (
-    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE !== undefined &&
-    process.env.CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE !== ""
-  ) {
-    return process.env.CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE as Effort
-  }
+const VALID_EFFORTS = new Set<Effort>(["none", "low", "medium", "high", "xhigh"])
 
+function toCodexEffort(
+  effort: NonNullable<AnthropicRequest["output_config"]>["effort"],
+): Effort | undefined {
+  if (effort === "max") return "xhigh"
   return effort
+}
+
+function resolveEffort(effort?: Effort): Effort | undefined {
+  const override = process.env.CCP_CODEX_EFFORT
+  if (override === undefined || override === "") {
+    return effort
+  }
+  if (!VALID_EFFORTS.has(override as Effort)) {
+    throw new Error(
+      `Invalid effort override: "${override}". Must be one of: ${Array.from(VALID_EFFORTS).join(", ")}`,
+    )
+  }
+  return override as Effort
 }
 
 export function translateRequest(req: AnthropicRequest, opts: TranslateOptions = {}): ResponsesRequest {
@@ -119,7 +123,7 @@ export function translateRequest(req: AnthropicRequest, opts: TranslateOptions =
   if (instructions) out.instructions = instructions
   if (tools && tools.length) out.tools = tools
   if (opts.sessionId) out.prompt_cache_key = opts.sessionId
-  const effort = resolveEffort(req.output_config?.effort)
+  const effort = resolveEffort(toCodexEffort(req.output_config?.effort))
   if (effort) {
     out.reasoning = { effort }
     out.include = ["reasoning.encrypted_content"]

--- a/src/providers/kimi/translate/request.ts
+++ b/src/providers/kimi/translate/request.ts
@@ -101,13 +101,13 @@ function clampMaxTokens(requested: number | undefined): number {
   return Math.min(requested, DEFAULT_MAX_TOKENS)
 }
 
-// Kimi's reasoning_effort is capped at "high"; collapse the proxy's "xhigh"
-// extension to "high" since Kimi has no stronger tier, and default to "medium"
-// when no effort is requested.
+// Kimi's reasoning_effort is capped at "high"; collapse the proxy's "max"
+// to "high" since Kimi has no stronger tier, and default to "medium" when no
+// effort is requested.
 function mapReasoningEffort(
   effort: NonNullable<AnthropicRequest["output_config"]>["effort"],
 ): "low" | "medium" | "high" {
-  if (effort === "xhigh") return "high"
+  if (effort === "max") return "high"
   return effort ?? "medium"
 }
 

--- a/src/providers/kimi/translate/request.ts
+++ b/src/providers/kimi/translate/request.ts
@@ -80,6 +80,7 @@ export function translateRequest(
   const messages = buildMessages(req)
   const tools = req.tools?.map(toKimiTool)
 
+  assertValidEffort(req.output_config?.effort)
   const out: KimiChatRequest = {
     model: req.model,
     messages,
@@ -99,6 +100,16 @@ export function translateRequest(
 function clampMaxTokens(requested: number | undefined): number {
   if (!requested || requested <= 0) return DEFAULT_MAX_TOKENS
   return Math.min(requested, DEFAULT_MAX_TOKENS)
+}
+
+const ANTHROPIC_EFFORTS = new Set(["low", "medium", "high", "max"])
+
+function assertValidEffort(effort: unknown): void {
+  if (effort !== undefined && !ANTHROPIC_EFFORTS.has(effort as string)) {
+    throw new Error(
+      `Invalid output_config.effort: "${effort}". Must be one of: ${Array.from(ANTHROPIC_EFFORTS).join(", ")}`,
+    )
+  }
 }
 
 // Kimi's reasoning_effort is capped at "high"; collapse the proxy's "max"

--- a/src/providers/kimi/translate/request.ts
+++ b/src/providers/kimi/translate/request.ts
@@ -86,7 +86,7 @@ export function translateRequest(
     stream: true,
     stream_options: { include_usage: true },
     max_tokens: clampMaxTokens(req.max_tokens),
-    reasoning_effort: req.output_config?.effort ?? "medium",
+    reasoning_effort: mapReasoningEffort(req.output_config?.effort),
     thinking: { type: "enabled" },
   }
   if (tools && tools.length) out.tools = tools
@@ -99,6 +99,16 @@ export function translateRequest(
 function clampMaxTokens(requested: number | undefined): number {
   if (!requested || requested <= 0) return DEFAULT_MAX_TOKENS
   return Math.min(requested, DEFAULT_MAX_TOKENS)
+}
+
+// Kimi's reasoning_effort is capped at "high"; collapse the proxy's "xhigh"
+// extension to "high" since Kimi has no stronger tier, and default to "medium"
+// when no effort is requested.
+function mapReasoningEffort(
+  effort: NonNullable<AnthropicRequest["output_config"]>["effort"],
+): "low" | "medium" | "high" {
+  if (effort === "xhigh") return "high"
+  return effort ?? "medium"
 }
 
 function mapToolChoice(choice: AnthropicRequest["tool_choice"]): KimiToolChoice {


### PR DESCRIPTION
# Description

This PR adds two new environment variables that I needed when using this proxy and also makes some minor changes to the type declaration of the `effort`.

## Environment Variables

All of these were added based on my own usage of this proxy and based on my own needs. To elaborate a bit more, I use this proxy in conjunction with the [agent-teams](https://code.claude.com/docs/en/agent-teams) feature provided by the claude code harness. When using this feature it's very hard to instruct the team lead on what model to choose when spawning team mates and what effort level to set. Sadly, most of the time it looks like the model would just ignore these instructions as it looks like the tool that they use to spawn team mates doesn't give them this level of control over the models to use. I use gpt-5.4 with the claude code harness exclusively for the agent-teams feature and therefore I wanted to be able to completely override the selected model and effort level at a proxy level so that all requests, no matter what the selected model is, go to gpt-5.4 xhigh.

- `CLAUDE_CODEX_PROXY_OPEN_AI_MODEL_OVERRIDE` - Allows for the proxy to override the selected model with the model provided in the environment variable.
- `CLAUDE_CODEX_PROXY_OPEN_AI_EFFORT_OVERRIDE` - Allows for the proxy to override the selected effort level with the effort level provided in the environment variable.

## Effort Type Definition

With the release of opus-4-7, claude now has an xhigh effort level. Due to that, I've redefined effort to be it's own type alias defined as follows:

```typescript
export type Effort = "none" | "low" | "medium" | "high" | "xhigh"
```