### PR TITLE
fix(cursor): force Composer 2.5 non-fast mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ upstream for each request is chosen from `ANTHROPIC_MODEL`.
 
 - `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4-mini`, `gpt-5.2` → **codex**
 - `kimi-for-coding`, `kimi-k2.6`, `k2.6` → **kimi**
-- `cursor`, `cursor-plan`, `cursor-ask`, `composer-2.5-fast`, `cursor:<model-id>`, `cursor-plan:<model-id>`, `cursor-ask:<model-id>` → **cursor**
+- `cursor`, `cursor-plan`, `cursor-ask`, `composer-2.5`, `composer-2.5-fast`, `cursor:<model-id>`, `cursor-plan:<model-id>`, `cursor-ask:<model-id>` → **cursor**
 
 An unknown model returns a 400 listing the supported ids. There is no
 implicit default provider.

--- a/src/providers/cursor/translate/model.test.ts
+++ b/src/providers/cursor/translate/model.test.ts
@@ -17,7 +17,10 @@ describe("Cursor model selection", () => {
   it("maps composer aliases explicitly", () => {
     expect(resolveCursorModel({ model: "cursor-composer", metadata: undefined })).toEqual({
       mode: "AGENT_MODE_AGENT",
-      requestedModel: { modelId: "composer-2.5" },
+      requestedModel: {
+        modelId: "composer-2.5",
+        parameters: [{ id: "fast", value: "false" }],
+      },
     });
     expect(resolveCursorModel({ model: "cursor-composer-fast", metadata: undefined })).toEqual({
       mode: "AGENT_MODE_AGENT",
@@ -49,6 +52,14 @@ describe("Cursor model selection", () => {
     expect(selected.requestedModel).toEqual({
       modelId: "claude-sonnet-4-6",
       parameters: [{ id: "fast", value: "true" }],
+    });
+
+    expect(resolveCursorModel({
+      model: "cursor:composer-2.5",
+      metadata: undefined,
+    }).requestedModel).toEqual({
+      modelId: "composer-2.5",
+      parameters: [{ id: "fast", value: "false" }],
     });
   });
 

--- a/src/providers/cursor/translate/model.ts
+++ b/src/providers/cursor/translate/model.ts
@@ -9,6 +9,11 @@ export interface CursorModelSelection {
 
 type AnthropicEffort = NonNullable<AnthropicRequest["output_config"]>["effort"];
 
+const COMPOSER_2_5_MODEL: CursorModelRequest = {
+  modelId: "composer-2.5",
+  parameters: [{ id: "fast", value: "false" }],
+};
+
 const LEGACY_CURSOR_MODELS = [
   "cursor",
   "cursor-agent",
@@ -61,7 +66,7 @@ export function resolveCursorModel(req: Pick<AnthropicRequest, "model" | "metada
       return { requestedModel: { modelId: "default" }, mode };
     case "cursor-composer":
     case "composer-2.5":
-      return { requestedModel: { modelId: "composer-2.5" }, mode };
+      return { requestedModel: COMPOSER_2_5_MODEL, mode };
     case "cursor-composer-fast":
     case "composer-2.5-fast":
       return {
@@ -74,6 +79,7 @@ export function resolveCursorModel(req: Pick<AnthropicRequest, "model" | "metada
 }
 
 function parseRawCursorModel(raw: string): CursorModelRequest {
+  if (raw === "composer-2.5") return COMPOSER_2_5_MODEL;
   if (CURSOR_AGENT_MODEL_ID_SET.has(raw)) return { modelId: raw };
   if (raw.endsWith("-fast")) {
     return {


### PR DESCRIPTION
  Cursor treats Composer 2.5 as fast unless the request explicitly sets
  fast=false. Update Cursor model resolution so composer-2.5 and
  cursor:composer-2.5 send fast=false, while composer-2.5-fast remains
  explicitly fast.

  Also document composer-2.5 as a Cursor model alias and add regression
  coverage for the prefixed Cursor model form.

  Verified:
  - bun run typecheck
  - bun test src/providers/cursor/translate/model.test.ts src/providers/cursor/client.test.ts
  - bun test
  - claude -p with cursor:composer-2.5; traffic capture confirmed fast=false