### PR TITLE
Show Codex Reasoning Summaries as Thinking Blocks

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -12,6 +12,7 @@ import {
   codexUserAgent,
   codexModel,
   codexEffort,
+  codexReasoningSummary,
   codexServiceTier,
   codexBaseUrl,
   codexTransport,
@@ -87,6 +88,7 @@ describe("config defaults", () => {
     expect(codexUserAgent("default-ua")).toBe("default-ua");
     expect(codexModel()).toBeUndefined();
     expect(codexEffort()).toBeUndefined();
+    expect(codexReasoningSummary()).toBeUndefined();
     expect(codexServiceTier()).toBeUndefined();
     expect(codexBaseUrl("default-codex-url")).toBe("default-codex-url");
     expect(codexTransport()).toBe("websocket");
@@ -120,6 +122,20 @@ describe("file overrides default", () => {
     writeFileSync(configPath, JSON.stringify({ codex: { serviceTier: "fast" } }));
     setEnv({});
     expect(codexServiceTier()).toBe("fast");
+  });
+
+  it("codex.reasoningSummary from config.json", () => {
+    writeFileSync(configPath, JSON.stringify({ codex: { reasoningSummary: "off" } }));
+    setEnv({});
+    expect(codexReasoningSummary()).toBe("off");
+  });
+
+  it("codex.reasoningSummary env beats file and empty env falls through", () => {
+    writeFileSync(configPath, JSON.stringify({ codex: { reasoningSummary: "off" } }));
+    setEnv({ CCP_CODEX_REASONING_SUMMARY: "auto" });
+    expect(codexReasoningSummary()).toBe("auto");
+    setEnv({ CCP_CODEX_REASONING_SUMMARY: "" });
+    expect(codexReasoningSummary()).toBe("off");
   });
 
   it("codex.baseUrl from config.json", () => {
@@ -397,6 +413,7 @@ describe("config summary", () => {
       CCP_KIMI_USER_AGENT: "env-kimi-ua",
       CCP_CODEX_MODEL: "gpt-5.5",
       CCP_CODEX_EFFORT: "medium",
+      CCP_CODEX_REASONING_SUMMARY: "off",
       CCP_CODEX_SERVICE_TIER: "fast",
       CCP_CODEX_BASE_URL: "https://codex-env.example.com",
       CCP_CODEX_TRANSPORT: "auto",
@@ -417,6 +434,7 @@ describe("config summary", () => {
       "CCP_KIMI_USER_AGENT (env)",
       "CCP_CODEX_MODEL (env)",
       "CCP_CODEX_EFFORT (env)",
+      "CCP_CODEX_REASONING_SUMMARY (env)",
       "CCP_CODEX_SERVICE_TIER (env)",
       "CCP_CODEX_BASE_URL (env)",
       "CCP_CODEX_TRANSPORT=auto (env)",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ export interface FileConfig {
     userAgent?: string;
     model?: string;
     effort?: string;
+    reasoningSummary?: string;
     serviceTier?: string;
     baseUrl?: string;
     transport?: CodexTransport;
@@ -140,6 +141,7 @@ function validate(raw: unknown): FileConfig {
       "userAgent",
       "model",
       "effort",
+      "reasoningSummary",
       "serviceTier",
       "baseUrl",
       "transport",
@@ -150,6 +152,7 @@ function validate(raw: unknown): FileConfig {
       userAgent: "string",
       model: "string",
       effort: "string",
+      reasoningSummary: "string",
       serviceTier: "string",
       baseUrl: "string",
       transport: "string",
@@ -261,6 +264,13 @@ export function codexEffort(): string | undefined {
   return emptyOrUnset(c.env.CCP_CODEX_EFFORT) ?? emptyOrUnset(c.file.codex?.effort);
 }
 
+export function codexReasoningSummary(): string | undefined {
+  const c = getConfig();
+  return (
+    emptyOrUnset(c.env.CCP_CODEX_REASONING_SUMMARY) ?? emptyOrUnset(c.file.codex?.reasoningSummary)
+  );
+}
+
 export function codexServiceTier(): string | undefined {
   const c = getConfig();
   return emptyOrUnset(c.env.CCP_CODEX_SERVICE_TIER) ?? emptyOrUnset(c.file.codex?.serviceTier);
@@ -307,7 +317,9 @@ export function cursorBaseUrl(): string {
 
 export function cursorClientVersion(): string {
   const c = getConfig();
-  return c.env.CCP_CURSOR_CLIENT_VERSION ?? c.file.cursor?.clientVersion ?? "cli-2026.06.04-5fd875e";
+  return (
+    c.env.CCP_CURSOR_CLIENT_VERSION ?? c.file.cursor?.clientVersion ?? "cli-2026.06.04-5fd875e"
+  );
 }
 
 function resolvedCodexTransport(c: LoadedConfig): CodexTransport {
@@ -339,7 +351,9 @@ function resolvedCursorBaseUrl(c: LoadedConfig): string {
 }
 
 function resolvedCursorClientVersion(c: LoadedConfig): string {
-  return c.env.CCP_CURSOR_CLIENT_VERSION ?? c.file.cursor?.clientVersion ?? "cli-2026.06.04-5fd875e";
+  return (
+    c.env.CCP_CURSOR_CLIENT_VERSION ?? c.file.cursor?.clientVersion ?? "cli-2026.06.04-5fd875e"
+  );
 }
 
 export function configOverrideSummaryLines(cfg: LoadedConfig = getConfig()): string[] {
@@ -362,6 +376,9 @@ export function configOverrideSummaryLines(cfg: LoadedConfig = getConfig()): str
   if (cfg.env.CCP_CODEX_EFFORT) overrides.push("CCP_CODEX_EFFORT (env)");
   else if (fromFile.codex?.effort) overrides.push("codex.effort (config)");
 
+  if (cfg.env.CCP_CODEX_REASONING_SUMMARY) overrides.push("CCP_CODEX_REASONING_SUMMARY (env)");
+  else if (fromFile.codex?.reasoningSummary) overrides.push("codex.reasoningSummary (config)");
+
   if (cfg.env.CCP_CODEX_SERVICE_TIER) overrides.push("CCP_CODEX_SERVICE_TIER (env)");
   else if (fromFile.codex?.serviceTier) overrides.push("codex.serviceTier (config)");
 
@@ -378,8 +395,10 @@ export function configOverrideSummaryLines(cfg: LoadedConfig = getConfig()): str
   else if (fromFile.codex?.previousResponseId !== undefined)
     overrides.push(`codex.previousResponseId=${fromFile.codex.previousResponseId} (config)`);
 
-  if (cfg.env.CCP_ALIAS_PROVIDER) overrides.push(`CCP_ALIAS_PROVIDER=${resolvedAliasProvider(cfg)} (env)`);
-  else if (fromFile.aliasProvider) overrides.push(`aliasProvider=${fromFile.aliasProvider} (config)`);
+  if (cfg.env.CCP_ALIAS_PROVIDER)
+    overrides.push(`CCP_ALIAS_PROVIDER=${resolvedAliasProvider(cfg)} (env)`);
+  else if (fromFile.aliasProvider)
+    overrides.push(`aliasProvider=${fromFile.aliasProvider} (config)`);
 
   if (cfg.env.CCP_LOG_VERBOSE !== undefined) overrides.push("CCP_LOG_VERBOSE (env)");
   else if (fromFile.log?.verbose) overrides.push("log.verbose (config)");

--- a/src/providers/codex/translate/accumulate.test.ts
+++ b/src/providers/codex/translate/accumulate.test.ts
@@ -69,4 +69,62 @@ describe("accumulateResponse", () => {
     ]);
     expect(result.response.usage.server_tool_use).toEqual({ web_search_requests: 1 });
   });
+
+  it("materialises reasoning summaries as a thinking block before the text", async () => {
+    const result = await accumulateResponse(
+      upstreamFromChunks([
+        sse("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          summary_index: 0,
+          delta: "part one",
+        }),
+        sse("response.reasoning_summary_part.added", {
+          output_index: 0,
+          summary_index: 1,
+          part: { type: "summary_text", text: "" },
+        }),
+        sse("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          summary_index: 1,
+          delta: "part two",
+        }),
+        sse("response.output_item.done", {
+          output_index: 0,
+          item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+        }),
+        sse("response.output_item.added", { output_index: 1, item: { type: "message", id: "m" } }),
+        sse("response.output_text.delta", { output_index: 1, delta: "answer" }),
+        sse("response.output_item.done", { output_index: 1, item: { type: "message", id: "m" } }),
+        sse("response.completed", { response: { id: "resp_1", usage: {} } }),
+      ]),
+      { messageId: "msg_1", model: "gpt-5.5", log: silentLog },
+    );
+
+    expect(result.response.content).toEqual([
+      { type: "thinking", thinking: "part one\n\npart two", signature: "" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  it("emits no thinking block for a reasoning item with an empty summary", async () => {
+    const result = await accumulateResponse(
+      upstreamFromChunks([
+        sse("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+        }),
+        sse("response.output_item.done", {
+          output_index: 0,
+          item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+        }),
+        sse("response.output_item.added", { output_index: 1, item: { type: "message", id: "m" } }),
+        sse("response.output_text.delta", { output_index: 1, delta: "answer" }),
+        sse("response.output_item.done", { output_index: 1, item: { type: "message", id: "m" } }),
+        sse("response.completed", { response: { id: "resp_1", usage: {} } }),
+      ]),
+      { messageId: "msg_1", model: "gpt-5.5", log: silentLog },
+    );
+
+    expect(result.response.content).toEqual([{ type: "text", text: "answer" }]);
+  });
 });

--- a/src/providers/codex/translate/accumulate.ts
+++ b/src/providers/codex/translate/accumulate.ts
@@ -35,7 +35,7 @@ export async function accumulateResponse(
   upstream: ReadableStream<Uint8Array>,
   opts: { messageId: string; model: string; log: Logger; traffic?: TrafficCapture },
 ): Promise<AccumulatedResponse> {
-  const blockAccumulator = createBlockAccumulator();
+  const blockAccumulator = createBlockAccumulator({ includeThinking: true });
   let stopReason: AnthropicNonStreamResponse["stop_reason"] = null;
   let usage: ReturnType<typeof mapUsageToAnthropic> | undefined;
   let rawUsage: CodexUsage | undefined;
@@ -49,6 +49,13 @@ export async function accumulateResponse(
 
   for await (const e of reduceUpstream(upstream, opts.log, diagnostics)) {
     switch (e.kind) {
+      case "thinking-start":
+        blockAccumulator.onThinkingStart(e.index);
+        break;
+      case "thinking-delta": {
+        blockAccumulator.onThinkingDelta(e.index, e.text);
+        break;
+      }
       case "text-start":
         blockAccumulator.onTextStart(e.index);
         break;
@@ -66,6 +73,7 @@ export async function accumulateResponse(
       case "web-search":
         webSearchEvents.push(e);
         break;
+      case "thinking-stop":
       case "text-stop":
       case "tool-stop":
         break;
@@ -89,7 +97,13 @@ export async function accumulateResponse(
     ...buildWebSearchCompatBlocks(webSearchEvents, text),
   ];
   for (const block of accumulatedBlocks) {
-    if (block.kind === "text") {
+    if (block.kind === "thinking") {
+      if (block.text)
+        indexedContent.push({
+          index: block.index,
+          content: { type: "thinking", thinking: block.text, signature: "" },
+        });
+    } else if (block.kind === "text") {
       if (block.text)
         indexedContent.push({ index: block.index, content: { type: "text", text: block.text } });
     } else if (block.kind === "tool") {

--- a/src/providers/codex/translate/reducer.test.ts
+++ b/src/providers/codex/translate/reducer.test.ts
@@ -267,3 +267,168 @@ describe("reduceUpstream finish metadata", () => {
     });
   });
 });
+
+const reasoningSummaryDelta = (delta: string, summaryIndex = 0) =>
+  sse("response.reasoning_summary_text.delta", {
+    output_index: 0,
+    summary_index: summaryIndex,
+    delta,
+  });
+const reasoningItemDone = sse("response.output_item.done", {
+  output_index: 0,
+  item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+});
+const messageBlock = [
+  sse("response.output_item.added", { output_index: 1, item: { type: "message", id: "m" } }),
+  sse("response.output_text.delta", { output_index: 1, delta: "answer" }),
+  sse("response.output_item.done", { output_index: 1, item: { type: "message", id: "m" } }),
+];
+const completed = sse("response.completed", { response: { id: "resp_1", usage: {} } });
+const thinkingOf = (out: Awaited<ReturnType<typeof events>>) =>
+  out.filter(
+    (e) => e.kind === "thinking-start" || e.kind === "thinking-delta" || e.kind === "thinking-stop",
+  );
+
+describe("reduceUpstream reasoning summaries", () => {
+  it("emits thinking events from summary deltas, before and below the text block", async () => {
+    const out = await events([
+      sse("response.reasoning_summary_part.added", {
+        output_index: 0,
+        summary_index: 0,
+        part: { type: "summary_text", text: "" },
+      }),
+      reasoningSummaryDelta("Plan"),
+      reasoningSummaryDelta("ning"),
+      reasoningItemDone,
+      ...messageBlock,
+      completed,
+    ]);
+
+    expect(thinkingOf(out)).toEqual([
+      { kind: "thinking-start", index: 0 },
+      { kind: "thinking-delta", index: 0, text: "Plan" },
+      { kind: "thinking-delta", index: 0, text: "ning" },
+      { kind: "thinking-stop", index: 0 },
+    ]);
+    const stopAt = out.findIndex((e) => e.kind === "thinking-stop");
+    const textStartAt = out.findIndex((e) => e.kind === "text-start");
+    expect(stopAt).toBeGreaterThanOrEqual(0);
+    expect(stopAt).toBeLessThan(textStartAt);
+    expect(out.find((e) => e.kind === "text-start")).toEqual({ kind: "text-start", index: 1 });
+  });
+
+  it("emits no thinking for a reasoning item with an empty summary (trivial turn)", async () => {
+    const out = await events([
+      sse("response.output_item.added", {
+        output_index: 0,
+        item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+      }),
+      reasoningItemDone,
+      ...messageBlock,
+      completed,
+    ]);
+
+    expect(thinkingOf(out)).toEqual([]);
+  });
+
+  it("closes thinking before text even if the summary text.done never arrives", async () => {
+    const out = await events([reasoningSummaryDelta("hmm"), ...messageBlock, completed]);
+
+    const stopAt = out.findIndex((e) => e.kind === "thinking-stop");
+    const textStartAt = out.findIndex((e) => e.kind === "text-start");
+    expect(stopAt).toBeGreaterThanOrEqual(0);
+    expect(stopAt).toBeLessThan(textStartAt);
+  });
+
+  it("defensively closes an open thinking block at stream end", async () => {
+    const out = await events([reasoningSummaryDelta("dangling"), completed]);
+
+    expect(thinkingOf(out)).toEqual([
+      { kind: "thinking-start", index: 0 },
+      { kind: "thinking-delta", index: 0, text: "dangling" },
+      { kind: "thinking-stop", index: 0 },
+    ]);
+    expect(out.filter((e) => e.kind === "thinking-stop")).toHaveLength(1);
+  });
+
+  it("concatenates multiple summary parts into one thinking block", async () => {
+    const out = await events([
+      reasoningSummaryDelta("part one", 0),
+      sse("response.reasoning_summary_part.added", {
+        output_index: 0,
+        summary_index: 1,
+        part: { type: "summary_text", text: "" },
+      }),
+      reasoningSummaryDelta("part two", 1),
+      reasoningItemDone,
+      ...messageBlock,
+      completed,
+    ]);
+
+    expect(thinkingOf(out)).toEqual([
+      { kind: "thinking-start", index: 0 },
+      { kind: "thinking-delta", index: 0, text: "part one" },
+      { kind: "thinking-delta", index: 0, text: "\n\n" },
+      { kind: "thinking-delta", index: 0, text: "part two" },
+      { kind: "thinking-stop", index: 0 },
+    ]);
+  });
+
+  it("handles two reasoning items in one response", async () => {
+    const out = await events([
+      reasoningSummaryDelta("first"),
+      reasoningItemDone,
+      sse("response.output_item.added", {
+        output_index: 1,
+        item: { type: "function_call", call_id: "call_1", name: "Read" },
+      }),
+      sse("response.function_call_arguments.done", {
+        output_index: 1,
+        arguments: '{"file_path":"/tmp/a"}',
+      }),
+      sse("response.output_item.done", {
+        output_index: 1,
+        item: { type: "function_call", call_id: "call_1", name: "Read" },
+      }),
+      sse("response.reasoning_summary_text.delta", {
+        output_index: 2,
+        summary_index: 0,
+        delta: "second",
+      }),
+      sse("response.output_item.done", {
+        output_index: 2,
+        item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+      }),
+      completed,
+    ]);
+
+    expect(out.filter((e) => e.kind === "thinking-start")).toHaveLength(2);
+    expect(out.filter((e) => e.kind === "thinking-stop")).toHaveLength(2);
+    expect(
+      out.filter((e) => e.kind === "thinking-delta").map((e) => (e as { text: string }).text),
+    ).toEqual(["first", "second"]);
+  });
+
+  it("closes thinking before the Read-repair synthetic finish", async () => {
+    const out = await events([
+      reasoningSummaryDelta("deciding"),
+      sse("response.output_item.added", {
+        output_index: 1,
+        item: { type: "function_call", call_id: "call_1", name: "Read" },
+      }),
+      sse("response.function_call_arguments.delta", {
+        output_index: 1,
+        delta: '{"file_path":"/tmp/a","limit":2200',
+      }),
+      sse("response.function_call_arguments.delta", { output_index: 1, delta: " ".repeat(1024) }),
+    ]);
+
+    const stopAt = out.findIndex((e) => e.kind === "thinking-stop");
+    const finishAt = out.findIndex((e) => e.kind === "finish");
+    const toolStartAt = out.findIndex((e) => e.kind === "tool-start");
+    expect(stopAt).toBeGreaterThanOrEqual(0);
+    expect(stopAt).toBeLessThan(toolStartAt);
+    expect(stopAt).toBeLessThan(finishAt);
+    expect(out.at(-1)).toMatchObject({ kind: "finish", stopReason: "tool_use" });
+  });
+});

--- a/src/providers/codex/translate/reducer.ts
+++ b/src/providers/codex/translate/reducer.ts
@@ -30,6 +30,9 @@ export type TerminalType = "response.completed" | "response.incomplete" | "respo
 
 export type ReducerEvent =
   | TextToolReducerEvent
+  | { kind: "thinking-start"; index: number }
+  | { kind: "thinking-delta"; index: number; text: string }
+  | { kind: "thinking-stop"; index: number }
   | { kind: "tool-progress"; index: number }
   | { kind: "progress" }
   | {
@@ -292,6 +295,7 @@ export async function* reduceUpstream(
   const outputItemsByIndex = new Map<number, ResponsesInputItem>();
   const itemIdToOutputIndex = new Map<string, number>();
   let anthropicIndex = 0;
+  let thinkingIndex: number | undefined;
   let sawToolUse = false;
   let finalUsage: CodexUsage | undefined;
   let responseId: string | undefined;
@@ -326,6 +330,14 @@ export async function* reduceUpstream(
       arguments: state.argsAccum,
     });
   }
+
+  const closeThinking = function* () {
+    if (thinkingIndex !== undefined) {
+      const idx = thinkingIndex;
+      thinkingIndex = undefined;
+      yield { kind: "thinking-stop" as const, index: idx };
+    }
+  };
 
   const events = parseSseStream(upstream, diagnostics.stats);
   while (true) {
@@ -406,6 +418,7 @@ export async function* reduceUpstream(
         continue;
       }
       if (item.type === "message") {
+        yield* closeThinking();
         const idx = anthropicIndex++;
         blocksByOutputIndex.set(outputIndex, { kind: "text", index: idx, textAccum: "" });
         if (item.id) itemIdToOutputIndex.set(item.id, outputIndex);
@@ -413,6 +426,7 @@ export async function* reduceUpstream(
         continue;
       }
       if (item.type === "function_call") {
+        yield* closeThinking();
         sawToolUse = true;
         const idx = anthropicIndex++;
         const bufferUntilDone = shouldBufferToolArgs(item.name);
@@ -445,7 +459,25 @@ export async function* reduceUpstream(
       continue;
     }
 
+    if (t === "response.reasoning_summary_part.added") {
+      if (thinkingIndex !== undefined) {
+        yield { kind: "thinking-delta", index: thinkingIndex, text: "\n\n" };
+      }
+      continue;
+    }
+    if (t === "response.reasoning_summary_text.delta") {
+      const delta: string = p.delta ?? "";
+      if (!delta) continue;
+      if (thinkingIndex === undefined) {
+        thinkingIndex = anthropicIndex++;
+        yield { kind: "thinking-start", index: thinkingIndex };
+      }
+      yield { kind: "thinking-delta", index: thinkingIndex, text: delta };
+      continue;
+    }
+
     if (t === "response.output_text.delta") {
+      yield* closeThinking();
       const outputIndex: number | undefined = p.output_index;
       const itemId: string | undefined = p.item_id;
       let state: BlockState | undefined;
@@ -479,6 +511,7 @@ export async function* reduceUpstream(
         yield { kind: "tool-delta", index: state.index, partialJson: state.argsAccum };
         yield { kind: "tool-stop", index: state.index };
         blocksByOutputIndex.delete(p.output_index);
+        yield* closeThinking();
         const outputItems = Array.from(outputItemsByIndex.entries())
           .sort(([a], [b]) => a - b)
           .map(([, item]) => item);
@@ -525,6 +558,10 @@ export async function* reduceUpstream(
 
     if (t === "response.output_item.done") {
       const item = p.item;
+      if (item?.type === "reasoning") {
+        yield* closeThinking();
+        continue;
+      }
       if (item?.type === "web_search_call") {
         const idx = anthropicIndex++;
         const resultIndex = anthropicIndex++;
@@ -550,7 +587,6 @@ export async function* reduceUpstream(
         blocksByOutputIndex.delete(p.output_index);
         continue;
       }
-      if (item.type === "reasoning") continue;
       if (state.kind === "tool") {
         const finalArgs =
           (typeof item.arguments === "string" && item.arguments.length
@@ -626,6 +662,8 @@ export async function* reduceUpstream(
         : "Upstream stream ended without a terminal response event",
     );
   }
+
+  yield* closeThinking();
 
   const stopReason: StopReason = incomplete ? "max_tokens" : sawToolUse ? "tool_use" : "end_turn";
   const outputItems = Array.from(outputItemsByIndex.entries())

--- a/src/providers/codex/translate/request.test.ts
+++ b/src/providers/codex/translate/request.test.ts
@@ -31,8 +31,39 @@ describe("translateRequest", () => {
       output_config: { effort: "medium" },
     });
 
-    expect(translated.reasoning).toEqual({ effort: "medium" });
+    expect(translated.reasoning).toEqual({ effort: "medium", summary: "auto" });
     expect(translated.include).toEqual(["reasoning.encrypted_content"]);
+  });
+
+  for (const value of ["off", "none"]) {
+    it(`disables the reasoning summary when CCP_CODEX_REASONING_SUMMARY=${value}`, () => {
+      loadConfig({ env: { CCP_CODEX_REASONING_SUMMARY: value }, forceReload: true });
+      const translated = translateRequest({
+        ...baseRequest,
+        output_config: { effort: "medium" },
+      });
+
+      expect(translated.reasoning).toEqual({ effort: "medium" });
+      expect(translated.include).toEqual(["reasoning.encrypted_content"]);
+    });
+  }
+
+  it("keeps the summary on (auto) for any non-disabling override value", () => {
+    loadConfig({ env: { CCP_CODEX_REASONING_SUMMARY: "detailed" }, forceReload: true });
+    const translated = translateRequest({
+      ...baseRequest,
+      output_config: { effort: "medium" },
+    });
+
+    expect(translated.reasoning).toEqual({ effort: "medium", summary: "auto" });
+  });
+
+  it("produces byte-identical reasoning across calls so continuation stays stable", () => {
+    const req = { ...baseRequest, output_config: { effort: "high" as const } };
+    const a = translateRequest(req);
+    const b = translateRequest(req);
+
+    expect(JSON.stringify(a.reasoning)).toBe(JSON.stringify(b.reasoning));
   });
 
   it("translates Anthropic web search to the Codex hosted web_search tool", () => {

--- a/src/providers/codex/translate/request.ts
+++ b/src/providers/codex/translate/request.ts
@@ -4,7 +4,7 @@ import type {
   AnthropicRequest,
   AnthropicTool,
 } from "../../../anthropic/schema.ts";
-import { codexEffort, codexServiceTier } from "../../../config.ts";
+import { codexEffort, codexReasoningSummary, codexServiceTier } from "../../../config.ts";
 import {
   assertValidEffort,
   mapToolChoice as mapAnthropicToolChoice,
@@ -210,7 +210,9 @@ export function translateRequest(
   assertValidEffort(req.output_config?.effort);
   const effort = resolveEffort(toCodexEffort(req.output_config?.effort));
   if (effort) {
-    out.reasoning = { effort };
+    const summary = codexReasoningSummary();
+    out.reasoning =
+      summary === "off" || summary === "none" ? { effort } : { effort, summary: "auto" };
     out.include = ["reasoning.encrypted_content"];
   }
   return out;

--- a/src/providers/codex/translate/stream.test.ts
+++ b/src/providers/codex/translate/stream.test.ts
@@ -472,4 +472,71 @@ describe("translateStream", () => {
 
     expect(output).not.toContain("event: error");
   });
+
+  it("renders a thinking block (empty signature) before the text block", async () => {
+    const output = await collectFromChunks([
+      sse("response.reasoning_summary_text.delta", {
+        output_index: 0,
+        summary_index: 0,
+        delta: "Working it out",
+      }),
+      sse("response.output_item.done", {
+        output_index: 0,
+        item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+      }),
+      sse("response.output_item.added", { output_index: 1, item: { type: "message", id: "m" } }),
+      sse("response.output_text.delta", { output_index: 1, delta: "answer" }),
+      sse("response.output_item.done", { output_index: 1, item: { type: "message", id: "m" } }),
+      sse("response.completed", { response: { usage: {} } }),
+    ]);
+
+    expect(output).toContain('"content_block":{"type":"thinking","thinking":"","signature":""}');
+    expect(output).toContain('"type":"thinking_delta","thinking":"Working it out"');
+    expect(output).toContain("event: message_stop");
+    expect(output).not.toContain("event: error");
+    expect(output.indexOf('"type":"thinking_delta"')).toBeLessThan(
+      output.indexOf('"type":"text_delta"'),
+    );
+  });
+
+  it("emits no thinking block for a reasoning item with an empty summary", async () => {
+    const output = await collectFromChunks([
+      sse("response.output_item.added", {
+        output_index: 0,
+        item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+      }),
+      sse("response.output_item.done", {
+        output_index: 0,
+        item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+      }),
+      sse("response.output_item.added", { output_index: 1, item: { type: "message", id: "m" } }),
+      sse("response.output_text.delta", { output_index: 1, delta: "answer" }),
+      sse("response.output_item.done", { output_index: 1, item: { type: "message", id: "m" } }),
+      sse("response.completed", { response: { usage: {} } }),
+    ]);
+
+    expect(output).not.toContain('"type":"thinking"');
+    expect(output).toContain("event: message_stop");
+    expect(output).not.toContain("event: error");
+  });
+
+  it("renders thinking alongside web search without an open-block error", async () => {
+    const output = await collectFromChunks([
+      sse("response.reasoning_summary_text.delta", {
+        output_index: 0,
+        summary_index: 0,
+        delta: "Deciding to search",
+      }),
+      sse("response.output_item.done", {
+        output_index: 0,
+        item: { type: "reasoning", summary: [], encrypted_content: "enc" },
+      }),
+      ...webSearchChunks(),
+    ]);
+
+    expect(output).toContain('"type":"thinking_delta","thinking":"Deciding to search"');
+    expect(output).toContain('"type":"web_search_tool_result"');
+    expect(output).toContain("event: message_stop");
+    expect(output).not.toContain("event: error");
+  });
 });

--- a/src/providers/codex/translate/stream.ts
+++ b/src/providers/codex/translate/stream.ts
@@ -56,7 +56,10 @@ export function translateStream(
   const encoder = new TextEncoder();
   return new ReadableStream<Uint8Array>({
     async start(controller) {
-      const openBlocks = new Map<number, { type: "text" | "tool"; id?: string; name?: string }>();
+      const openBlocks = new Map<
+        number,
+        { type: "text" | "tool" | "thinking"; id?: string; name?: string }
+      >();
       let diagnostics = attachTrafficCapture(createUpstreamStreamDiagnostics(), opts.traffic);
       let closed = false;
       let messageStarted = false;
@@ -174,6 +177,9 @@ export function translateStream(
         }
       };
       const isContentEvent = (event: ReducerEvent): boolean =>
+        event.kind === "thinking-start" ||
+        event.kind === "thinking-delta" ||
+        event.kind === "thinking-stop" ||
         event.kind === "text-start" ||
         event.kind === "text-delta" ||
         event.kind === "text-stop" ||
@@ -182,6 +188,26 @@ export function translateStream(
         event.kind === "tool-stop";
       const emitContentEvent = (e: ReducerEvent) => {
         switch (e.kind) {
+          case "thinking-start":
+            openBlocks.set(e.index, { type: "thinking" });
+            ensureMessageStart();
+            emit("content_block_start", {
+              type: "content_block_start",
+              index: e.index,
+              content_block: { type: "thinking", thinking: "", signature: "" },
+            });
+            break;
+          case "thinking-delta":
+            emit("content_block_delta", {
+              type: "content_block_delta",
+              index: e.index,
+              delta: { type: "thinking_delta", thinking: e.text },
+            });
+            break;
+          case "thinking-stop":
+            openBlocks.delete(e.index);
+            emit("content_block_stop", { type: "content_block_stop", index: e.index });
+            break;
           case "text-start":
             openBlocks.set(e.index, { type: "text" });
             ensureMessageStart();
@@ -250,6 +276,9 @@ export function translateStream(
                 continue;
               }
               switch (e.kind) {
+                case "thinking-start":
+                case "thinking-delta":
+                case "thinking-stop":
                 case "text-start":
                 case "text-delta":
                 case "text-stop":


### PR DESCRIPTION
### Summary

- Codex previously discarded all reasoning output, and never asked Codex for a summary
- The proxy now requests `reasoning.summary` from Codex and translates the `reasoning_summary_text` events into Anthropic `thinking` content blocks

### Behaviour

- **Default `summary: "auto"`**:
    - The model decides when a summary is worthwhile, so it's selective
    - This matches native Claude Code behaviour
- **Overridable** via `CCP_CODEX_REASONING_SUMMARY` (env) / `codex.reasoningSummary` (config):
    - Unset → `auto`; `off`/`none` disables
    - Mirrors existing `codexEffort`/`codexModel` pattern

### Implementation Notes

- Thinking blocks open *lazily* on the first *non-empty* summary delta
- A `closeThinking()` helper closes the block before any sibling (text/tool) block opens and at every stream exit
- Thinking blocks use an *empty signature* (as the Cursor provider does)
- Display-only: reasoning is not round-tripped to Codex, so continuation is unaffected

### Testing

- Unit tests for
    - the reducer (lazy-open, empty-summary, close-before-sibling, multi-part concatenation, two reasoning items in one response)
    - the streaming/non-streaming frontends
    - request translation
    - the config accessor
- Verified end-to-end through real Claude Code:
    - streaming and non-streaming both render the summary as a thinking block
    - `CCP_CODEX_REASONING_SUMMARY=off` suppresses it
