### PR TITLE
Accept xhigh effort from Claude Code

### DIFF
--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -190,6 +190,7 @@ pub struct TranslateOptions {
 fn to_codex_effort(effort: Option<&str>) -> Option<Effort> {
     match effort {
         Some("max") => Some(Effort::Xhigh),
+        Some("xhigh") => Some(Effort::Xhigh),
         Some("low") => Some(Effort::Low),
         Some("medium") => Some(Effort::Medium),
         Some("high") => Some(Effort::High),
@@ -748,6 +749,22 @@ mod tests {
         let out = translate_request(&req, opts()).unwrap();
         let value = serde_json::to_value(out).unwrap();
         assert!(value.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn translate_effort_xhigh_maps_to_xhigh() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "xhigh"}
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::Xhigh)));
+        assert_eq!(
+            out.include,
+            Some(vec!["reasoning.encrypted_content".to_string()])
+        );
     }
 
     #[test]

--- a/src/providers/kimi/translate/request.rs
+++ b/src/providers/kimi/translate/request.rs
@@ -172,7 +172,7 @@ fn clamp_max_tokens(requested: Option<u32>) -> u32 {
 
 fn map_reasoning_effort(effort: Option<&str>) -> String {
     match effort {
-        Some("max") => "high".to_string(),
+        Some("max" | "xhigh") => "high".to_string(),
         Some(v) => v.to_string(),
         None => "medium".to_string(),
     }
@@ -758,6 +758,18 @@ mod tests {
         let req = req.unwrap();
         let result = translate_request(&req, TranslateOptions { session_id: None });
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn effort_xhigh_maps_to_high() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "kimi-for-coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "output_config": {"effort": "xhigh"}
+        }))
+        .unwrap();
+        let translated = translate_request(&req, TranslateOptions { session_id: None }).unwrap();
+        assert_eq!(translated.reasoning_effort.as_deref(), Some("high"));
     }
 
     #[test]

--- a/src/providers/translate_shared.rs
+++ b/src/providers/translate_shared.rs
@@ -63,7 +63,7 @@ pub fn read_effort(req: &MessagesRequest) -> Result<Option<&str>, anyhow::Error>
     };
     match output_config.get("effort") {
         Some(Value::String(s)) => {
-            let valid = ["low", "medium", "high", "max"];
+            let valid = ["low", "medium", "high", "xhigh", "max"];
             if valid.contains(&s.as_str()) {
                 Ok(Some(s.as_str()))
             } else {


### PR DESCRIPTION
## Summary

Issue:

- Claude Code has an "xhigh" effort, both in the terminal and VS Code
- This is silently rejected by the translator - 'foot-gun'

Solution: accept Claude Code `output_config.effort: "xhigh"` in shared effort parsing:

- Map Codex `xhigh` to upstream `reasoning.effort: "xhigh"`
- Map Kimi `xhigh` down to upstream `reasoning_effort: "high"`
- No changes were needed for Cursor, which already accepted "xhigh"

Size:

- 3 files changed
- Only 3 lines outside of tests

## Verification

Default unit tests:

- `cargo fmt --all --check`
- `cargo test xhigh --all`
- `cargo test --all`

Manual Codex e2e test/experiment:

- the request returned HTTP 200
- the captured upstream payload contained `reasoning.effort: "xhigh"`
- only Codex (not Kimi or Cursor), as that's the only subscription I have

## Notes

- `cargo clippy --all-targets -- -D warnings` currently fails on unrelated existing Rust 1.96 warnings outside this change, so those are left untouched
- Separately, while testing this on recent `main` (`607d014`) beyond release `v0.1.2`, Codex rejected the newer `max_output_tokens` parameter with `Unsupported parameter: max_output_tokens`; this PR is built off release `v0.1.2`
