### PR TITLE
Preserve max reasoning effort for Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Forward Claude Code's `max` effort as Codex `reasoning.effort: "max"` so
+  GPT-5.6 can use its highest supported reasoning level instead of silently
+  receiving `xhigh`.
+
 ## v0.1.10 (2026-07-10)
 
 - Claude Code requests using Opus 4.8, Sonnet 5, and Fable 5 model names can

--- a/README.md
+++ b/README.md
@@ -266,9 +266,8 @@ model `gpt-5.6-sol` with `service_tier: "priority"`. An explicit
 
 Reasoning effort: Claude Code's `output_config.effort` value (the one you see in
 the UI as `◐ medium · /effort`) is forwarded as Codex `reasoning.effort` (`low`
-/ `medium` / `high` / `xhigh`). Claude Code's `max` value is sent upstream as
-`xhigh`. An explicit `codex.effort` / `CCP_CODEX_EFFORT` override still takes
-precedence and can also force `none`.
+/ `medium` / `high` / `xhigh` / `max`). An explicit `codex.effort` /
+`CCP_CODEX_EFFORT` override still takes precedence and can also force `none`.
 
 Reasoning summaries: when a Codex request has reasoning effort, the proxy asks
 Codex for `reasoning.summary: "auto"` and translates returned summary deltas
@@ -654,7 +653,7 @@ Windows, and at
 | `CCP_KIMI_OAUTH_HOST`            | `kimi.oauthHost`           | `https://auth.kimi.com`                           | Override Kimi's OAuth host (debugging only)                                                                                                                                       |
 | `CCP_KIMI_BASE_URL`              | `kimi.baseUrl`             | `https://api.kimi.com/coding/v1`                  | Override Kimi's API base URL                                                                                                                                                      |
 | `CCP_CODEX_MODEL`                | `codex.model`              | unset                                             | Force all Codex requests to this model (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-iterra`) |
-| `CCP_CODEX_EFFORT`               | `codex.effort`             | unset                                             | Force all Codex requests to this reasoning effort (`none`, `low`, `medium`, `high`, `xhigh`)                                                                                      |
+| `CCP_CODEX_EFFORT`               | `codex.effort`             | unset                                             | Force all Codex requests to this reasoning effort (`none`, `low`, `medium`, `high`, `xhigh`, `max`)                                                                               |
 | `CCP_CODEX_REASONING_SUMMARY`    | `codex.reasoningSummary`   | unset                                             | Request Codex reasoning summaries when reasoning effort is enabled; `off` and `none` suppress summaries                                                                           |
 | `CCP_CODEX_SERVICE_TIER`         | `codex.serviceTier`        | unset                                             | Force all Codex requests to this service tier (`fast`/`priority`, `flex`; `fast` is sent upstream as `priority`)                                                                  |
 | `CCP_CODEX_BASE_URL`             | `codex.baseUrl`            | `https://chatgpt.com/backend-api/codex/responses` | Override the Codex Responses endpoint                                                                                                                                             |

--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -23,6 +23,7 @@ pub enum Effort {
     Medium,
     High,
     Xhigh,
+    Max,
 }
 
 impl std::fmt::Display for Effort {
@@ -33,6 +34,7 @@ impl std::fmt::Display for Effort {
             Effort::Medium => write!(f, "medium"),
             Effort::High => write!(f, "high"),
             Effort::Xhigh => write!(f, "xhigh"),
+            Effort::Max => write!(f, "max"),
         }
     }
 }
@@ -205,7 +207,7 @@ pub struct TranslateOptions {
 
 fn to_codex_effort(effort: Option<&str>) -> Option<Effort> {
     match effort {
-        Some("max") => Some(Effort::Xhigh),
+        Some("max") => Some(Effort::Max),
         Some("xhigh") => Some(Effort::Xhigh),
         Some("low") => Some(Effort::Low),
         Some("medium") => Some(Effort::Medium),
@@ -217,13 +219,14 @@ fn to_codex_effort(effort: Option<&str>) -> Option<Effort> {
 fn resolve_effort(effort: Option<Effort>) -> Result<Option<Effort>, anyhow::Error> {
     let override_effort = config::codex_effort();
     if let Some(ref val) = override_effort {
-        let valid = ["none", "low", "medium", "high", "xhigh"];
+        let valid = ["none", "low", "medium", "high", "xhigh", "max"];
         if !valid.contains(&val.as_str()) {
             anyhow::bail!(
-                "Invalid effort override: \"{val}\". Must be one of: none, low, medium, high, xhigh"
+                "Invalid effort override: \"{val}\". Must be one of: none, low, medium, high, xhigh, max"
             );
         }
         return Ok(Some(match val.as_str() {
+            "max" => Effort::Max,
             "xhigh" => Effort::Xhigh,
             "high" => Effort::High,
             "medium" => Effort::Medium,
@@ -995,7 +998,7 @@ mod tests {
     }
 
     #[test]
-    fn translate_effort_max_maps_to_xhigh() {
+    fn translate_effort_max_maps_to_max() {
         let req: MessagesRequest = serde_json::from_value(json!({
             "model": "gpt-5.5",
             "messages": [{"role":"user", "content":"hello"}],
@@ -1003,7 +1006,7 @@ mod tests {
         }))
         .unwrap();
         let out = translate_request(&req, opts()).unwrap();
-        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::Xhigh)));
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::Max)));
     }
 
     #[test]

--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -838,7 +838,45 @@ fn unsupported_tool_result_block_to_string(block: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
     use serde_json::json;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    struct EnvVarGuard {
+        _lock: MutexGuard<'static, ()>,
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self {
+                _lock: lock,
+                key,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
 
     fn opts() -> TranslateOptions {
         TranslateOptions {
@@ -1003,6 +1041,19 @@ mod tests {
             "model": "gpt-5.5",
             "messages": [{"role":"user", "content":"hello"}],
             "output_config": {"effort": "max"}
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::Max)));
+    }
+
+    #[test]
+    fn translate_effort_override_max_maps_to_max() {
+        let _env = EnvVarGuard::set("CCP_CODEX_EFFORT", "max");
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "low"}
         }))
         .unwrap();
         let out = translate_request(&req, opts()).unwrap();


### PR DESCRIPTION
## Summary

- serialize Claude Code `output_config.effort: "max"` as Codex `reasoning.effort: "max"`
- allow `max` in `CCP_CODEX_EFFORT` / `codex.effort`
- keep `xhigh` unchanged

GPT-5.6 supports `max` as a distinct effort above `xhigh`; mapping both inputs to `xhigh` silently loses the selected level. The current model guidance lists `none`, `low`, `medium`, `high`, `xhigh`, and `max`: https://developers.openai.com/api/docs/guides/model-guidance?model=gpt-5.6-sol

## Verification

- `cargo fmt --all --check`
- `cargo test translate_effort_max_maps_to_max --all`
- `cargo test --all` (440 passed)