### PR TITLE
Add xAI SuperGrok OAuth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+- Add **xAI SuperGrok OAuth** provider (`xai auth login` / `device` / `status` /
+  `logout`): SuperGrok / X Premium+ subscription via `auth.x.ai`, Responses API
+  at `api.x.ai/v1/responses`, Anthropic Messages translation with tools,
+  reasoning/effort, streaming, and optional `previous_response_id` continuity.
+  Optional `CCP_XAI_API_KEY` / `XAI_API_KEY` fallback for entitlement 403s
+  (OAuth tokens are kept on tier denial; API key is tried once). Models include
+  `grok-build-0.1`, `grok-composer-2.5-fast`, `grok-4.3`, `grok-4.5`, and Grok
+  4.20 variants; `aliasProvider: "xai"` routes Anthropic-style aliases to
+  `grok-build-0.1`. Base URL / issuer overrides are pinned to HTTPS `*.x.ai`.
+  ([#25](https://github.com/raine/claude-code-proxy/issues/25))
+
 - Forward Claude Code's `max` effort as Codex `reasoning.effort: "max"` so
   GPT-5.6 can use its highest supported reasoning level instead of silently
   receiving `xhigh`.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 `claude-code-proxy` lets you use
 [Claude Code](https://www.anthropic.com/claude-code) with your **ChatGPT
-Plus/Pro** subscription, your **Kimi Code** (kimi.com) account, or **Cursor
-Agent**.
+Plus/Pro** subscription, your **Kimi Code** (kimi.com) account, **Cursor
+Agent**, or an **xAI SuperGrok / X Premium+** subscription.
 
 <img src="meta/claude-code-screenshot.webp" alt="Claude Code running through claude-code-proxy" width="630" />
 
@@ -46,8 +46,9 @@ artifacts are published as `claude-code-proxy-windows-amd64.zip` and
 
 ### 2. Pick a provider and authenticate
 
-The proxy supports three upstream providers. Pick one and run its login flow; the
-proxy will refuse to start traffic until a token is stored.
+The proxy supports four upstream providers. Pick one and run its login flow; the
+proxy will refuse to start traffic until a token is stored (except optional xAI
+API-key fallback).
 
 **Codex (ChatGPT Plus/Pro):**
 
@@ -79,9 +80,23 @@ Cursor authentication uses Cursor's browser login, but the proxy stores its own
 tokens. It does not read Cursor Agent's Keychain/auth.json. You can also set
 `CCP_CURSOR_AUTH_TOKEN` for the proxy process.
 
-On macOS credentials go to Keychain. On Windows they are written under
-`%APPDATA%\claude-code-proxy\<provider>\auth.json`; on Linux they are written
-under `${XDG_CONFIG_HOME:-$HOME/.config}/claude-code-proxy/<provider>/auth.json`
+**xAI SuperGrok / X Premium+:**
+
+```sh
+claude-code-proxy xai auth login      # browser OAuth (PKCE)
+# or, on a headless machine:
+claude-code-proxy xai auth device     # device-code flow
+```
+
+Sign in with a **SuperGrok** or **X Premium+** account. No `XAI_API_KEY` is
+required for the OAuth path. Optional escape hatch: `CCP_XAI_API_KEY` /
+`XAI_API_KEY` if OAuth login succeeds but inference returns 403 (xAI tier
+gating).
+
+On macOS credentials go to Keychain (where a provider uses keychain storage). On
+Windows they are written under `%APPDATA%\claude-code-proxy\<provider>\auth.json`;
+on Linux they are written under
+`${XDG_CONFIG_HOME:-$HOME/.config}/claude-code-proxy/<provider>/auth.json`
 (mode 0600 where supported). Set `CCP_CONFIG_DIR` before `cursor auth login` to
 store a separate Cursor login at `$CCP_CONFIG_DIR/cursor/auth.json`.
 
@@ -91,6 +106,7 @@ Verify:
 claude-code-proxy codex auth status
 claude-code-proxy kimi auth status
 claude-code-proxy cursor auth status
+claude-code-proxy xai auth status
 ```
 
 ### 3. Start the proxy
@@ -330,6 +346,48 @@ Auth:
 | `kimi auth status` | Show user ID + token expiry           |
 | `kimi auth logout` | Delete stored credentials             |
 
+### xAI (SuperGrok / X Premium+)
+
+Upstream: `https://api.x.ai/v1/responses` (Responses API), authenticated with
+SuperGrok / X Premium+ OAuth (or optional API key fallback).
+
+Set `ANTHROPIC_MODEL` to an allowlisted Grok model, for example:
+
+- `grok-build-0.1` (coding default; Grok Build)
+- `grok-composer-2.5-fast`
+- `grok-4.3`
+- `grok-4.5`
+- `grok-4.20-0309-reasoning`
+- `grok-4.20-0309-non-reasoning`
+- `grok-4.20-multi-agent-0309`
+
+Aliases such as `grok-build` and `grok-4.3-latest` resolve to the matching wire
+id. Unknown model strings are rejected (no silent remap).
+
+Reasoning effort: Claude Code's `output_config.effort` is forwarded as Responses
+`reasoning.effort` (`none` / `low` / `medium` / `high` / `xhigh` / `max`, subject
+to model support). Thinking/reasoning content is mapped back to Anthropic
+thinking blocks when present.
+
+Session continuity: with a session id, the proxy can attach
+`previous_response_id` on append-only follow-ups (enabled by default;
+`xai.previousResponseId` / `CCP_XAI_PREVIOUS_RESPONSE_ID`).
+
+Auth:
+
+| Command           | What it does                                      |
+| ----------------- | ------------------------------------------------- |
+| `xai auth login`  | Browser OAuth (PKCE) via `auth.x.ai` (port 56121) |
+| `xai auth device` | Device-code OAuth for headless machines           |
+| `xai auth status` | Show token expiry + scope                         |
+| `xai auth logout` | Delete stored credentials                         |
+
+Some SuperGrok plans return HTTP 403 on the OAuth API surface even when the
+in-app subscription is active (tier gating). Re-login usually does not fix
+that. The proxy keeps OAuth tokens and, if configured, retries once with
+`CCP_XAI_API_KEY` / `XAI_API_KEY`. Otherwise check your plan at
+[x.ai/grok](https://x.ai/grok).
+
 ### Cursor Agent
 
 Upstream: `https://api2.cursor.sh/agent.v1.AgentService/Run` (Cursor Agent's
@@ -422,6 +480,7 @@ sequenceDiagram
 | `codex auth login` / `device` / `status` / `logout` | Codex OAuth management      |
 | `kimi  auth login` / `status` / `logout`            | Kimi OAuth management       |
 | `cursor auth login` / `status` / `logout`           | Cursor OAuth management     |
+| `xai   auth login` / `device` / `status` / `logout` | xAI SuperGrok OAuth         |
 
 ---
 
@@ -634,6 +693,13 @@ Windows, and at
     "clientVersion": "cli-2026.06.04-5fd875e",
     "agentBundle": "/path/to/cursor-agent/index.js"
   },
+  "xai": {
+    "baseUrl": "https://api.x.ai/v1",
+    "oauthIssuer": "https://auth.x.ai",
+    "effort": "high",
+    "reasoningSummary": "auto",
+    "previousResponseId": true
+  },
   "log": {
     "stderr": false,
     "verbose": false
@@ -649,7 +715,13 @@ Windows, and at
 | `CCP_LOG_STDERR`                 | `log.stderr`               | unset                                             | Also mirror log lines to stderr; any env value enables it                                                                                                                         |
 | `CCP_LOG_VERBOSE`                | `log.verbose`              | unset                                             | Preserve full string fields in `proxy.log`; any env value enables it                                                                                                              |
 | `CCP_TRAFFIC_LOG`                | —                          | unset                                             | Write full per-request traffic captures under `traffic/` for session debugging (`1`, `true`, or `yes`)                                                                            |
-| `CCP_ALIAS_PROVIDER`             | `aliasProvider`            | `codex`                                           | Route Anthropic-style aliases (`haiku`, `sonnet`, `opus`, `claude-*`) through `codex` or `kimi`                                                                                   |
+| `CCP_ALIAS_PROVIDER`             | `aliasProvider`            | `codex`                                           | Route Anthropic-style aliases (`haiku`, `sonnet`, `opus`, `claude-*`) through `codex`, `kimi`, or `xai`                                                                            |
+| `CCP_XAI_BASE_URL`               | `xai.baseUrl`              | `https://api.x.ai/v1`                             | Override xAI API base (HTTPS `*.x.ai` hosts only for OAuth bearer)                                                                                                                |
+| `CCP_XAI_OAUTH_ISSUER`           | `xai.oauthIssuer`          | `https://auth.x.ai`                               | Override xAI OAuth issuer                                                                                                                                                         |
+| `CCP_XAI_EFFORT`                 | `xai.effort`               | unset                                             | Force xAI reasoning effort                                                                                                                                                        |
+| `CCP_XAI_REASONING_SUMMARY`      | `xai.reasoningSummary`     | unset                                             | Request reasoning summaries when effort is set; `off`/`none` suppress                                                                                                             |
+| `CCP_XAI_PREVIOUS_RESPONSE_ID`   | `xai.previousResponseId`   | `true`                                            | Enable Responses continuation with `previous_response_id` when the request is append-only                                                                                         |
+| `CCP_XAI_API_KEY` / `XAI_API_KEY`| —                          | unset                                             | Optional API-key fallback when OAuth is unavailable or returns entitlement 403                                                                                                    |
 | `CCP_KIMI_OAUTH_HOST`            | `kimi.oauthHost`           | `https://auth.kimi.com`                           | Override Kimi's OAuth host (debugging only)                                                                                                                                       |
 | `CCP_KIMI_BASE_URL`              | `kimi.baseUrl`             | `https://api.kimi.com/coding/v1`                  | Override Kimi's API base URL                                                                                                                                                      |
 | `CCP_CODEX_MODEL`                | `codex.model`              | unset                                             | Force all Codex requests to this model (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-iterra`) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use crate::paths;
 pub enum AliasProvider {
     Codex,
     Kimi,
+    Xai,
 }
 
 impl AliasProvider {
@@ -16,6 +17,7 @@ impl AliasProvider {
         match self {
             AliasProvider::Codex => "codex",
             AliasProvider::Kimi => "kimi",
+            AliasProvider::Xai => "xai",
         }
     }
 }
@@ -38,6 +40,7 @@ struct FileConfig {
     pub kimi: Option<KimiConfig>,
     pub codex: Option<CodexConfig>,
     pub cursor: Option<CursorConfig>,
+    pub xai: Option<XaiConfig>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -81,6 +84,20 @@ struct KimiConfig {
     pub base_url: Option<String>,
 }
 
+#[derive(Deserialize, Clone)]
+struct XaiConfig {
+    #[serde(rename = "baseUrl")]
+    pub base_url: Option<String>,
+    #[serde(rename = "oauthIssuer")]
+    pub oauth_issuer: Option<String>,
+    #[serde(rename = "reasoningSummary")]
+    pub reasoning_summary: Option<String>,
+    #[serde(rename = "effort")]
+    pub effort: Option<String>,
+    #[serde(rename = "previousResponseId")]
+    pub previous_response_id: Option<bool>,
+}
+
 #[derive(Deserialize)]
 struct FileLog {
     pub verbose: Option<bool>,
@@ -91,6 +108,7 @@ fn parse_alias(raw: &str) -> Option<AliasProvider> {
     match raw {
         "codex" => Some(AliasProvider::Codex),
         "kimi" => Some(AliasProvider::Kimi),
+        "xai" => Some(AliasProvider::Xai),
         _ => None,
     }
 }
@@ -511,6 +529,102 @@ pub fn cursor_agent_bundle() -> Option<String> {
         && let Some(bundle) = cursor.agent_bundle
     {
         return Some(bundle);
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// xAI SuperGrok config
+// ---------------------------------------------------------------------------
+
+pub fn xai_base_url() -> String {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env.get("CCP_XAI_BASE_URL") {
+        return raw.clone();
+    }
+    if let Some(raw) = env.get("XAI_BASE_URL") {
+        return raw.clone();
+    }
+    let config_dir = paths::config_dir();
+    if let Some(file) = read_file_config(&config_dir)
+        && let Some(xai) = file.xai
+        && let Some(url) = xai.base_url
+    {
+        return url;
+    }
+    "https://api.x.ai/v1".to_string()
+}
+
+pub fn xai_oauth_issuer() -> String {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env.get("CCP_XAI_OAUTH_ISSUER") {
+        return raw.clone();
+    }
+    let config_dir = paths::config_dir();
+    if let Some(file) = read_file_config(&config_dir)
+        && let Some(xai) = file.xai
+        && let Some(issuer) = xai.oauth_issuer
+    {
+        return issuer;
+    }
+    "https://auth.x.ai".to_string()
+}
+
+pub fn xai_effort() -> Option<String> {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env.get("CCP_XAI_EFFORT") {
+        return Some(raw.clone());
+    }
+    let config_dir = paths::config_dir();
+    if let Some(file) = read_file_config(&config_dir)
+        && let Some(xai) = file.xai
+    {
+        return xai.effort;
+    }
+    None
+}
+
+pub fn xai_reasoning_summary() -> Option<String> {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env
+        .get("CCP_XAI_REASONING_SUMMARY")
+        .filter(|raw| !raw.is_empty())
+    {
+        return Some(raw.clone());
+    }
+    let config_dir = paths::config_dir();
+    if let Some(file) = read_file_config(&config_dir)
+        && let Some(xai) = file.xai
+        && let Some(summary) = xai.reasoning_summary.filter(|raw| !raw.is_empty())
+    {
+        return Some(summary);
+    }
+    None
+}
+
+pub fn xai_previous_response_id() -> bool {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env.get("CCP_XAI_PREVIOUS_RESPONSE_ID") {
+        return matches!(raw.to_ascii_lowercase().as_str(), "1" | "true" | "yes");
+    }
+    let config_dir = paths::config_dir();
+    if let Some(file) = read_file_config(&config_dir)
+        && let Some(xai) = file.xai
+        && let Some(val) = xai.previous_response_id
+    {
+        return val;
+    }
+    true
+}
+
+pub fn xai_api_key() -> Option<String> {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env
+        .get("CCP_XAI_API_KEY")
+        .or_else(|| env.get("XAI_API_KEY"))
+        .filter(|raw| !raw.trim().is_empty())
+    {
+        return Some(raw.clone());
     }
     None
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,10 @@ enum Commands {
         #[command(subcommand)]
         command: ProviderGroup,
     },
+    Xai {
+        #[command(subcommand)]
+        command: ProviderGroup,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -130,6 +134,7 @@ fn main() -> Result<()> {
         Commands::Codex { command } => run_provider_cli("codex", command),
         Commands::Kimi { command } => run_provider_cli("kimi", command),
         Commands::Cursor { command } => run_provider_cli("cursor", command),
+        Commands::Xai { command } => run_provider_cli("xai", command),
     }
 }
 
@@ -189,7 +194,7 @@ fn run_provider_cli(name: &str, command: ProviderGroup) -> Result<()> {
 
 fn print_models(registry: &Registry, full: bool) {
     let grouped = registry.grouped_models();
-    for provider in ["codex", "kimi", "cursor"] {
+    for provider in ["codex", "kimi", "cursor", "xai"] {
         let Some(models) = grouped.get(provider) else {
             continue;
         };

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,3 +2,4 @@ pub mod codex;
 pub mod cursor;
 pub mod kimi;
 pub mod translate_shared;
+pub mod xai;

--- a/src/providers/xai/auth/browser_login.rs
+++ b/src/providers/xai/auth/browser_login.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
+
+use super::constants::{OAUTH_CALLBACK_PATH, OAUTH_PORT, issuer};
+use super::jwt::TokenResponse;
+use super::pkce::{
+    PkceCodes, build_authorize_url, exchange_code_for_tokens, generate_pkce, generate_state,
+};
+
+const BROWSER_LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
+
+pub struct BrowserLoginConfig {
+    pub issuer: String,
+    pub port: u16,
+    pub timeout: Duration,
+}
+
+impl BrowserLoginConfig {
+    pub fn new(issuer: impl Into<String>) -> Self {
+        Self {
+            issuer: issuer.into(),
+            port: OAUTH_PORT,
+            timeout: BROWSER_LOGIN_TIMEOUT,
+        }
+    }
+
+    fn redirect_uri(&self, bound_port: u16) -> String {
+        format!("http://127.0.0.1:{bound_port}{OAUTH_CALLBACK_PATH}")
+    }
+}
+
+fn parse_query(query: &str) -> HashMap<String, String> {
+    let mut params = HashMap::new();
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        params.insert(key.into_owned(), value.into_owned());
+    }
+    params
+}
+
+fn extract_request_path_and_query(stream: &mut TcpStream) -> Option<(String, String)> {
+    let mut buf = [0; 4096];
+    let n = stream.read(&mut buf).ok()?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let first_line = request.lines().next()?;
+    let mut parts = first_line.split_whitespace();
+    let _method = parts.next()?;
+    let path_and_query = parts.next()?;
+    let mut split = path_and_query.splitn(2, '?');
+    let path = split.next().unwrap_or("").to_string();
+    let query = split.next().unwrap_or("").to_string();
+    Some((path, query))
+}
+
+fn write_response(stream: &mut TcpStream, status: u16, content_type: &str, body: &str) {
+    let status_line = match status {
+        200 => "200 OK",
+        400 => "400 Bad Request",
+        404 => "404 Not Found",
+        500 => "500 Internal Server Error",
+        _ => "500 Internal Server Error",
+    };
+    let response = format!(
+        "HTTP/1.1 {status_line}\r\nContent-Length: {}\r\nContent-Type: {content_type}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+pub fn run_browser_login() -> Result<TokenResponse, anyhow::Error> {
+    let config = BrowserLoginConfig::new(issuer());
+    run_browser_login_with_config(&config)
+}
+
+pub fn run_browser_login_with_config(
+    config: &BrowserLoginConfig,
+) -> Result<TokenResponse, anyhow::Error> {
+    let pkce = generate_pkce();
+    let state = generate_state();
+
+    // Prefer canonical port; fall back to an ephemeral port if busy.
+    let listener = match TcpListener::bind(format!("127.0.0.1:{}", config.port)) {
+        Ok(l) => l,
+        Err(_) => TcpListener::bind("127.0.0.1:0")
+            .map_err(|e| anyhow::anyhow!("Failed to bind OAuth callback listener: {e}"))?,
+    };
+    let bound_port = listener
+        .local_addr()
+        .map_err(|e| anyhow::anyhow!("Failed to read bound port: {e}"))?
+        .port();
+    let redirect_uri = config.redirect_uri(bound_port);
+    let auth_url = build_authorize_url(&config.issuer, &redirect_uri, &pkce, &state)?;
+
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| anyhow::anyhow!("Failed to set non-blocking: {e}"))?;
+
+    println!("Open this URL in your browser to authorize:\n\n  {auth_url}\n");
+
+    let deadline = std::time::Instant::now() + config.timeout;
+    loop {
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!("OAuth timeout");
+        }
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                return handle_callback(
+                    &mut stream,
+                    &config.issuer,
+                    &redirect_uri,
+                    &pkce,
+                    &state,
+                );
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => anyhow::bail!("Server error: {e}"),
+        }
+    }
+}
+
+fn handle_callback(
+    stream: &mut TcpStream,
+    issuer: &str,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    state: &str,
+) -> Result<TokenResponse, anyhow::Error> {
+    let _ = stream.set_nonblocking(false);
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+
+    let (path, query) = match extract_request_path_and_query(stream) {
+        Some(pair) => pair,
+        None => {
+            write_response(stream, 400, "text/plain", "Bad request");
+            anyhow::bail!("Bad request");
+        }
+    };
+
+    if path != OAUTH_CALLBACK_PATH {
+        write_response(stream, 404, "text/plain", "Not found");
+        anyhow::bail!("Not found");
+    }
+
+    let params = parse_query(&query);
+    if let Some(error) = params.get("error") {
+        write_response(stream, 400, "text/plain", &format!("Auth failed: {error}"));
+        anyhow::bail!("{error}");
+    }
+
+    let code = match params.get("code") {
+        Some(c) => c.clone(),
+        None => {
+            write_response(stream, 400, "text/plain", "Auth failed: Invalid callback");
+            anyhow::bail!("Invalid callback");
+        }
+    };
+
+    let received_state = params.get("state").cloned().unwrap_or_default();
+    if received_state != state {
+        write_response(stream, 400, "text/plain", "Auth failed: Invalid callback");
+        anyhow::bail!("Invalid callback: state mismatch");
+    }
+
+    match exchange_code_for_tokens(issuer, &code, pkce, redirect_uri) {
+        Ok(tokens) => {
+            write_response(
+                stream,
+                200,
+                "text/html",
+                "<html><body><h1>Authorization Successful</h1><p>You can close this window.</p></body></html>",
+            );
+            Ok(tokens)
+        }
+        Err(e) => {
+            write_response(stream, 500, "text/plain", &e.to_string());
+            Err(e)
+        }
+    }
+}

--- a/src/providers/xai/auth/constants.rs
+++ b/src/providers/xai/auth/constants.rs
@@ -1,0 +1,81 @@
+use crate::config;
+
+pub const CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+pub const SCOPE: &str = "openid profile email offline_access grok-cli:access api:access";
+pub const DEFAULT_ISSUER: &str = "https://auth.x.ai";
+pub const DEFAULT_API_BASE: &str = "https://api.x.ai/v1";
+/// Canonical loopback port used by OpenCode / Kilo / ecosystem for xAI PKCE.
+pub const OAUTH_PORT: u16 = 56121;
+pub const OAUTH_CALLBACK_PATH: &str = "/callback";
+/// Refresh up to 1h early (access tokens ~6h on SuperGrok flows; same policy as Hermes).
+pub const REFRESH_MARGIN_MS: u64 = 60 * 60 * 1000;
+pub const DEVICE_POLL_SAFETY_MARGIN_MS: u64 = 500;
+pub const GRANT_DEVICE_CODE: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// Shared copy for SuperGrok OAuth tier gating (refresh or inference HTTP 403).
+/// Re-login usually will not fix this; API key is the escape hatch.
+pub const TIER_DENIED_HINT: &str = "\
+xAI returned 403 for this SuperGrok/X Premium+ OAuth session. \
+xAI may restrict OAuth API access by tier even when the in-app subscription is active. \
+Re-running `xai auth login` usually will not fix this. \
+Set CCP_XAI_API_KEY or XAI_API_KEY as a fallback, or check your plan at https://x.ai/grok.";
+
+pub fn issuer() -> String {
+    let raw = config::xai_oauth_issuer();
+    match pin_xai_https_origin(&raw, DEFAULT_ISSUER) {
+        Ok(url) => url,
+        Err(reason) => {
+            eprintln!("warning: ignoring xAI oauth issuer override ({reason}); using {DEFAULT_ISSUER}");
+            DEFAULT_ISSUER.to_string()
+        }
+    }
+}
+
+pub fn api_base_url() -> String {
+    let raw = config::xai_base_url();
+    match pin_xai_https_origin(&raw, DEFAULT_API_BASE) {
+        Ok(url) => url.trim_end_matches('/').to_string(),
+        Err(reason) => {
+            eprintln!("warning: ignoring xAI base URL override ({reason}); using {DEFAULT_API_BASE}");
+            DEFAULT_API_BASE.to_string()
+        }
+    }
+}
+
+/// Pin OAuth/inference origins to HTTPS xAI hosts. On failure returns Err reason
+/// so callers can fall back to defaults (Hermes-style: never ship tokens off-host).
+pub fn pin_xai_https_origin(candidate: &str, fallback: &str) -> Result<String, String> {
+    let trimmed = candidate.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Ok(fallback.to_string());
+    }
+    let url = url::Url::parse(trimmed).map_err(|e| format!("invalid URL: {e}"))?;
+    if url.scheme() != "https" {
+        return Err(format!("non-HTTPS origin: {trimmed}"));
+    }
+    let host = url.host_str().unwrap_or("").to_ascii_lowercase();
+    if host == "x.ai" || host.ends_with(".x.ai") {
+        Ok(trimmed.to_string())
+    } else {
+        Err(format!("host {host:?} is not an xAI origin"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pin_accepts_api_x_ai() {
+        assert_eq!(
+            pin_xai_https_origin("https://api.x.ai/v1/", DEFAULT_API_BASE).unwrap(),
+            "https://api.x.ai/v1"
+        );
+    }
+
+    #[test]
+    fn pin_rejects_foreign_and_http() {
+        assert!(pin_xai_https_origin("http://api.x.ai/v1", DEFAULT_API_BASE).is_err());
+        assert!(pin_xai_https_origin("https://evil.example/v1", DEFAULT_API_BASE).is_err());
+    }
+}

--- a/src/providers/xai/auth/device.rs
+++ b/src/providers/xai/auth/device.rs
@@ -1,0 +1,127 @@
+use std::time::{Duration, Instant};
+
+use super::constants::{CLIENT_ID, DEVICE_POLL_SAFETY_MARGIN_MS, GRANT_DEVICE_CODE, SCOPE, issuer};
+use super::jwt::TokenResponse;
+
+const MAX_DEVICE_POLL_WAIT: Duration = Duration::from_secs(600);
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct DeviceAuthResponse {
+    device_code: String,
+    user_code: String,
+    #[serde(default)]
+    verification_uri: Option<String>,
+    #[serde(default)]
+    verification_uri_complete: Option<String>,
+    #[serde(default)]
+    expires_in: Option<u64>,
+    #[serde(default)]
+    interval: Option<u64>,
+}
+
+pub fn run_device_login() -> Result<TokenResponse, anyhow::Error> {
+    run_device_login_with_issuer(&issuer())
+}
+
+pub fn run_device_login_with_issuer(issuer_url: &str) -> Result<TokenResponse, anyhow::Error> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap_or_default();
+
+    let init_resp = client
+        .post(format!("{issuer_url}/oauth2/device/code"))
+        .form(&[("client_id", CLIENT_ID), ("scope", SCOPE)])
+        .send()
+        .map_err(|e| anyhow::anyhow!("Device authorization network error: {e}"))?;
+
+    if !init_resp.status().is_success() {
+        let status = init_resp.status().as_u16();
+        let text = init_resp.text().unwrap_or_default();
+        anyhow::bail!("Device authorization failed: {status} {text}");
+    }
+
+    let auth: DeviceAuthResponse = init_resp
+        .json()
+        .map_err(|e| anyhow::anyhow!("failed to parse device authorization response: {e}"))?;
+
+    let visit = auth
+        .verification_uri_complete
+        .or(auth.verification_uri)
+        .unwrap_or_else(|| format!("{issuer_url}/device"));
+
+    eprintln!();
+    eprintln!("Visit: {visit}");
+    eprintln!("Code:  {}", auth.user_code);
+    eprintln!();
+
+    let interval_ms = (auth.interval.unwrap_or(5).max(1)) * 1000 + DEVICE_POLL_SAFETY_MARGIN_MS;
+    let max_wait = auth
+        .expires_in
+        .map(|s| Duration::from_secs(s.max(30)))
+        .unwrap_or(MAX_DEVICE_POLL_WAIT);
+    let deadline = Instant::now() + max_wait;
+
+    loop {
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "Device auth timed out after {} seconds",
+                max_wait.as_secs()
+            );
+        }
+
+        let resp = client
+            .post(format!("{issuer_url}/oauth2/token"))
+            .form(&[
+                ("grant_type", GRANT_DEVICE_CODE),
+                ("device_code", auth.device_code.as_str()),
+                ("client_id", CLIENT_ID),
+            ])
+            .send()
+            .map_err(|e| anyhow::anyhow!("Device token poll network error: {e}"))?;
+
+        let status = resp.status().as_u16();
+        if status == 200 {
+            let tokens: TokenResponse = resp
+                .json()
+                .map_err(|e| anyhow::anyhow!("failed to parse token response: {e}"))?;
+            if tokens.access_token.trim().is_empty() {
+                anyhow::bail!("xAI device-code response missing access_token");
+            }
+            if tokens
+                .refresh_token
+                .as_ref()
+                .map(|r| r.trim().is_empty())
+                .unwrap_or(true)
+            {
+                anyhow::bail!("xAI device-code response missing refresh_token");
+            }
+            return Ok(tokens);
+        }
+
+        let body: serde_json::Value = resp.json().unwrap_or_else(|_| serde_json::json!({}));
+        let error = body
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        match error {
+            "authorization_pending" => {
+                std::thread::sleep(Duration::from_millis(interval_ms));
+            }
+            "slow_down" => {
+                std::thread::sleep(Duration::from_millis(interval_ms + 2000));
+            }
+            "expired_token" | "access_denied" => {
+                anyhow::bail!("Device authorization failed: {error}");
+            }
+            _ if status == 400 || status == 401 || status == 403 => {
+                anyhow::bail!("Device authorization failed: {status} {error}");
+            }
+            _ => {
+                // Treat other non-success as pending-ish unless clearly fatal
+                std::thread::sleep(Duration::from_millis(interval_ms));
+            }
+        }
+    }
+}

--- a/src/providers/xai/auth/jwt.rs
+++ b/src/providers/xai/auth/jwt.rs
@@ -1,0 +1,126 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    pub expires_in: Option<u64>,
+    #[serde(default)]
+    pub id_token: Option<String>,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub token_type: Option<String>,
+}
+
+pub fn validate_token_response(tokens: &TokenResponse) -> anyhow::Result<()> {
+    if tokens.access_token.trim().is_empty() {
+        anyhow::bail!("token response missing access token");
+    }
+    if matches!(tokens.expires_in, Some(0)) {
+        anyhow::bail!("token response has invalid expiration");
+    }
+    Ok(())
+}
+
+/// Prefer rotated refresh token when present.
+pub fn refresh_token_from(tokens: &TokenResponse, current: &str) -> String {
+    tokens
+        .refresh_token
+        .clone()
+        .filter(|r| !r.trim().is_empty())
+        .unwrap_or_else(|| current.to_string())
+}
+
+/// Absolute expiry in unix ms. Prefer `expires_in`, else JWT `exp`, else now+1h.
+pub fn expires_at_ms(tokens: &TokenResponse, now_ms: u64) -> u64 {
+    if let Some(secs) = tokens.expires_in.filter(|s| *s > 0) {
+        return now_ms.saturating_add(secs.saturating_mul(1000));
+    }
+    if let Some(exp_ms) = jwt_exp_ms(&tokens.access_token) {
+        return exp_ms;
+    }
+    now_ms.saturating_add(3600 * 1000)
+}
+
+pub fn jwt_exp_ms(token: &str) -> Option<u64> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    use base64::Engine;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| {
+            let padded = format!("{payload}{}", "=".repeat((4 - payload.len() % 4) % 4));
+            base64::engine::general_purpose::URL_SAFE.decode(padded)
+        })
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    claims.get("exp")?.as_u64().map(|exp| exp * 1000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    fn test_jwt_with_exp(exp: u64) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+        format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn validate_accepts_valid() {
+        let t = TokenResponse {
+            access_token: "a".into(),
+            refresh_token: Some("r".into()),
+            expires_in: Some(3600),
+            id_token: None,
+            scope: None,
+            token_type: None,
+        };
+        assert!(validate_token_response(&t).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_access() {
+        let t = TokenResponse {
+            access_token: "".into(),
+            refresh_token: Some("r".into()),
+            expires_in: Some(3600),
+            id_token: None,
+            scope: None,
+            token_type: None,
+        };
+        assert!(validate_token_response(&t).is_err());
+    }
+
+    #[test]
+    fn expires_prefers_expires_in() {
+        let t = TokenResponse {
+            access_token: test_jwt_with_exp(9_999_999),
+            refresh_token: Some("r".into()),
+            expires_in: Some(120),
+            id_token: None,
+            scope: None,
+            token_type: None,
+        };
+        assert_eq!(expires_at_ms(&t, 1_000_000), 1_000_000 + 120_000);
+    }
+
+    #[test]
+    fn expires_falls_back_to_jwt_exp() {
+        let t = TokenResponse {
+            access_token: test_jwt_with_exp(5000),
+            refresh_token: Some("r".into()),
+            expires_in: None,
+            id_token: None,
+            scope: None,
+            token_type: None,
+        };
+        assert_eq!(expires_at_ms(&t, 0), 5_000_000);
+    }
+}

--- a/src/providers/xai/auth/manager.rs
+++ b/src/providers/xai/auth/manager.rs
@@ -1,0 +1,212 @@
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::constants::{CLIENT_ID, REFRESH_MARGIN_MS, TIER_DENIED_HINT, issuer};
+use super::jwt::{TokenResponse, expires_at_ms, refresh_token_from, validate_token_response};
+use super::token_store::{StoredAuth, XaiTokenStore};
+use crate::auth::AuthStorage;
+
+pub struct XaiAuthManager<S: AuthStorage<StoredAuth>> {
+    pub store: XaiTokenStore<S>,
+    cached: Arc<Mutex<Option<StoredAuth>>>,
+}
+
+impl<S: AuthStorage<StoredAuth>> XaiAuthManager<S> {
+    pub fn new(store: XaiTokenStore<S>) -> Self {
+        Self {
+            store,
+            cached: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+
+    pub fn get_auth(&self) -> Result<StoredAuth, anyhow::Error> {
+        let cached = {
+            let guard = self.cached.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+            guard.clone()
+        };
+        let stored = match cached {
+            Some(ref auth) => auth.clone(),
+            None => {
+                let loaded = self.store.load_auth()?;
+                match loaded {
+                    Some(auth) => {
+                        let mut guard = self.cached.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+                        *guard = Some(auth.clone());
+                        auth
+                    }
+                    None => {
+                        anyhow::bail!(
+                            "Not authenticated. Run: claude-code-proxy xai auth login \
+                             (or `xai auth device` on headless hosts)"
+                        );
+                    }
+                }
+            }
+        };
+
+        if stored.expires > Self::now_ms() + REFRESH_MARGIN_MS {
+            return Ok(stored);
+        }
+
+        self.refresh_now(&stored)
+    }
+
+    pub fn force_refresh(&self) -> Result<StoredAuth, anyhow::Error> {
+        let stored = {
+            let guard = self.cached.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+            guard.clone()
+        };
+        let stored = match stored {
+            Some(auth) => auth,
+            None => {
+                let loaded = self.store.load_auth()?;
+                loaded.ok_or_else(|| anyhow::anyhow!("Not authenticated"))?
+            }
+        };
+        self.refresh_now(&stored)
+    }
+
+    fn refresh_now(&self, current: &StoredAuth) -> Result<StoredAuth, anyhow::Error> {
+        if current.refresh.is_empty() {
+            anyhow::bail!("No refresh token stored; re-authenticate with `xai auth login`");
+        }
+
+        let client = reqwest::blocking::Client::new();
+        let form = [
+            ("client_id", CLIENT_ID.to_string()),
+            ("grant_type", "refresh_token".to_string()),
+            ("refresh_token", current.refresh.clone()),
+        ];
+
+        let resp = client
+            .post(format!("{}/oauth2/token", issuer()))
+            .form(&form)
+            .send()
+            .map_err(|e| anyhow::anyhow!("refresh network error: {e}"))?;
+
+        let status = resp.status().as_u16();
+        let body_text = resp.text().unwrap_or_default();
+
+        // Tier / entitlement gate: keep tokens. Re-login will not help (Hermes #26847).
+        if status == 403 {
+            anyhow::bail!("{TIER_DENIED_HINT}");
+        }
+
+        // Revoked / invalid grant: clear store so status shows Not authenticated.
+        if status == 400 || status == 401 {
+            {
+                let mut guard = self.cached.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+                *guard = None;
+            }
+            let _ = self.store.clear_auth();
+            let detail = if body_text.trim().is_empty() {
+                "invalid or revoked refresh token".to_string()
+            } else {
+                body_text
+            };
+            anyhow::bail!(
+                "xAI token refresh failed ({status}): {detail}. \
+                 Run `claude-code-proxy xai auth login` (or `xai auth device`)."
+            );
+        }
+
+        if !(200..300).contains(&status) {
+            anyhow::bail!("Token refresh failed: {status} {body_text}");
+        }
+
+        let tokens: TokenResponse = serde_json::from_str(&body_text)
+            .map_err(|e| anyhow::anyhow!("failed to parse token response: {e}"))?;
+        validate_token_response(&tokens)?;
+        if tokens
+            .refresh_token
+            .as_ref()
+            .map(|r| r.trim().is_empty())
+            .unwrap_or(true)
+            && current.refresh.is_empty()
+        {
+            anyhow::bail!("token response missing refresh token");
+        }
+
+        let next = StoredAuth {
+            access: tokens.access_token.clone(),
+            refresh: refresh_token_from(&tokens, &current.refresh),
+            expires: expires_at_ms(&tokens, Self::now_ms()),
+            scope: tokens.scope.clone().or_else(|| current.scope.clone()),
+        };
+        self.store.save_auth(next.clone())?;
+        {
+            let mut guard = self.cached.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+            *guard = Some(next.clone());
+        }
+        Ok(next)
+    }
+
+    pub fn persist_initial_tokens(
+        &self,
+        tokens: &TokenResponse,
+    ) -> Result<StoredAuth, anyhow::Error> {
+        validate_token_response(tokens)?;
+        let refresh = tokens
+            .refresh_token
+            .clone()
+            .filter(|r| !r.trim().is_empty())
+            .ok_or_else(|| anyhow::anyhow!("token response missing refresh token"))?;
+        let auth = StoredAuth {
+            access: tokens.access_token.clone(),
+            refresh,
+            expires: expires_at_ms(tokens, Self::now_ms()),
+            scope: tokens.scope.clone(),
+        };
+        self.store.save_auth(auth.clone())?;
+        {
+            let mut guard = self.cached.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+            *guard = Some(auth.clone());
+        }
+        Ok(auth)
+    }
+
+    pub fn reset_cache(&self) {
+        if let Ok(mut guard) = self.cached.lock() {
+            *guard = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::InMemoryAuthStore;
+
+    fn test_store() -> XaiTokenStore<InMemoryAuthStore<StoredAuth>> {
+        XaiTokenStore::new(InMemoryAuthStore::new())
+    }
+
+    #[test]
+    fn get_auth_returns_stored() {
+        let store = test_store();
+        let auth = StoredAuth {
+            access: "test_access".into(),
+            refresh: "test_refresh".into(),
+            expires: 9999999999999,
+            scope: Some("openid".into()),
+        };
+        store.save_auth(auth.clone()).unwrap();
+        let manager = XaiAuthManager::new(store);
+        let result = manager.get_auth().unwrap();
+        assert_eq!(result.access, "test_access");
+    }
+
+    #[test]
+    fn get_auth_fails_when_no_auth() {
+        let store = test_store();
+        let manager = XaiAuthManager::new(store);
+        assert!(manager.get_auth().is_err());
+    }
+}

--- a/src/providers/xai/auth/mod.rs
+++ b/src/providers/xai/auth/mod.rs
@@ -1,0 +1,7 @@
+pub mod browser_login;
+pub mod constants;
+pub mod device;
+pub mod jwt;
+pub mod manager;
+pub mod pkce;
+pub mod token_store;

--- a/src/providers/xai/auth/pkce.rs
+++ b/src/providers/xai/auth/pkce.rs
@@ -1,0 +1,133 @@
+use sha2::{Digest, Sha256};
+
+use super::constants::{CLIENT_ID, SCOPE};
+use super::jwt::TokenResponse;
+
+#[derive(Debug, Clone)]
+pub struct PkceCodes {
+    pub verifier: String,
+    pub challenge: String,
+}
+
+fn base64_url_encode(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+pub fn generate_pkce() -> PkceCodes {
+    let mut verifier_bytes = vec![0u8; 32];
+    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut verifier_bytes);
+    let verifier = base64_url_encode(&verifier_bytes);
+    let hash = Sha256::digest(verifier.as_bytes());
+    let challenge = base64_url_encode(&hash);
+    PkceCodes {
+        verifier,
+        challenge,
+    }
+}
+
+pub fn generate_state() -> String {
+    let mut state_bytes = vec![0u8; 32];
+    rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut state_bytes);
+    base64_url_encode(&state_bytes)
+}
+
+pub fn build_authorize_url(
+    issuer: &str,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    state: &str,
+) -> Result<String, anyhow::Error> {
+    let mut url = url::Url::parse(&format!("{issuer}/oauth2/authorize"))?;
+    url.query_pairs_mut()
+        .append_pair("response_type", "code")
+        .append_pair("client_id", CLIENT_ID)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("scope", SCOPE)
+        .append_pair("code_challenge", &pkce.challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("state", state)
+        .append_pair("nonce", &generate_state());
+    Ok(url.to_string())
+}
+
+pub fn exchange_code_for_tokens(
+    issuer: &str,
+    code: &str,
+    pkce: &PkceCodes,
+    redirect_uri: &str,
+) -> Result<TokenResponse, anyhow::Error> {
+    let client = reqwest::blocking::Client::new();
+    // xAI expects code_challenge echoed on token exchange (Hermes/OpenCode).
+    let form = [
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", CLIENT_ID),
+        ("code_verifier", pkce.verifier.as_str()),
+        ("code_challenge", pkce.challenge.as_str()),
+        ("code_challenge_method", "S256"),
+    ];
+
+    let resp = client
+        .post(format!("{issuer}/oauth2/token"))
+        .form(&form)
+        .send()
+        .map_err(|e| anyhow::anyhow!("Token exchange network error: {e}"))?;
+
+    let status = resp.status().as_u16();
+    if !resp.status().is_success() {
+        let text = resp.text().unwrap_or_default();
+        anyhow::bail!("Token exchange failed: {status} {text}");
+    }
+
+    let tokens = resp
+        .json()
+        .map_err(|e| anyhow::anyhow!("failed to parse token exchange response: {e}"))?;
+    Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    #[test]
+    fn generate_pkce_produces_expected_format() {
+        let pkce = generate_pkce();
+        assert_eq!(pkce.verifier.len(), 43);
+        assert_eq!(pkce.challenge.len(), 43);
+        assert!(!pkce.verifier.contains('+'));
+        assert!(!pkce.verifier.contains('/'));
+        assert!(!pkce.verifier.contains('='));
+    }
+
+    #[test]
+    fn challenge_is_s256_of_verifier() {
+        let pkce = generate_pkce();
+        let expected_hash = Sha256::digest(pkce.verifier.as_bytes());
+        let expected = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(expected_hash);
+        assert_eq!(pkce.challenge, expected);
+    }
+
+    #[test]
+    fn authorize_url_contains_xai_params() {
+        let pkce = PkceCodes {
+            verifier: "v".into(),
+            challenge: "c".into(),
+        };
+        let url = build_authorize_url(
+            "https://auth.x.ai",
+            "http://127.0.0.1:56121/callback",
+            &pkce,
+            "state",
+        )
+        .unwrap();
+        assert!(url.starts_with("https://auth.x.ai/oauth2/authorize?"));
+        assert!(url.contains("client_id=b1a00492-073a-47ea-816f-4c329264a828"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("grok-cli%3Aaccess") || url.contains("grok-cli:access"));
+        assert!(url.contains("api%3Aaccess") || url.contains("api:access"));
+        assert!(url.contains("state=state"));
+    }
+}

--- a/src/providers/xai/auth/token_store.rs
+++ b/src/providers/xai/auth/token_store.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+
+use crate::auth::{AuthStorage, FileAuthStore};
+use crate::paths;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredAuth {
+    pub access: String,
+    pub refresh: String,
+    pub expires: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+pub struct XaiTokenStore<S: AuthStorage<StoredAuth>> {
+    store: S,
+}
+
+impl<S: AuthStorage<StoredAuth>> XaiTokenStore<S> {
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+
+    pub fn load_auth(&self) -> Result<Option<StoredAuth>, anyhow::Error> {
+        self.store.load()
+    }
+
+    pub fn save_auth(&self, value: StoredAuth) -> Result<(), anyhow::Error> {
+        self.store.save(value)
+    }
+
+    pub fn clear_auth(&self) -> Result<(), anyhow::Error> {
+        self.store.clear()
+    }
+
+    pub fn auth_path(&self) -> String {
+        self.store.path()
+    }
+}
+
+pub fn file_store() -> XaiTokenStore<FileAuthStore<StoredAuth>> {
+    let primary = paths::provider_auth_file("xai");
+    let legacy = paths::provider_legacy_auth_file("xai");
+    let store = FileAuthStore::new(
+        primary.to_string_lossy().to_string(),
+        legacy.to_string_lossy().to_string(),
+    );
+    XaiTokenStore::new(store)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::InMemoryAuthStore;
+
+    #[test]
+    fn roundtrip() {
+        let store = XaiTokenStore::new(InMemoryAuthStore::new());
+        let auth = StoredAuth {
+            access: "a".into(),
+            refresh: "r".into(),
+            expires: 9999999999999,
+            scope: Some("openid".into()),
+        };
+        store.save_auth(auth.clone()).unwrap();
+        let loaded = store.load_auth().unwrap().unwrap();
+        assert_eq!(loaded, auth);
+    }
+}

--- a/src/providers/xai/client.rs
+++ b/src/providers/xai/client.rs
@@ -1,0 +1,290 @@
+use std::time::Duration;
+
+use crate::config;
+use crate::retry::{MAX_RATE_LIMIT_RETRIES, compute_backoff_delay};
+
+use super::auth::constants::{TIER_DENIED_HINT, api_base_url};
+use super::auth::manager::XaiAuthManager;
+use super::auth::token_store::{StoredAuth, file_store};
+use super::continuation::ContinuationCandidate;
+use super::translate::request::ResponsesRequest;
+
+#[derive(Debug)]
+pub struct XaiError {
+    pub status: u16,
+    pub message: String,
+    pub detail: Option<String>,
+    pub retry_after: Option<String>,
+    /// When true, caller should treat this as OAuth entitlement failure (not a bad login).
+    pub tier_denied: bool,
+}
+
+pub struct XaiResponse {
+    pub body: Vec<u8>,
+    pub status: u16,
+}
+
+pub struct XaiHttpClient {
+    client: reqwest::blocking::Client,
+    auth_manager: XaiAuthManager<crate::auth::FileAuthStore<StoredAuth>>,
+}
+
+impl Default for XaiHttpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl XaiHttpClient {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::blocking::Client::builder()
+                .timeout(Duration::from_secs(300))
+                .build()
+                .expect("failed to create HTTP client"),
+            auth_manager: XaiAuthManager::new(file_store()),
+        }
+    }
+
+    pub fn post_responses(
+        &self,
+        body: &ResponsesRequest,
+        continuation: Option<&ContinuationCandidate>,
+    ) -> Result<XaiResponse, XaiError> {
+        let mut body_json = serde_json::to_value(body).map_err(|e| XaiError {
+            status: 500,
+            message: "Failed to serialize request".to_string(),
+            detail: Some(e.to_string()),
+            retry_after: None,
+            tier_denied: false,
+        })?;
+        apply_continuation(&mut body_json, continuation);
+
+        let body_str = serde_json::to_string(&body_json).map_err(|e| XaiError {
+            status: 500,
+            message: "Failed to serialize request".to_string(),
+            detail: Some(e.to_string()),
+            retry_after: None,
+            tier_denied: false,
+        })?;
+
+        // Prefer OAuth; fall back to API key when missing OAuth or on tier 403.
+        let oauth_result = self.auth_manager.get_auth();
+        if let Ok(mut auth) = oauth_result {
+            let mut attempt = 0u32;
+            loop {
+                match self.attempt_post(&auth.access, &body_str) {
+                    Ok(response) if response.status == 401 && attempt == 0 => {
+                        match self.auth_manager.force_refresh() {
+                            Ok(new_auth) => {
+                                auth = new_auth;
+                                attempt += 1;
+                                continue;
+                            }
+                            Err(e) => {
+                                let msg = e.to_string();
+                                // Refresh already explained tier denial; try API key if set.
+                                if msg.contains("403") || msg.contains("SuperGrok") {
+                                    if let Some(resp) = self.try_api_key_fallback(&body_str) {
+                                        return resp;
+                                    }
+                                    return Err(XaiError {
+                                        status: 403,
+                                        message: TIER_DENIED_HINT.to_string(),
+                                        detail: Some(msg),
+                                        retry_after: None,
+                                        tier_denied: true,
+                                    });
+                                }
+                                return Err(XaiError {
+                                    status: 401,
+                                    message: "Unauthorized".to_string(),
+                                    detail: Some(msg),
+                                    retry_after: None,
+                                    tier_denied: false,
+                                });
+                            }
+                        }
+                    }
+                    Ok(response) if response.status == 403 => {
+                        // Entitlement: keep OAuth tokens; try API key once.
+                        if let Some(resp) = self.try_api_key_fallback(&body_str) {
+                            return resp;
+                        }
+                        return Err(map_error_response(403, &response.body));
+                    }
+                    Ok(response) if response.status == 429 => {
+                        if attempt < MAX_RATE_LIMIT_RETRIES {
+                            let delay = compute_backoff_delay(attempt, None);
+                            std::thread::sleep(Duration::from_millis(delay.wait_ms));
+                            attempt += 1;
+                            continue;
+                        }
+                        return Err(XaiError {
+                            status: 429,
+                            message: "Rate limited".to_string(),
+                            detail: Some(String::from_utf8_lossy(&response.body).into_owned()),
+                            retry_after: Some("5".into()),
+                            tier_denied: false,
+                        });
+                    }
+                    Ok(response) if response.status >= 400 => {
+                        return Err(map_error_response(response.status, &response.body));
+                    }
+                    Ok(response) => return Ok(response),
+                    Err(err) if err.status == 429 && attempt < MAX_RATE_LIMIT_RETRIES => {
+                        let delay = compute_backoff_delay(attempt, err.retry_after.as_deref());
+                        std::thread::sleep(Duration::from_millis(delay.wait_ms));
+                        attempt += 1;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+
+        if let Some(resp) = self.try_api_key_fallback(&body_str) {
+            return resp;
+        }
+
+        let oauth_err = oauth_result.err().map(|e| e.to_string());
+        Err(XaiError {
+            status: 401,
+            message: "Not authenticated".to_string(),
+            detail: Some(oauth_err.unwrap_or_else(|| {
+                "Run `claude-code-proxy xai auth login` (or `xai auth device`), \
+                 or set CCP_XAI_API_KEY / XAI_API_KEY"
+                    .into()
+            })),
+            retry_after: None,
+            tier_denied: false,
+        })
+    }
+
+    fn try_api_key_fallback(&self, body: &str) -> Option<Result<XaiResponse, XaiError>> {
+        let api_key = config::xai_api_key()?;
+        Some(match self.attempt_post(&api_key, body) {
+            Ok(response) if response.status >= 400 => {
+                Err(map_error_response(response.status, &response.body))
+            }
+            Ok(response) => Ok(response),
+            Err(err) => Err(err),
+        })
+    }
+
+    fn attempt_post(&self, bearer: &str, body: &str) -> Result<XaiResponse, XaiError> {
+        // api_base_url() already pins to HTTPS *.x.ai with default fallback.
+        let base = api_base_url();
+        let url = format!("{base}/responses");
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "text/event-stream, application/json")
+            .header("Authorization", format!("Bearer {bearer}"))
+            .header("x-grok-source", "claude-code-proxy")
+            .body(body.to_string())
+            .send()
+            .map_err(|e| XaiError {
+                status: 0,
+                message: "Network error".to_string(),
+                detail: Some(e.to_string()),
+                retry_after: None,
+                tier_denied: false,
+            })?;
+
+        let status = resp.status().as_u16();
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let body = resp.bytes().map(|b| b.to_vec()).unwrap_or_default();
+
+        if status == 429 {
+            return Err(XaiError {
+                status: 429,
+                message: "Rate limited".to_string(),
+                detail: Some(String::from_utf8_lossy(&body).into_owned()),
+                retry_after,
+                tier_denied: false,
+            });
+        }
+
+        Ok(XaiResponse { body, status })
+    }
+}
+
+fn apply_continuation(
+    body: &mut serde_json::Value,
+    continuation: Option<&ContinuationCandidate>,
+) {
+    let Some(candidate) = continuation else {
+        return;
+    };
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    if let Some(ref prev_id) = candidate.previous_response_id {
+        obj.insert(
+            "previous_response_id".to_string(),
+            serde_json::json!(prev_id),
+        );
+    }
+    if let Some(ref delta) = candidate.input_delta {
+        obj.insert(
+            "input".to_string(),
+            serde_json::to_value(delta).unwrap_or_default(),
+        );
+    }
+}
+
+fn map_error_response(status: u16, body: &[u8]) -> XaiError {
+    let text = String::from_utf8_lossy(body).into_owned();
+    if status == 403 {
+        return XaiError {
+            status: 403,
+            message: TIER_DENIED_HINT.to_string(),
+            detail: Some(text),
+            retry_after: None,
+            tier_denied: true,
+        };
+    }
+    let message = if status == 401 {
+        "Authentication failed. Run `claude-code-proxy xai auth login` or set CCP_XAI_API_KEY."
+            .to_string()
+    } else {
+        "Upstream error".to_string()
+    };
+    XaiError {
+        status,
+        message,
+        detail: Some(text),
+        retry_after: None,
+        tier_denied: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::xai::auth::constants::pin_xai_https_origin;
+
+    #[test]
+    fn pin_accepts_api_x_ai() {
+        assert!(pin_xai_https_origin("https://api.x.ai/v1", "https://api.x.ai/v1").is_ok());
+    }
+
+    #[test]
+    fn pin_rejects_http_and_foreign_hosts() {
+        assert!(pin_xai_https_origin("http://api.x.ai/v1", "https://api.x.ai/v1").is_err());
+        assert!(pin_xai_https_origin("https://evil.example/v1", "https://api.x.ai/v1").is_err());
+    }
+
+    #[test]
+    fn map_403_is_tier_denied() {
+        let err = map_error_response(403, br#"{"error":"permission"}"#);
+        assert!(err.tier_denied);
+        assert!(err.message.contains("CCP_XAI_API_KEY"));
+    }
+}

--- a/src/providers/xai/continuation.rs
+++ b/src/providers/xai/continuation.rs
@@ -1,0 +1,426 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::translate::request::{ResponsesInputItem, ResponsesRequest};
+
+const TTL_MS: u64 = 30 * 60 * 1000;
+const MAX_STATES: usize = 10_000;
+const MAX_SESSION_TRANSCRIPT_BYTES: u64 = 2_000_000;
+const MAX_TOTAL_TRANSCRIPT_BYTES: u64 = 20_000_000;
+
+#[derive(Clone)]
+struct ContinuationState {
+    response_id: String,
+    prompt_signature: String,
+    transcript: Vec<ResponsesInputItem>,
+    transcript_bytes: u64,
+    updated_at: u64,
+}
+
+static STATES: Mutex<Option<HashMap<String, ContinuationState>>> = Mutex::new(None);
+static TOTAL_TRANSCRIPT_BYTES: Mutex<u64> = Mutex::new(0);
+
+#[derive(Clone)]
+pub struct ContinuationCandidate {
+    pub previous_response_id: Option<String>,
+    pub input_delta: Option<Vec<ResponsesInputItem>>,
+    pub input_delta_count: usize,
+    pub disabled_reason: Option<String>,
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+pub fn continuation_candidate(
+    session_id: Option<&str>,
+    body: &ResponsesRequest,
+    enabled: bool,
+) -> ContinuationCandidate {
+    let now = now_ms();
+
+    if !enabled {
+        return ContinuationCandidate {
+            previous_response_id: None,
+            input_delta: None,
+            input_delta_count: body.input.len(),
+            disabled_reason: Some("disabled".to_string()),
+        };
+    }
+
+    let session_id = match session_id {
+        Some(s) => s,
+        None => {
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: body.input.len(),
+                disabled_reason: Some("missing_session".to_string()),
+            };
+        }
+    };
+
+    let state = {
+        let guard = STATES.lock().unwrap();
+        guard.as_ref().and_then(|m| m.get(session_id).cloned())
+    };
+    let state = match state {
+        Some(s) if now - s.updated_at <= TTL_MS => s,
+        Some(_) => {
+            clear_continuation(Some(session_id));
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: body.input.len(),
+                disabled_reason: Some("missing_state".to_string()),
+            };
+        }
+        None => {
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: body.input.len(),
+                disabled_reason: Some("missing_state".to_string()),
+            };
+        }
+    };
+
+    let signature = prompt_signature(body);
+    if signature != state.prompt_signature {
+        clear_continuation(Some(session_id));
+        return ContinuationCandidate {
+            previous_response_id: None,
+            input_delta: None,
+            input_delta_count: body.input.len(),
+            disabled_reason: Some("prompt_changed".to_string()),
+        };
+    }
+
+    let suffix = input_suffix_after_prefix(&body.input, &state.transcript);
+    let suffix = match suffix {
+        Some(s) => s,
+        None => {
+            clear_continuation(Some(session_id));
+            return ContinuationCandidate {
+                previous_response_id: None,
+                input_delta: None,
+                input_delta_count: body.input.len(),
+                disabled_reason: Some("not_append_only".to_string()),
+            };
+        }
+    };
+
+    if suffix.is_empty() {
+        return ContinuationCandidate {
+            previous_response_id: None,
+            input_delta: None,
+            input_delta_count: 0,
+            disabled_reason: Some("empty_delta".to_string()),
+        };
+    }
+
+    ContinuationCandidate {
+        previous_response_id: Some(state.response_id),
+        input_delta: Some(suffix.clone()),
+        input_delta_count: suffix.len(),
+        disabled_reason: None,
+    }
+}
+
+pub fn record_continuation(
+    session_id: Option<&str>,
+    request_body: &ResponsesRequest,
+    response_id: Option<&str>,
+    output_items: &[ResponsesInputItem],
+) {
+    let session_id = match session_id {
+        Some(s) => s,
+        None => return,
+    };
+
+    let response_id = match response_id {
+        Some(id) => id.to_string(),
+        None => {
+            clear_continuation(Some(session_id));
+            return;
+        }
+    };
+
+    let mut transcript: Vec<ResponsesInputItem> = request_body.input.clone();
+    transcript.extend_from_slice(output_items);
+
+    let transcript_json = serde_json::to_string(&transcript).unwrap_or_default();
+    let transcript_bytes = transcript_json.len() as u64;
+
+    if transcript_bytes > MAX_SESSION_TRANSCRIPT_BYTES {
+        clear_continuation(Some(session_id));
+        return;
+    }
+
+    clear_continuation(Some(session_id));
+
+    let state = ContinuationState {
+        response_id,
+        prompt_signature: prompt_signature(request_body),
+        transcript,
+        transcript_bytes,
+        updated_at: now_ms(),
+    };
+
+    {
+        let mut guard = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+        *guard += transcript_bytes;
+    }
+    {
+        let mut guard = STATES.lock().unwrap();
+        let map = guard.get_or_insert_with(HashMap::new);
+        map.insert(session_id.to_string(), state);
+    }
+    evict_oldest();
+}
+
+pub fn clear_continuation(session_id: Option<&str>) {
+    let session_id = match session_id {
+        Some(s) => s,
+        None => return,
+    };
+    let mut guard = STATES.lock().unwrap();
+    if let Some(map) = guard.as_mut()
+        && let Some(existing) = map.remove(session_id)
+    {
+        let mut bytes_guard = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+        *bytes_guard = bytes_guard.saturating_sub(existing.transcript_bytes);
+    }
+}
+
+pub fn has_continuation_for_tests(session_id: &str) -> bool {
+    let guard = STATES.lock().unwrap();
+    guard.as_ref().is_some_and(|m| m.contains_key(session_id))
+}
+
+pub fn clear_all_continuations_for_tests() {
+    let mut guard = STATES.lock().unwrap();
+    *guard = None;
+    let mut bytes_guard = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+    *bytes_guard = 0;
+}
+
+fn input_suffix_after_prefix(
+    input: &[ResponsesInputItem],
+    prefix: &[ResponsesInputItem],
+) -> Option<Vec<ResponsesInputItem>> {
+    if prefix.len() > input.len() {
+        return None;
+    }
+    for i in 0..prefix.len() {
+        let a = serde_json::to_value(&input[i]).unwrap_or_default();
+        let b = serde_json::to_value(&prefix[i]).unwrap_or_default();
+        if a != b {
+            return None;
+        }
+    }
+    Some(input[prefix.len()..].to_vec())
+}
+
+fn prompt_signature(body: &ResponsesRequest) -> String {
+    let value = serde_json::to_value(body).unwrap_or_default();
+    let obj = match value.as_object() {
+        Some(o) => o,
+        None => return String::new(),
+    };
+    let mut entries: Vec<(&String, &serde_json::Value)> =
+        obj.iter().filter(|(k, _)| *k != "input").collect();
+    entries.sort_by_key(|(a, _)| *a);
+    let mut sig = String::from("{");
+    for (i, (key, val)) in entries.iter().enumerate() {
+        if i > 0 {
+            sig.push(',');
+        }
+        sig.push_str(&format!("\"{}\":{}", key, stable_json(val)));
+    }
+    sig.push('}');
+    sig
+}
+
+fn stable_json(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => serde_json::to_string(s).unwrap_or_default(),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(stable_json).collect();
+            format!("[{}]", items.join(","))
+        }
+        serde_json::Value::Object(obj) => {
+            let mut entries: Vec<(&String, &serde_json::Value)> = obj.iter().collect();
+            entries.sort_by_key(|(a, _)| *a);
+            let items: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(k).unwrap_or_default(),
+                        stable_json(v)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+fn evict_oldest() {
+    let mut guard = STATES.lock().unwrap();
+    let map = match guard.as_mut() {
+        Some(m) => m,
+        None => return,
+    };
+    let mut bytes_guard = TOTAL_TRANSCRIPT_BYTES.lock().unwrap();
+    while map.len() > MAX_STATES || *bytes_guard > MAX_TOTAL_TRANSCRIPT_BYTES {
+        let key = map.keys().next().cloned();
+        match key {
+            Some(k) => {
+                if let Some(existing) = map.remove(&k) {
+                    *bytes_guard = bytes_guard.saturating_sub(existing.transcript_bytes);
+                }
+            }
+            None => break,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request_with_input(
+        input: Vec<ResponsesInputItem>,
+        extra: Option<serde_json::Value>,
+    ) -> ResponsesRequest {
+        let mut fields = serde_json::Map::new();
+        fields.insert("model".into(), json!("gpt-5.5"));
+        fields.insert("input".into(), json!(input));
+        fields.insert("store".into(), json!(false));
+        fields.insert("stream".into(), json!(true));
+        fields.insert("text".into(), json!({"verbosity": "low"}));
+        fields.insert("parallel_tool_calls".into(), json!(true));
+        if let Some(extras) = extra
+            && let Some(obj) = extras.as_object()
+        {
+            for (k, v) in obj {
+                fields.insert(k.clone(), v.clone());
+            }
+        }
+        serde_json::from_value(serde_json::Value::Object(fields)).unwrap()
+    }
+
+    #[test]
+    fn continuation_behaviors() {
+        // All tests run in sequence to avoid global state interference
+
+        // disabled_when_not_enabled
+        clear_all_continuations_for_tests();
+        let input = vec![ResponsesInputItem::Message {
+            role: "user".to_string(),
+            content: vec![
+                super::super::translate::request::ResponsesContentPart::InputText {
+                    text: "one".to_string(),
+                },
+            ],
+        }];
+        let req = request_with_input(input, None);
+        let result = continuation_candidate(Some("s1"), &req, false);
+        assert_eq!(result.disabled_reason, Some("disabled".to_string()));
+        assert_eq!(result.input_delta_count, 1);
+
+        // missing_session
+        clear_all_continuations_for_tests();
+        let input = vec![ResponsesInputItem::Message {
+            role: "user".to_string(),
+            content: vec![
+                super::super::translate::request::ResponsesContentPart::InputText {
+                    text: "one".to_string(),
+                },
+            ],
+        }];
+        let req = request_with_input(input, None);
+        let result = continuation_candidate(None, &req, true);
+        assert_eq!(result.disabled_reason, Some("missing_session".to_string()));
+
+        // uses_previous_response_id_for_append_only
+        clear_all_continuations_for_tests();
+        let input = vec![ResponsesInputItem::Message {
+            role: "user".to_string(),
+            content: vec![
+                super::super::translate::request::ResponsesContentPart::InputText {
+                    text: "one".to_string(),
+                },
+            ],
+        }];
+        let req = request_with_input(input, None);
+        record_continuation(Some("s1"), &req, Some("resp_1"), &[]);
+
+        let input2 = vec![
+            ResponsesInputItem::Message {
+                role: "user".to_string(),
+                content: vec![
+                    super::super::translate::request::ResponsesContentPart::InputText {
+                        text: "one".to_string(),
+                    },
+                ],
+            },
+            ResponsesInputItem::Message {
+                role: "user".to_string(),
+                content: vec![
+                    super::super::translate::request::ResponsesContentPart::InputText {
+                        text: "two".to_string(),
+                    },
+                ],
+            },
+        ];
+        let req2 = request_with_input(input2, None);
+        let result = continuation_candidate(Some("s1"), &req2, true);
+        assert_eq!(result.previous_response_id, Some("resp_1".to_string()));
+        assert_eq!(result.input_delta_count, 1);
+
+        // clears_state_when_prompt_signature_changes
+        clear_all_continuations_for_tests();
+        let input = vec![ResponsesInputItem::Message {
+            role: "user".to_string(),
+            content: vec![
+                super::super::translate::request::ResponsesContentPart::InputText {
+                    text: "one".to_string(),
+                },
+            ],
+        }];
+        let req = request_with_input(input.clone(), None);
+        record_continuation(Some("s1"), &req, Some("resp_1"), &[]);
+
+        let req2 = request_with_input(input, Some(json!({"service_tier": "flex"})));
+        let result = continuation_candidate(Some("s1"), &req2, true);
+        assert_eq!(result.disabled_reason, Some("prompt_changed".to_string()));
+        assert!(!has_continuation_for_tests("s1"));
+
+        // clears_state_when_missing_response_id
+        clear_all_continuations_for_tests();
+        let input = vec![ResponsesInputItem::Message {
+            role: "user".to_string(),
+            content: vec![
+                super::super::translate::request::ResponsesContentPart::InputText {
+                    text: "one".to_string(),
+                },
+            ],
+        }];
+        let req = request_with_input(input.clone(), None);
+        record_continuation(Some("s1"), &req, Some("resp_1"), &[]);
+        assert!(has_continuation_for_tests("s1"));
+
+        record_continuation(Some("s1"), &req, None, &[]);
+        assert!(!has_continuation_for_tests("s1"));
+    }
+}

--- a/src/providers/xai/count_tokens.rs
+++ b/src/providers/xai/count_tokens.rs
@@ -1,0 +1,166 @@
+use super::translate::request::{
+    ResponsesContentPart, ResponsesInputItem, ResponsesRequest, ResponsesTool,
+};
+
+/// Approximate token counter for Codex translated requests.
+/// Uses a simple monotonic estimator that satisfies Claude Code's
+/// compaction logic (needs approximate, not exact counts).
+pub fn count_translated_tokens(translated: &ResponsesRequest) -> u64 {
+    let mut total = 0u64;
+
+    // Instructions
+    if let Some(ref instructions) = translated.instructions {
+        total += approx_token_count(instructions);
+    }
+
+    // Input items
+    for item in &translated.input {
+        total += count_input_item_tokens(item);
+    }
+
+    // Tools
+    if let Some(ref tools) = translated.tools {
+        total += count_tool_tokens(tools);
+    }
+
+    // Overhead
+    total += translated.input.len() as u64 * 4;
+    total += translated.tools.as_ref().map_or(0, |t| t.len() as u64 * 4);
+
+    // Model name
+    total += approx_token_count(&translated.model);
+
+    total.max(1)
+}
+
+fn count_input_item_tokens(item: &ResponsesInputItem) -> u64 {
+    match item {
+        ResponsesInputItem::AdditionalTools { tools, .. } => tools
+            .iter()
+            .map(|tool| approx_token_count(&serde_json::to_string(tool).unwrap_or_default()))
+            .sum(),
+        ResponsesInputItem::Message { content, .. } => {
+            let mut total = 0u64;
+            for part in content {
+                total += count_content_part_tokens(part);
+            }
+            total
+        }
+        ResponsesInputItem::FunctionCall {
+            name, arguments, ..
+        } => approx_token_count(name) + approx_token_count(arguments),
+        ResponsesInputItem::FunctionCallOutput { output, .. } => approx_token_count(output),
+    }
+}
+
+fn count_content_part_tokens(part: &ResponsesContentPart) -> u64 {
+    match part {
+        ResponsesContentPart::InputText { text } => approx_token_count(text),
+        ResponsesContentPart::OutputText { text } => approx_token_count(text),
+        ResponsesContentPart::InputImage { .. } => 2000, // Image token estimate
+    }
+}
+
+fn count_tool_tokens(tools: &[ResponsesTool]) -> u64 {
+    let mut total = 0u64;
+    for tool in tools {
+        match tool {
+            ResponsesTool::Function(f) => {
+                total += approx_token_count(&f.name);
+                if let Some(ref desc) = f.description {
+                    total += approx_token_count(desc);
+                }
+                total +=
+                    approx_token_count(&serde_json::to_string(&f.parameters).unwrap_or_default());
+            }
+            ResponsesTool::WebSearch(_) => {
+                total += 10; // fixed overhead for web search tool
+            }
+        }
+    }
+    total
+}
+
+fn approx_token_count(text: &str) -> u64 {
+    if text.is_empty() {
+        return 0;
+    }
+    let mut count = 0u64;
+    let mut in_word = false;
+
+    for ch in text.chars() {
+        if ch.is_alphanumeric() || ch == '-' || ch == '_' {
+            if !in_word {
+                count += 1;
+                in_word = true;
+            }
+        } else {
+            in_word = false;
+            if !ch.is_whitespace() {
+                count += 1;
+            }
+        }
+    }
+
+    count.max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn count_simple_request() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "store": false,
+            "stream": true,
+            "parallel_tool_calls": true,
+            "text": {"verbosity": "low"},
+        }))
+        .unwrap();
+        let count = count_translated_tokens(&req);
+        assert!(count > 0);
+    }
+
+    #[test]
+    fn count_request_with_tools() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "use tool"}]}],
+            "tools": [{"type": "function", "name": "search", "parameters": {"type": "object"}}],
+            "store": false,
+            "stream": true,
+            "parallel_tool_calls": true,
+            "text": {"verbosity": "low"},
+        }))
+        .unwrap();
+        let count = count_translated_tokens(&req);
+        assert!(count > 0);
+    }
+
+    #[test]
+    fn count_is_monotonic() {
+        let short: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+            "store": false,
+            "stream": true,
+            "parallel_tool_calls": true,
+            "text": {"verbosity": "low"},
+        }))
+        .unwrap();
+        let long: ResponsesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "this is a much longer message with many words in it"}]}],
+            "store": false,
+            "stream": true,
+            "parallel_tool_calls": true,
+            "text": {"verbosity": "low"},
+        }))
+        .unwrap();
+        assert!(count_translated_tokens(&long) >= count_translated_tokens(&short));
+    }
+}

--- a/src/providers/xai/mod.rs
+++ b/src/providers/xai/mod.rs
@@ -1,0 +1,388 @@
+pub mod auth;
+pub mod client;
+pub mod continuation;
+pub mod count_tokens;
+pub mod translate;
+
+use async_trait::async_trait;
+use axum::Json;
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::anthropic::error::json_error;
+use crate::anthropic::schema::{CountTokensResponse, MessagesRequest};
+use crate::config;
+use crate::monitor::usage_from_anthropic_sse;
+use crate::provider::{CliHandlers, Provider, RequestContext};
+use crate::registry::XAI_MODELS;
+
+use self::auth::browser_login::run_browser_login;
+use self::auth::device::run_device_login;
+use self::auth::manager::XaiAuthManager;
+use self::auth::token_store::file_store;
+use self::client::XaiHttpClient;
+use self::continuation::{
+    clear_continuation, continuation_candidate, record_continuation,
+};
+use self::count_tokens::count_translated_tokens;
+use self::translate::accumulate::accumulate_response_with_traffic;
+use self::translate::model_allowlist::{assert_allowed_model, resolve_model};
+use self::translate::reducer::finish_metadata_from_upstream;
+use self::translate::request::{TranslateOptions, translate_request};
+use self::translate::stream::translate_stream_bytes_with_traffic;
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+pub struct XaiProvider;
+
+impl Default for XaiProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl XaiProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Provider for XaiProvider {
+    fn name(&self) -> &'static str {
+        "xai"
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        XAI_MODELS.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn cli(&self) -> &'static dyn CliHandlers {
+        &XAI_CLI
+    }
+
+    async fn handle_messages(&self, body: MessagesRequest, ctx: RequestContext) -> Response {
+        let message_id = format!("msg_{}", uuid::Uuid::new_v4().to_string().replace('-', ""));
+        let want_stream = body.stream;
+        let model = body.model.as_deref().unwrap_or("grok-build-0.1");
+        let resolved = resolve_model(model);
+
+        if let Err(e) = assert_allowed_model(&resolved) {
+            return json_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                format!(
+                    "Model \"{model}\" resolves to unsupported model \"{}\"",
+                    e.model
+                ),
+            );
+        }
+        if let Some(monitor) = ctx.monitor.as_ref() {
+            monitor.model_resolved(&ctx.req_id, &resolved);
+        }
+
+        let translated = match translate_request(
+            &body,
+            TranslateOptions {
+                session_id: ctx.session_id.clone(),
+                service_tier: None,
+                model: resolved.clone(),
+                use_responses_lite: false,
+            },
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                return json_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    e.to_string(),
+                );
+            }
+        };
+
+        let previous_response_id_enabled = config::xai_previous_response_id();
+        let continuation = continuation_candidate(
+            ctx.session_id.as_deref(),
+            &translated,
+            previous_response_id_enabled,
+        );
+
+        if let Some(monitor) = ctx.monitor.as_ref() {
+            monitor.upstream_started(&ctx.req_id);
+        }
+
+        let traffic = ctx.traffic.clone();
+        let session_id = ctx.session_id.clone();
+        let translated_for_cont = translated.clone();
+        let upstream = match tokio::task::spawn_blocking(move || {
+            let client = XaiHttpClient::new();
+            client.post_responses(&translated, Some(&continuation))
+        })
+        .await
+        {
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                clear_continuation(session_id.as_deref());
+                return map_xai_error_to_response(&e);
+            }
+            Err(join_err) => {
+                clear_continuation(session_id.as_deref());
+                return json_error(
+                    StatusCode::BAD_GATEWAY,
+                    "api_error",
+                    format!("Blocking task join error: {join_err}"),
+                );
+            }
+        };
+
+        if want_stream {
+            let sse_bytes = match translate_stream_bytes_with_traffic(
+                &upstream.body,
+                &message_id,
+                model,
+                traffic.as_deref(),
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    clear_continuation(session_id.as_deref());
+                    return json_error(
+                        StatusCode::BAD_GATEWAY,
+                        "api_error",
+                        format!("Stream translation error: {e}"),
+                    );
+                }
+            };
+            if let Some(monitor) = ctx.monitor.as_ref() {
+                let (input_tokens, output_tokens) = usage_from_anthropic_sse(&sse_bytes);
+                monitor.stream_progress(
+                    &ctx.req_id,
+                    sse_bytes.len() as u64,
+                    count_sse_events(&sse_bytes),
+                    input_tokens,
+                    output_tokens,
+                );
+            }
+            update_continuation_from_upstream(
+                session_id.as_deref(),
+                &translated_for_cont,
+                &upstream.body,
+            );
+
+            let headers = [
+                (http::header::CONTENT_TYPE, "text/event-stream"),
+                (http::header::CACHE_CONTROL, "no-cache"),
+                (http::header::CONNECTION, "keep-alive"),
+            ];
+            (headers, sse_bytes).into_response()
+        } else {
+            match accumulate_response_with_traffic(
+                &upstream.body,
+                &message_id,
+                model,
+                traffic.as_deref(),
+            ) {
+                Ok(json) => {
+                    if let Some(monitor) = ctx.monitor.as_ref() {
+                        monitor.usage_updated(
+                            &ctx.req_id,
+                            json.pointer("/usage/input_tokens").and_then(|v| v.as_u64()),
+                            json.pointer("/usage/output_tokens")
+                                .and_then(|v| v.as_u64()),
+                        );
+                    }
+                    update_continuation_from_upstream(
+                        session_id.as_deref(),
+                        &translated_for_cont,
+                        &upstream.body,
+                    );
+                    (StatusCode::OK, Json(json)).into_response()
+                }
+                Err(e) => {
+                    clear_continuation(session_id.as_deref());
+                    json_error(
+                        StatusCode::BAD_GATEWAY,
+                        "api_error",
+                        format!("Accumulation error: {e}"),
+                    )
+                }
+            }
+        }
+    }
+
+    async fn handle_count_tokens(&self, body: MessagesRequest, ctx: RequestContext) -> Response {
+        let model = body.model.as_deref().unwrap_or("grok-build-0.1");
+        let resolved = resolve_model(model);
+        if let Err(e) = assert_allowed_model(&resolved) {
+            return json_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                format!(
+                    "Model \"{model}\" resolves to unsupported model \"{}\"",
+                    e.model
+                ),
+            );
+        }
+        if let Some(monitor) = ctx.monitor.as_ref() {
+            monitor.model_resolved(&ctx.req_id, &resolved);
+        }
+
+        let translated = match translate_request(
+            &body,
+            TranslateOptions {
+                session_id: None,
+                service_tier: None,
+                model: resolved,
+                use_responses_lite: false,
+            },
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                return json_error(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    e.to_string(),
+                );
+            }
+        };
+
+        let tokens = count_translated_tokens(&translated);
+        if let Some(monitor) = ctx.monitor.as_ref() {
+            monitor.usage_updated(&ctx.req_id, Some(tokens), None);
+        }
+        (
+            StatusCode::OK,
+            Json(CountTokensResponse {
+                input_tokens: tokens,
+            }),
+        )
+            .into_response()
+    }
+}
+
+fn count_sse_events(bytes: &[u8]) -> u64 {
+    String::from_utf8_lossy(bytes).matches("event:").count() as u64
+}
+
+fn update_continuation_from_upstream(
+    session_id: Option<&str>,
+    request_body: &translate::request::ResponsesRequest,
+    upstream_body: &[u8],
+) {
+    match finish_metadata_from_upstream(upstream_body) {
+        Ok(Some(finish)) if finish.continuation_eligible => {
+            record_continuation(
+                session_id,
+                request_body,
+                finish.response_id.as_deref(),
+                &finish.output_items,
+            );
+        }
+        _ => clear_continuation(session_id),
+    }
+}
+
+fn map_xai_error_to_response(err: &client::XaiError) -> Response {
+    // Prefer the actionable message (tier hints, re-auth guidance) over raw upstream JSON.
+    let body = if err.message.is_empty() {
+        err.detail.as_deref().unwrap_or("Upstream error")
+    } else {
+        &err.message
+    };
+    match err.status {
+        401 => json_error(StatusCode::UNAUTHORIZED, "authentication_error", body),
+        // 403 tier denial is not "wrong password" — keep 403 so clients don't thrash re-login.
+        403 => json_error(
+            if err.tier_denied {
+                StatusCode::FORBIDDEN
+            } else {
+                StatusCode::UNAUTHORIZED
+            },
+            "authentication_error",
+            body,
+        ),
+        429 => {
+            let retry_after = err.retry_after.as_deref().unwrap_or("5");
+            let resp = json_error(StatusCode::TOO_MANY_REQUESTS, "rate_limit_error", body);
+            let headers = [(http::header::RETRY_AFTER, retry_after)];
+            (headers, resp).into_response()
+        }
+        _ => json_error(StatusCode::BAD_GATEWAY, "api_error", body),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+pub(crate) struct XaiCli;
+
+impl CliHandlers for XaiCli {
+    fn login(&self) -> Result<(), anyhow::Error> {
+        println!("xAI SuperGrok OAuth (browser PKCE). For headless hosts use: xai auth device");
+        let tokens = run_browser_login()?;
+        persist_and_print(&tokens)
+    }
+
+    fn device(&self) -> Result<(), anyhow::Error> {
+        println!("xAI SuperGrok OAuth (device code — open the URL on any browser)");
+        let tokens = run_device_login()?;
+        persist_and_print(&tokens)
+    }
+
+    fn status(&self) -> Result<(), anyhow::Error> {
+        let store = file_store();
+        let api_key = config::xai_api_key().is_some();
+        match store.load_auth()? {
+            Some(auth) => {
+                println!("Auth path: {}", store.auth_path());
+                println!("Authenticated: true (OAuth)");
+                if let Some(ref scope) = auth.scope {
+                    println!("Scope: {scope}");
+                }
+                let remaining = auth.expires.saturating_sub(now_ms()) as i64 / 1000;
+                println!("Access token expires in {remaining}s");
+                println!("API base: {}", crate::providers::xai::auth::constants::api_base_url());
+                if api_key {
+                    println!("API key fallback: configured (used if OAuth returns 403)");
+                }
+                Ok(())
+            }
+            None => {
+                if api_key {
+                    println!("Authenticated: false (OAuth)");
+                    println!("API key fallback: configured");
+                    println!("API base: {}", crate::providers::xai::auth::constants::api_base_url());
+                    return Ok(());
+                }
+                anyhow::bail!("Not authenticated");
+            }
+        }
+    }
+
+    fn logout(&self) -> Result<(), anyhow::Error> {
+        let store = file_store();
+        store.clear_auth()?;
+        println!("Logged out");
+        Ok(())
+    }
+}
+
+fn persist_and_print(tokens: &auth::jwt::TokenResponse) -> Result<(), anyhow::Error> {
+    let store = file_store();
+    let manager = XaiAuthManager::new(store);
+    let saved = manager.persist_initial_tokens(tokens)?;
+    println!("Auth saved in {}", manager.store.auth_path());
+    if let Some(ref scope) = saved.scope {
+        println!("Scope: {scope}");
+    }
+    println!("Authentication complete");
+    Ok(())
+}
+
+pub(crate) static XAI_CLI: XaiCli = XaiCli;

--- a/src/providers/xai/translate/accumulate.rs
+++ b/src/providers/xai/translate/accumulate.rs
@@ -1,0 +1,538 @@
+use serde_json::Value;
+
+use crate::traffic::TrafficCapture;
+
+use super::reducer::{
+    AnthropicUsage, ReducerEvent, UpstreamStreamError, map_codex_usage_to_anthropic,
+    reduce_upstream_bytes,
+};
+use super::web_search_compat::{WebSearchCompatContent, build_web_search_compat_blocks};
+
+pub fn accumulate_response(
+    upstream: &[u8],
+    message_id: &str,
+    model: &str,
+) -> Result<Value, anyhow::Error> {
+    accumulate_response_with_traffic(upstream, message_id, model, None)
+}
+
+pub fn accumulate_response_with_traffic(
+    upstream: &[u8],
+    message_id: &str,
+    model: &str,
+    traffic: Option<&TrafficCapture>,
+) -> Result<Value, anyhow::Error> {
+    let events = match reduce_upstream_bytes(upstream) {
+        Ok(events) => events,
+        Err(err) => {
+            write_reducer_error_capture(traffic, &err);
+            return Err(anyhow::anyhow!(
+                "upstream error: {} ({:?})",
+                err.message,
+                err.kind
+            ));
+        }
+    };
+
+    let mut blocks: Vec<AccumulatedBlock> = Vec::new();
+    let mut stop_reason: Option<String> = None;
+    let mut usage: Option<AnthropicUsage> = None;
+    let mut web_search_events: Vec<ReducerEvent> = Vec::new();
+    let mut deferred_text_parts: Vec<String> = Vec::new();
+
+    enum BlockKind {
+        Thinking {
+            text: String,
+        },
+        Text {
+            text: String,
+        },
+        Tool {
+            id: String,
+            name: String,
+            args: String,
+        },
+    }
+
+    struct AccumulatedBlock {
+        index: usize,
+        kind: BlockKind,
+    }
+
+    for event in &events {
+        match event {
+            ReducerEvent::WebSearch { .. } => {
+                web_search_events.push(event.clone());
+            }
+            ReducerEvent::ThinkingStart { index } => {
+                blocks.push(AccumulatedBlock {
+                    index: *index,
+                    kind: BlockKind::Thinking {
+                        text: String::new(),
+                    },
+                });
+            }
+            ReducerEvent::ThinkingDelta { index, text } => {
+                if let Some(block) = blocks.iter_mut().rev().find(|b| b.index == *index)
+                    && let BlockKind::Thinking { text: t } = &mut block.kind
+                {
+                    t.push_str(text);
+                }
+            }
+            ReducerEvent::TextStart { index } => {
+                blocks.push(AccumulatedBlock {
+                    index: *index,
+                    kind: BlockKind::Text {
+                        text: String::new(),
+                    },
+                });
+            }
+            ReducerEvent::TextDelta { index, text } => {
+                if let Some(block) = blocks.iter_mut().rev().find(|b| b.index == *index)
+                    && let BlockKind::Text { text: t } = &mut block.kind
+                {
+                    t.push_str(text);
+                }
+                deferred_text_parts.push(text.clone());
+            }
+            ReducerEvent::ToolStart { index, id, name } => {
+                blocks.push(AccumulatedBlock {
+                    index: *index,
+                    kind: BlockKind::Tool {
+                        id: id.clone(),
+                        name: name.clone(),
+                        args: String::new(),
+                    },
+                });
+            }
+            ReducerEvent::ToolDelta {
+                index,
+                partial_json,
+            } => {
+                if let Some(block) = blocks.iter_mut().rev().find(|b| b.index == *index)
+                    && let BlockKind::Tool { args, .. } = &mut block.kind
+                {
+                    args.push_str(partial_json);
+                }
+            }
+            ReducerEvent::Finish {
+                stop_reason: sr,
+                usage: u,
+                web_search_requests,
+                ..
+            } => {
+                stop_reason = Some(sr.to_string());
+                let ws = Some(*web_search_requests).filter(|n| *n > 0);
+                usage = Some(map_codex_usage_to_anthropic(u, ws));
+            }
+            _ => {}
+        }
+    }
+
+    let text_from_deferred: String = deferred_text_parts.join("");
+
+    let mut indexed_content: Vec<(usize, Value)> = Vec::new();
+
+    if !web_search_events.is_empty() {
+        let compat_blocks = build_web_search_compat_blocks(&web_search_events, &text_from_deferred);
+        for block in &compat_blocks {
+            match &block.content {
+                WebSearchCompatContent::ServerToolUse { id, name, input } => {
+                    indexed_content.push((
+                        block.index,
+                        serde_json::json!({
+                            "type": "server_tool_use",
+                            "id": id,
+                            "name": name,
+                            "input": input,
+                        }),
+                    ));
+                }
+                WebSearchCompatContent::WebSearchToolResult {
+                    tool_use_id,
+                    content: results,
+                } => {
+                    let result_content: Vec<Value> = results
+                        .iter()
+                        .map(|r| {
+                            serde_json::json!({
+                                "type": "web_search_result",
+                                "title": r.title,
+                                "url": r.url,
+                            })
+                        })
+                        .collect();
+                    indexed_content.push((
+                        block.index,
+                        serde_json::json!({
+                            "type": "web_search_tool_result",
+                            "tool_use_id": tool_use_id,
+                            "content": result_content,
+                        }),
+                    ));
+                }
+            }
+        }
+    }
+
+    for block in &blocks {
+        match &block.kind {
+            BlockKind::Thinking { text } => {
+                if !text.is_empty() {
+                    indexed_content.push((
+                        block.index,
+                        serde_json::json!({
+                            "type": "thinking",
+                            "thinking": text,
+                            "signature": "",
+                        }),
+                    ));
+                }
+            }
+            BlockKind::Text { text } => {
+                if !text.is_empty() {
+                    indexed_content.push((
+                        block.index,
+                        serde_json::json!({
+                            "type": "text",
+                            "text": text,
+                        }),
+                    ));
+                }
+            }
+            BlockKind::Tool { id, name, args } => {
+                let parsed = serde_json::from_str::<Value>(args)
+                    .unwrap_or_else(|_| Value::String(args.clone()));
+                indexed_content.push((
+                    block.index,
+                    serde_json::json!({
+                        "type": "tool_use",
+                        "id": id,
+                        "name": name,
+                        "input": parsed,
+                    }),
+                ));
+            }
+        }
+    }
+
+    indexed_content.sort_by_key(|(index, _)| *index);
+    let content: Vec<Value> = indexed_content
+        .into_iter()
+        .map(|(_, content)| content)
+        .collect();
+
+    let response = serde_json::json!({
+        "id": message_id,
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content,
+        "stop_reason": stop_reason,
+        "stop_sequence": null,
+        "usage": usage.unwrap_or_default(),
+    });
+
+    Ok(response)
+}
+
+fn write_reducer_error_capture(traffic: Option<&TrafficCapture>, err: &UpstreamStreamError) {
+    let Some(traffic) = traffic else {
+        return;
+    };
+    traffic.write_json(
+        "060-codex-reducer-error",
+        &serde_json::json!({
+            "kind": format!("{:?}", err.kind),
+            "message": err.message,
+            "retryAfterSeconds": err.retry_after_seconds,
+            "diagnostics": err.diagnostics,
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sse_event(type_name: &str, payload: serde_json::Value) -> String {
+        let mut obj = if let serde_json::Value::Object(m) = payload {
+            m
+        } else {
+            return String::new();
+        };
+        obj.insert("type".into(), serde_json::json!(type_name));
+        format!(
+            "data: {}\n\n",
+            serde_json::to_string(&serde_json::Value::Object(obj)).unwrap()
+        )
+    }
+
+    #[test]
+    fn accumulate_text_response() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                json!({
+                    "output_index":0,"delta":"Hello world"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,"item":{"type":"message"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","usage":{"input_tokens":5,"output_tokens":2}}
+                })
+            ),
+        );
+        let response = accumulate_response(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap();
+        assert_eq!(response["type"], "message");
+        assert_eq!(response["content"][0]["type"], "text");
+        assert_eq!(response["content"][0]["text"], "Hello world");
+        assert_eq!(response["stop_reason"], "end_turn");
+    }
+
+    #[test]
+    fn accumulate_tool_use_response() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"function_call","call_id":"call_1","name":"Read"}
+                })
+            ),
+            sse_event(
+                "response.function_call_arguments.delta",
+                json!({
+                    "output_index":0,"delta":"{\"file_path\":\"/tmp/a\"}"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"function_call","call_id":"call_1","name":"Read","arguments":"{\"file_path\":\"/tmp/a\"}"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","usage":{"input_tokens":3}}
+                })
+            ),
+        );
+        let response = accumulate_response(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap();
+        assert_eq!(response["content"][0]["type"], "tool_use");
+        assert_eq!(response["content"][0]["input"]["file_path"], "/tmp/a");
+    }
+
+    #[test]
+    fn accumulate_web_search_response() {
+        let upstream = format!(
+            "{}{}{}{}{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"web_search_call","id":"ws_1"}
+                })
+            ),
+            sse_event(
+                "response.web_search_call.in_progress",
+                json!({
+                    "output_index":0,"item_id":"ws_1"
+                })
+            ),
+            sse_event(
+                "response.web_search_call.completed",
+                json!({
+                    "output_index":0,"item_id":"ws_1"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"web_search_call","id":"ws_1","action":{"query":"test query"}}
+                })
+            ),
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":1,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                json!({
+                    "output_index":1,"delta":"See [Result](https://result.com)"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":1,"item":{"type":"message"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","usage":{"input_tokens":3,"output_tokens":1}}
+                })
+            ),
+        );
+        let response = accumulate_response(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap();
+        let content = response["content"].as_array().unwrap();
+        assert!(content.len() >= 3);
+        // First should be server_tool_use
+        assert_eq!(content[0]["type"], "server_tool_use");
+        // Second should be web_search_tool_result
+        assert_eq!(content[1]["type"], "web_search_tool_result");
+        // Third should be text
+        assert_eq!(content[2]["type"], "text");
+    }
+
+    #[test]
+    fn accumulate_reasoning_summary_as_thinking_before_text() {
+        let upstream = format!(
+            "{}{}{}{}{}{}{}",
+            sse_event(
+                "response.reasoning_summary_text.delta",
+                json!({
+                    "output_index":0,"summary_index":0,"delta":"part one"
+                })
+            ),
+            sse_event(
+                "response.reasoning_summary_part.added",
+                json!({
+                    "output_index":0,
+                    "summary_index":1,
+                    "part":{"type":"summary_text","text":""}
+                })
+            ),
+            sse_event(
+                "response.reasoning_summary_text.delta",
+                json!({
+                    "output_index":0,"summary_index":1,"delta":"part two"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}
+                })
+            ),
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":1,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                json!({
+                    "output_index":1,"delta":"answer"
+                })
+            ),
+            format!(
+                "{}{}",
+                sse_event(
+                    "response.output_item.done",
+                    json!({
+                        "output_index":1,"item":{"type":"message"}
+                    })
+                ),
+                sse_event(
+                    "response.completed",
+                    json!({
+                        "response":{"id":"resp_1","usage":{}}
+                    })
+                )
+            ),
+        );
+        let response = accumulate_response(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap();
+        let content = response["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], "part one\n\npart two");
+        assert_eq!(content[0]["signature"], "");
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "answer");
+    }
+
+    #[test]
+    fn accumulate_empty_reasoning_summary_emits_no_thinking() {
+        let upstream = format!(
+            "{}{}{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}
+                })
+            ),
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":1,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                json!({
+                    "output_index":1,"delta":"answer"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":1,"item":{"type":"message"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","usage":{}}
+                })
+            ),
+        );
+        let response = accumulate_response(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap();
+        let content = response["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "answer");
+    }
+
+    #[test]
+    fn accumulate_handles_upstream_error() {
+        let upstream = sse_event("error", json!({"error":{"message":"upstream failure"}}));
+        let result = accumulate_response(upstream.as_bytes(), "msg_e", "model");
+        assert!(result.is_err());
+    }
+}

--- a/src/providers/xai/translate/mod.rs
+++ b/src/providers/xai/translate/mod.rs
@@ -1,0 +1,7 @@
+pub mod accumulate;
+pub mod model_allowlist;
+pub mod read_rewrite;
+pub mod reducer;
+pub mod request;
+pub mod stream;
+pub mod web_search_compat;

--- a/src/providers/xai/translate/model_allowlist.rs
+++ b/src/providers/xai/translate/model_allowlist.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+
+use crate::registry::XAI_MODELS;
+
+pub const XAI_DEFAULT_MODEL: &str = "grok-build-0.1";
+
+/// Wire models the proxy will send upstream (single source: registry::XAI_MODELS).
+pub fn allowed_models() -> &'static [&'static str] {
+    XAI_MODELS
+}
+
+static ALIAS_TARGETS: once_cell::sync::Lazy<HashMap<&'static str, &'static str>> =
+    once_cell::sync::Lazy::new(|| {
+        let mut m = HashMap::new();
+        for model in XAI_MODELS {
+            m.insert(*model, *model);
+        }
+        // Short / legacy aliases → canonical wire ids
+        m.insert("grok-build", XAI_DEFAULT_MODEL);
+        m.insert("grok-build-latest", XAI_DEFAULT_MODEL);
+        m.insert("grok-composer-2.5", "grok-composer-2.5-fast");
+        m.insert("grok-4.3-latest", "grok-4.3");
+        m.insert("grok-4.5-latest", "grok-4.5");
+        // Anthropic-style aliases → coding default when aliasProvider=xai
+        for alias in [
+            "haiku",
+            "claude-haiku-4-5",
+            "claude-haiku-4-5-20251001",
+            "sonnet",
+            "claude-sonnet-4-6",
+            "claude-sonnet-5",
+            "opus",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "fable",
+            "claude-fable-5",
+        ] {
+            m.insert(alias, XAI_DEFAULT_MODEL);
+        }
+        m
+    });
+
+pub fn resolve_model(model: &str) -> String {
+    ALIAS_TARGETS
+        .get(model)
+        .copied()
+        .unwrap_or(model)
+        .to_string()
+}
+
+pub fn assert_allowed_model(model: &str) -> Result<(), ModelNotAllowedError> {
+    if XAI_MODELS.contains(&model) {
+        Ok(())
+    } else {
+        Err(ModelNotAllowedError {
+            model: model.to_string(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct ModelNotAllowedError {
+    pub model: String,
+}
+
+impl std::fmt::Display for ModelNotAllowedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Model not allowed: {}", self.model)
+    }
+}
+
+impl std::error::Error for ModelNotAllowedError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_aliases_to_default() {
+        assert_eq!(resolve_model("haiku"), XAI_DEFAULT_MODEL);
+        assert_eq!(resolve_model("claude-opus-4-8"), XAI_DEFAULT_MODEL);
+        assert_eq!(resolve_model("grok-build"), XAI_DEFAULT_MODEL);
+    }
+
+    #[test]
+    fn resolve_explicit_models() {
+        assert_eq!(resolve_model("grok-4.3"), "grok-4.3");
+        assert_eq!(resolve_model("grok-build-0.1"), "grok-build-0.1");
+        assert_eq!(
+            resolve_model("grok-composer-2.5-fast"),
+            "grok-composer-2.5-fast"
+        );
+    }
+
+    #[test]
+    fn assert_allowed() {
+        assert!(assert_allowed_model("grok-build-0.1").is_ok());
+        assert!(assert_allowed_model("grok-composer-2.5-fast").is_ok());
+        assert!(assert_allowed_model("gpt-5.4").is_err());
+    }
+}

--- a/src/providers/xai/translate/read_rewrite.rs
+++ b/src/providers/xai/translate/read_rewrite.rs
@@ -1,0 +1,139 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use serde_json::Value;
+
+const MAX_REWRITE_NOTES: usize = 4_096;
+const READ_OFFSET_REWRITE_THRESHOLD: i64 = 1_000_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadOffsetRewrite {
+    pub offset: i64,
+    pub file_path: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct RewriteStore {
+    order: VecDeque<String>,
+    entries: HashMap<String, ReadOffsetRewrite>,
+}
+
+static READ_OFFSET_REWRITES: Lazy<Mutex<RewriteStore>> =
+    Lazy::new(|| Mutex::new(RewriteStore::default()));
+
+pub fn sanitize_read_args(name: &str, args: &str, call_id: Option<&str>) -> String {
+    if name != "Read" || args.is_empty() {
+        return args.to_string();
+    }
+
+    let parsed: Value = match serde_json::from_str(args) {
+        Ok(v) => v,
+        Err(_) => return args.to_string(),
+    };
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => return args.to_string(),
+    };
+
+    let mut sanitized = obj.clone();
+    let mut changed = false;
+
+    let has_empty_pages = obj
+        .get("pages")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.is_empty());
+    if has_empty_pages {
+        sanitized.remove("pages");
+        changed = true;
+    }
+
+    if let Some(offset) = obj.get("offset").and_then(|v| v.as_i64())
+        && offset >= READ_OFFSET_REWRITE_THRESHOLD
+    {
+        sanitized.remove("offset");
+        changed = true;
+        if let Some(call_id) = call_id.filter(|id| !id.is_empty()) {
+            record_read_offset_rewrite(
+                call_id,
+                ReadOffsetRewrite {
+                    offset,
+                    file_path: obj
+                        .get("file_path")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                },
+            );
+        }
+    }
+
+    if changed {
+        serde_json::to_string(&sanitized).unwrap_or_else(|_| args.to_string())
+    } else {
+        args.to_string()
+    }
+}
+
+pub fn read_offset_rewrite(call_id: &str) -> Option<ReadOffsetRewrite> {
+    READ_OFFSET_REWRITES
+        .lock()
+        .ok()
+        .and_then(|store| store.entries.get(call_id).cloned())
+}
+
+fn record_read_offset_rewrite(call_id: &str, note: ReadOffsetRewrite) {
+    let Ok(mut store) = READ_OFFSET_REWRITES.lock() else {
+        return;
+    };
+
+    if !store.entries.contains_key(call_id) {
+        store.order.push_back(call_id.to_string());
+    }
+    store.entries.insert(call_id.to_string(), note);
+
+    while store.entries.len() > MAX_REWRITE_NOTES {
+        let Some(oldest) = store.order.pop_front() else {
+            break;
+        };
+        store.entries.remove(&oldest);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_read_args_removes_empty_pages() {
+        let args = r#"{"file_path":"/tmp/a","pages":""}"#;
+        let sanitized = sanitize_read_args("Read", args, None);
+        let parsed: Value = serde_json::from_str(&sanitized).unwrap();
+        assert!(parsed.get("pages").is_none());
+        assert_eq!(
+            parsed.get("file_path").and_then(|v| v.as_str()),
+            Some("/tmp/a")
+        );
+    }
+
+    #[test]
+    fn sanitize_read_args_drops_and_records_absurd_offset() {
+        let args = r#"{"file_path":"/tmp/a","offset":1300000,"limit":20}"#;
+        let sanitized = sanitize_read_args("Read", args, Some("call_rewrite_test"));
+        let parsed: Value = serde_json::from_str(&sanitized).unwrap();
+        assert!(parsed.get("offset").is_none());
+        assert_eq!(parsed.get("limit").and_then(|v| v.as_i64()), Some(20));
+
+        let note = read_offset_rewrite("call_rewrite_test").unwrap();
+        assert_eq!(note.offset, 1_300_000);
+        assert_eq!(note.file_path.as_deref(), Some("/tmp/a"));
+    }
+
+    #[test]
+    fn sanitize_read_args_keeps_normal_offset() {
+        let args = r#"{"file_path":"/tmp/a","offset":1300,"limit":20}"#;
+        let sanitized = sanitize_read_args("Read", args, Some("call_keep_test"));
+        let parsed: Value = serde_json::from_str(&sanitized).unwrap();
+        assert_eq!(parsed.get("offset").and_then(|v| v.as_i64()), Some(1_300));
+        assert!(read_offset_rewrite("call_keep_test").is_none());
+    }
+}

--- a/src/providers/xai/translate/reducer.rs
+++ b/src/providers/xai/translate/reducer.rs
@@ -1,0 +1,1579 @@
+use crate::anthropic::sse::parse_sse_events;
+
+use super::read_rewrite::sanitize_read_args;
+use super::request::ResponsesInputItem;
+
+#[derive(Debug, Clone)]
+pub struct UpstreamStreamError {
+    pub kind: UpstreamErrorKind,
+    pub message: String,
+    pub retry_after_seconds: Option<u64>,
+    pub diagnostics: Option<UpstreamStreamDiagnostics>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpstreamErrorKind {
+    RateLimit,
+    Overloaded,
+    Transient,
+    Failed,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct UpstreamStreamDiagnostics {
+    pub event_count: usize,
+    pub last_event_type: Option<String>,
+    pub saw_terminal_event: bool,
+    pub open_blocks: Vec<OpenBlockDiagnostic>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OpenBlockDiagnostic {
+    pub output_index: usize,
+    pub anthropic_index: usize,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_bytes: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub argument_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CodexUsage {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub input_tokens_details_cached: Option<u64>,
+    pub output_tokens_details_reasoning: Option<u64>,
+}
+
+pub type StopReason = &'static str;
+pub const STOP_END_TURN: &str = "end_turn";
+pub const STOP_TOOL_USE: &str = "tool_use";
+pub const STOP_MAX_TOKENS: &str = "max_tokens";
+
+pub type TerminalType = &'static str;
+pub const TERM_COMPLETED: &str = "response.completed";
+pub const TERM_INCOMPLETE: &str = "response.incomplete";
+pub const TERM_DONE: &str = "response.done";
+
+const BUFFERED_READ_REPAIR_TRAILING_WHITESPACE_BYTES: usize = 1_024;
+const BUFFERED_TOOL_MAX_ARGS_BYTES: usize = 5_000_000;
+
+#[derive(Debug, Clone)]
+pub enum ReducerEvent {
+    ThinkingStart {
+        index: usize,
+    },
+    ThinkingDelta {
+        index: usize,
+        text: String,
+    },
+    ThinkingStop {
+        index: usize,
+    },
+    TextStart {
+        index: usize,
+    },
+    TextDelta {
+        index: usize,
+        text: String,
+    },
+    TextStop {
+        index: usize,
+    },
+    ToolStart {
+        index: usize,
+        id: String,
+        name: String,
+    },
+    ToolDelta {
+        index: usize,
+        partial_json: String,
+    },
+    ToolStop {
+        index: usize,
+    },
+    ToolProgress {
+        index: usize,
+    },
+    Progress,
+    WebSearch {
+        index: usize,
+        result_index: usize,
+        id: String,
+        query: String,
+    },
+    Finish {
+        stop_reason: StopReason,
+        terminal_type: String,
+        continuation_eligible: bool,
+        usage: Option<CodexUsage>,
+        web_search_requests: usize,
+        response_id: Option<String>,
+        output_items: Vec<ResponsesInputItem>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct FinishMetadata {
+    pub continuation_eligible: bool,
+    pub response_id: Option<String>,
+    pub output_items: Vec<ResponsesInputItem>,
+}
+
+enum BlockState {
+    Text {
+        index: usize,
+        text_accum: String,
+    },
+    Tool {
+        index: usize,
+        #[allow(dead_code)]
+        output_index: usize,
+        call_id: String,
+        name: String,
+        args_accum: String,
+        had_delta: bool,
+        buffer_until_done: bool,
+        emitted_args: bool,
+    },
+}
+
+pub fn finish_metadata_from_upstream(
+    input: &[u8],
+) -> Result<Option<FinishMetadata>, UpstreamStreamError> {
+    let events = reduce_upstream_bytes(input)?;
+    Ok(events.into_iter().rev().find_map(|event| match event {
+        ReducerEvent::Finish {
+            continuation_eligible,
+            response_id,
+            output_items,
+            ..
+        } => Some(FinishMetadata {
+            continuation_eligible,
+            response_id,
+            output_items,
+        }),
+        _ => None,
+    }))
+}
+
+pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, UpstreamStreamError> {
+    let sse_events = parse_sse_events(input);
+    let mut out = Vec::new();
+
+    let mut blocks_by_output_index: std::collections::HashMap<usize, BlockState> =
+        std::collections::HashMap::new();
+    let mut output_items_by_index: std::collections::BTreeMap<usize, ResponsesInputItem> =
+        std::collections::BTreeMap::new();
+    let mut item_id_to_output_index: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    let mut anthropic_index = 0usize;
+    let mut thinking_index: Option<usize> = None;
+    let mut saw_tool_use = false;
+    let mut final_usage: Option<CodexUsage> = None;
+    let mut response_id: Option<String> = None;
+    let mut terminal_type: Option<String> = None;
+    let mut continuation_eligible = false;
+    let mut incomplete = false;
+    let mut web_search_requests = 0usize;
+    let mut _saw_terminal = false;
+    let mut event_count = 0usize;
+    let mut last_event_type: Option<String> = None;
+
+    fn capture_output_item(
+        output_index: usize,
+        state: &BlockState,
+        items: &mut std::collections::BTreeMap<usize, ResponsesInputItem>,
+    ) {
+        match state {
+            BlockState::Text {
+                index: _,
+                text_accum,
+            } => {
+                if text_accum.is_empty() {
+                    return;
+                }
+                items.insert(
+                    output_index,
+                    ResponsesInputItem::Message {
+                        role: "assistant".to_string(),
+                        content: vec![super::request::ResponsesContentPart::OutputText {
+                            text: text_accum.clone(),
+                        }],
+                    },
+                );
+            }
+            BlockState::Tool {
+                args_accum,
+                name,
+                call_id,
+                ..
+            } => {
+                items.insert(
+                    output_index,
+                    ResponsesInputItem::FunctionCall {
+                        call_id: call_id.clone(),
+                        name: name.clone(),
+                        arguments: args_accum.clone(),
+                    },
+                );
+            }
+        }
+    }
+
+    fn close_thinking(out: &mut Vec<ReducerEvent>, thinking_index: &mut Option<usize>) {
+        if let Some(index) = thinking_index.take() {
+            out.push(ReducerEvent::ThinkingStop { index });
+        }
+    }
+
+    for evt in &sse_events {
+        let data = evt.data.trim();
+        if data.is_empty() {
+            continue;
+        }
+
+        let p: serde_json::Value = match serde_json::from_str(data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let t = p
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        event_count += 1;
+        last_event_type = Some(t.clone());
+
+        if t == "codex.rate_limits" {
+            if let Some(true) = p
+                .get("rate_limits")
+                .and_then(|r| r.get("limit_reached"))
+                .and_then(|v| v.as_bool())
+            {
+                let retry_after = p
+                    .get("rate_limits")
+                    .and_then(|r| r.get("primary"))
+                    .and_then(|r| r.get("reset_after_seconds"))
+                    .and_then(|v| v.as_f64());
+                return Err(UpstreamStreamError {
+                    kind: UpstreamErrorKind::RateLimit,
+                    message: "rate limit reached".to_string(),
+                    retry_after_seconds: retry_after.map(|f| f as u64),
+                    diagnostics: None,
+                });
+            }
+            out.push(ReducerEvent::Progress);
+            continue;
+        }
+
+        if t == "keepalive" {
+            out.push(ReducerEvent::Progress);
+            continue;
+        }
+
+        if t == "response.web_search_call.in_progress"
+            || t == "response.web_search_call.searching"
+            || t == "response.web_search_call.completed"
+        {
+            out.push(ReducerEvent::Progress);
+            continue;
+        }
+
+        if t == "response.failed" || t == "response.error" || t == "error" {
+            let msg = p
+                .get("response")
+                .and_then(|r| r.get("error"))
+                .and_then(|e| e.get("message"))
+                .and_then(|v| v.as_str())
+                .or_else(|| {
+                    p.get("error")
+                        .and_then(|e| e.get("message"))
+                        .and_then(|v| v.as_str())
+                })
+                .unwrap_or("Upstream error");
+            let kind = upstream_failure_kind(&p, msg);
+            let retry_after = retry_after_from_payload(&p);
+            return Err(UpstreamStreamError {
+                kind,
+                message: msg.to_string(),
+                retry_after_seconds: retry_after,
+                diagnostics: None,
+            });
+        }
+
+        if t == "response.output_item.added" {
+            let item = match p.get("item") {
+                Some(v) => v,
+                None => continue,
+            };
+            let output_index: usize =
+                p.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+
+            let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            if item_type == "reasoning" {
+                continue;
+            }
+            if item_type == "web_search_call" {
+                out.push(ReducerEvent::Progress);
+                continue;
+            }
+
+            if item_type == "message" {
+                close_thinking(&mut out, &mut thinking_index);
+                let idx = anthropic_index;
+                anthropic_index += 1;
+                if let Some(id) = item.get("id").and_then(|v| v.as_str()) {
+                    item_id_to_output_index.insert(id.to_string(), output_index);
+                }
+                blocks_by_output_index.insert(
+                    output_index,
+                    BlockState::Text {
+                        index: idx,
+                        text_accum: String::new(),
+                    },
+                );
+                out.push(ReducerEvent::TextStart { index: idx });
+                continue;
+            }
+
+            if item_type == "function_call" {
+                close_thinking(&mut out, &mut thinking_index);
+                saw_tool_use = true;
+                let idx = anthropic_index;
+                anthropic_index += 1;
+                let call_id = item
+                    .get("call_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = item
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let buffer_until_done = should_buffer_tool_args(&name);
+                blocks_by_output_index.insert(
+                    output_index,
+                    BlockState::Tool {
+                        index: idx,
+                        output_index,
+                        call_id: call_id.clone(),
+                        name: name.clone(),
+                        args_accum: String::new(),
+                        had_delta: false,
+                        buffer_until_done,
+                        emitted_args: false,
+                    },
+                );
+                out.push(ReducerEvent::ToolStart {
+                    index: idx,
+                    id: call_id,
+                    name,
+                });
+                continue;
+            }
+
+            continue;
+        }
+
+        if t == "response.reasoning_summary_part.added" {
+            if let Some(index) = thinking_index {
+                out.push(ReducerEvent::ThinkingDelta {
+                    index,
+                    text: "\n\n".to_string(),
+                });
+            }
+            continue;
+        }
+
+        if t == "response.reasoning_summary_text.delta" {
+            let delta = p.get("delta").and_then(|v| v.as_str()).unwrap_or("");
+            if delta.is_empty() {
+                continue;
+            }
+            if thinking_index.is_none() {
+                let index = anthropic_index;
+                anthropic_index += 1;
+                thinking_index = Some(index);
+                out.push(ReducerEvent::ThinkingStart { index });
+            }
+            out.push(ReducerEvent::ThinkingDelta {
+                index: thinking_index.unwrap(),
+                text: delta.to_string(),
+            });
+            continue;
+        }
+
+        if t == "response.output_text.delta" {
+            close_thinking(&mut out, &mut thinking_index);
+            let output_index = p
+                .get("output_index")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize);
+            let item_id = p.get("item_id").and_then(|v| v.as_str());
+            let state = if let Some(oi) = output_index {
+                blocks_by_output_index.get_mut(&oi)
+            } else if let Some(id) = item_id {
+                item_id_to_output_index
+                    .get(id)
+                    .and_then(|oi| blocks_by_output_index.get_mut(oi))
+            } else {
+                None
+            };
+            let delta = p.get("delta").and_then(|v| v.as_str()).unwrap_or("");
+            if delta.is_empty() {
+                continue;
+            }
+            match state {
+                Some(BlockState::Text { index, text_accum }) => {
+                    text_accum.push_str(delta);
+                    out.push(ReducerEvent::TextDelta {
+                        index: *index,
+                        text: delta.to_string(),
+                    });
+                }
+                _ => continue,
+            }
+            continue;
+        }
+
+        if t == "response.function_call_arguments.delta" {
+            let output_index = match p.get("output_index").and_then(|v| v.as_u64()) {
+                Some(v) => v as usize,
+                None => continue,
+            };
+            let delta = p.get("delta").and_then(|v| v.as_str()).unwrap_or("");
+            if delta.is_empty() {
+                continue;
+            }
+            let state = match blocks_by_output_index.get_mut(&output_index) {
+                Some(s) => s,
+                None => continue,
+            };
+            let mut repaired_read: Option<(usize, String)> = None;
+            match state {
+                BlockState::Tool {
+                    args_accum,
+                    had_delta,
+                    buffer_until_done,
+                    emitted_args,
+                    name,
+                    index,
+                    call_id,
+                    ..
+                } => {
+                    args_accum.push_str(delta);
+                    *had_delta = true;
+                    if args_accum.len() > BUFFERED_TOOL_MAX_ARGS_BYTES {
+                        return Err(UpstreamStreamError {
+                            kind: UpstreamErrorKind::Failed,
+                            message: format!("Buffered {name} tool arguments exceeded safe limits"),
+                            retry_after_seconds: None,
+                            diagnostics: None,
+                        });
+                    }
+
+                    if *buffer_until_done {
+                        if let Some(repaired) = repair_whitespace_stalled_read_args(
+                            name,
+                            args_accum,
+                            Some(call_id.as_str()),
+                        ) {
+                            *args_accum = repaired.clone();
+                            *emitted_args = true;
+                            repaired_read = Some((*index, repaired));
+                        } else {
+                            out.push(ReducerEvent::ToolProgress { index: *index });
+                        }
+                    } else {
+                        *emitted_args = true;
+                        out.push(ReducerEvent::ToolDelta {
+                            index: *index,
+                            partial_json: delta.to_string(),
+                        });
+                    }
+                }
+                _ => continue,
+            }
+            if let Some((index, repaired)) = repaired_read {
+                if let Some(state) = blocks_by_output_index.remove(&output_index) {
+                    capture_output_item(output_index, &state, &mut output_items_by_index);
+                }
+                out.push(ReducerEvent::ToolDelta {
+                    index,
+                    partial_json: repaired,
+                });
+                out.push(ReducerEvent::ToolStop { index });
+                let output_items: Vec<ResponsesInputItem> =
+                    output_items_by_index.into_values().collect();
+                out.push(ReducerEvent::Finish {
+                    stop_reason: STOP_TOOL_USE,
+                    terminal_type: TERM_INCOMPLETE.to_string(),
+                    continuation_eligible: false,
+                    usage: None,
+                    web_search_requests,
+                    response_id: None,
+                    output_items,
+                });
+                return Ok(out);
+            }
+            continue;
+        }
+
+        if t == "response.function_call_arguments.done" {
+            let output_index = match p.get("output_index").and_then(|v| v.as_u64()) {
+                Some(v) => v as usize,
+                None => continue,
+            };
+            if let Some(BlockState::Tool { args_accum, .. }) =
+                blocks_by_output_index.get_mut(&output_index)
+                && let Some(args) = p.get("arguments").and_then(|v| v.as_str())
+                && args_accum.is_empty()
+            {
+                *args_accum = args.to_string();
+            }
+            continue;
+        }
+
+        if t == "response.output_item.done" {
+            let output_index: usize =
+                p.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+            let item = p.get("item");
+
+            if let Some(item_val) = item
+                && item_val.get("type").and_then(|v| v.as_str()) == Some("reasoning")
+            {
+                close_thinking(&mut out, &mut thinking_index);
+                continue;
+            }
+
+            if let Some(item_val) = item
+                && item_val.get("type").and_then(|v| v.as_str()) == Some("web_search_call")
+            {
+                close_thinking(&mut out, &mut thinking_index);
+                let idx = anthropic_index;
+                anthropic_index += 1;
+                let result_index = anthropic_index;
+                anthropic_index += 1;
+                web_search_requests += 1;
+                let id_val = item_val.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                let id = server_tool_use_id_from_codex_web_search_id(id_val);
+                let query = web_search_query(item_val);
+                out.push(ReducerEvent::WebSearch {
+                    index: idx,
+                    result_index,
+                    id,
+                    query,
+                });
+                continue;
+            }
+
+            let state = blocks_by_output_index.remove(&output_index);
+            let mut state = match state {
+                Some(s) => s,
+                None => continue,
+            };
+
+            if let Some(item_val) = item {
+                if let BlockState::Tool {
+                    args_accum,
+                    name,
+                    call_id,
+                    buffer_until_done,
+                    emitted_args,
+                    had_delta,
+                    index,
+                    ..
+                } = &mut state
+                {
+                    if let Some(final_args) = item_val
+                        .get("arguments")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                    {
+                        if !args_accum.is_empty() && !*emitted_args {
+                            // Already have accum from deltas - skip
+                        } else if *had_delta {
+                            // Already emitted deltas
+                        } else {
+                            *args_accum = final_args.to_string();
+                        }
+                    }
+
+                    if !args_accum.is_empty() {
+                        let sanitized =
+                            sanitize_read_args(name, args_accum, Some(call_id.as_str()));
+                        *args_accum = sanitized;
+                        if *buffer_until_done || !*emitted_args {
+                            *emitted_args = true;
+                            out.push(ReducerEvent::ToolDelta {
+                                index: *index,
+                                partial_json: args_accum.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            capture_output_item(output_index, &state, &mut output_items_by_index);
+
+            match &state {
+                BlockState::Text { index, .. } => {
+                    out.push(ReducerEvent::TextStop { index: *index });
+                }
+                BlockState::Tool { index, .. } => {
+                    out.push(ReducerEvent::ToolStop { index: *index });
+                }
+            }
+            continue;
+        }
+
+        if t == "response.completed" || t == "response.incomplete" || t == "response.done" {
+            _saw_terminal = true;
+            terminal_type = Some(t.clone());
+            response_id = p
+                .get("response")
+                .and_then(|r| r.get("id"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            final_usage = p.get("response").map(parse_codex_usage);
+            if response_is_incomplete(&p, &t) {
+                incomplete = true;
+            }
+            continuation_eligible =
+                (t == "response.completed" || t == "response.done") && !incomplete;
+            continue;
+        }
+    }
+
+    let open_blocks = describe_open_blocks(&blocks_by_output_index);
+    if !_saw_terminal || !open_blocks.is_empty() {
+        let diagnostics = UpstreamStreamDiagnostics {
+            event_count,
+            last_event_type,
+            saw_terminal_event: _saw_terminal,
+            open_blocks,
+        };
+        return Err(UpstreamStreamError {
+            kind: UpstreamErrorKind::Transient,
+            message: if diagnostics.saw_terminal_event {
+                "upstream stream ended with open Codex output blocks".to_string()
+            } else {
+                "upstream stream ended before terminal Codex response event".to_string()
+            },
+            retry_after_seconds: None,
+            diagnostics: Some(diagnostics),
+        });
+    }
+
+    close_thinking(&mut out, &mut thinking_index);
+
+    let stop_reason: StopReason = if incomplete {
+        STOP_MAX_TOKENS
+    } else if saw_tool_use {
+        STOP_TOOL_USE
+    } else {
+        STOP_END_TURN
+    };
+
+    let output_items: Vec<ResponsesInputItem> = output_items_by_index.into_values().collect();
+
+    out.push(ReducerEvent::Finish {
+        stop_reason,
+        terminal_type: terminal_type.unwrap_or_else(|| TERM_INCOMPLETE.to_string()),
+        continuation_eligible,
+        usage: final_usage,
+        web_search_requests,
+        response_id,
+        output_items,
+    });
+
+    Ok(out)
+}
+
+fn describe_open_blocks(
+    blocks: &std::collections::HashMap<usize, BlockState>,
+) -> Vec<OpenBlockDiagnostic> {
+    let mut out: Vec<_> = blocks
+        .iter()
+        .map(|(output_index, state)| match state {
+            BlockState::Text { index, text_accum } => OpenBlockDiagnostic {
+                output_index: *output_index,
+                anthropic_index: *index,
+                kind: "text".to_string(),
+                name: None,
+                call_id: None,
+                text_bytes: Some(text_accum.len()),
+                argument_bytes: None,
+            },
+            BlockState::Tool {
+                index,
+                call_id,
+                name,
+                args_accum,
+                ..
+            } => OpenBlockDiagnostic {
+                output_index: *output_index,
+                anthropic_index: *index,
+                kind: "tool".to_string(),
+                name: Some(name.clone()),
+                call_id: Some(call_id.clone()),
+                text_bytes: None,
+                argument_bytes: Some(args_accum.len()),
+            },
+        })
+        .collect();
+    out.sort_by_key(|block| block.output_index);
+    out
+}
+
+fn parse_codex_usage(response: &serde_json::Value) -> CodexUsage {
+    let usage = match response.get("usage") {
+        Some(u) => u,
+        None => return CodexUsage::default(),
+    };
+    CodexUsage {
+        input_tokens: usage.get("input_tokens").and_then(|v| v.as_u64()),
+        output_tokens: usage.get("output_tokens").and_then(|v| v.as_u64()),
+        input_tokens_details_cached: usage
+            .get("input_tokens_details")
+            .and_then(|d| d.get("cached_tokens"))
+            .and_then(|v| v.as_u64()),
+        output_tokens_details_reasoning: usage
+            .get("output_tokens_details")
+            .and_then(|d| d.get("reasoning_tokens"))
+            .and_then(|v| v.as_u64()),
+    }
+}
+
+fn response_is_incomplete(payload: &serde_json::Value, event_type: &str) -> bool {
+    event_type == "response.incomplete"
+        || payload
+            .get("response")
+            .and_then(|r| r.get("status"))
+            .and_then(|v| v.as_str())
+            == Some("incomplete")
+        || payload
+            .get("response")
+            .and_then(|r| r.get("incomplete_details"))
+            .and_then(|d| d.get("reason"))
+            .and_then(|v| v.as_str())
+            .is_some()
+}
+
+fn should_buffer_tool_args(name: &str) -> bool {
+    name == "Read"
+}
+
+fn repair_whitespace_stalled_read_args(
+    name: &str,
+    args: &str,
+    call_id: Option<&str>,
+) -> Option<String> {
+    if name != "Read" {
+        return None;
+    }
+    let trimmed = args.trim_end();
+    let trailing_whitespace = args.len().saturating_sub(trimmed.len());
+    if trailing_whitespace < BUFFERED_READ_REPAIR_TRAILING_WHITESPACE_BYTES {
+        return None;
+    }
+    parse_read_args_candidate(trimmed, call_id).or_else(|| {
+        let with_brace = format!("{trimmed}}}");
+        parse_read_args_candidate(&with_brace, call_id)
+    })
+}
+
+fn parse_read_args_candidate(args: &str, call_id: Option<&str>) -> Option<String> {
+    let parsed: serde_json::Value = serde_json::from_str(args).ok()?;
+    if !is_valid_read_args(&parsed) {
+        return None;
+    }
+    Some(sanitize_read_args(
+        "Read",
+        &serde_json::to_string(&parsed).ok()?,
+        call_id,
+    ))
+}
+
+fn is_valid_read_args(value: &serde_json::Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    for key in obj.keys() {
+        if !matches!(key.as_str(), "file_path" | "offset" | "limit" | "pages") {
+            return false;
+        }
+    }
+    let Some(file_path) = obj.get("file_path").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    if file_path.is_empty() {
+        return false;
+    }
+    if let Some(offset) = obj.get("offset").and_then(|v| v.as_i64())
+        && offset < 0
+    {
+        return false;
+    }
+    if let Some(limit) = obj.get("limit").and_then(|v| v.as_i64())
+        && limit <= 0
+    {
+        return false;
+    }
+    if obj.get("offset").is_some_and(|v| !v.is_i64()) {
+        return false;
+    }
+    if obj.get("limit").is_some_and(|v| !v.is_i64()) {
+        return false;
+    }
+    if obj.get("pages").is_some_and(|v| !v.is_string()) {
+        return false;
+    }
+    true
+}
+
+fn web_search_query(item: &serde_json::Value) -> String {
+    let action = match item.get("action") {
+        Some(v) => v,
+        None => return String::new(),
+    };
+    if let Some(query) = action.get("query").and_then(|v| v.as_str()) {
+        return query.to_string();
+    }
+    if let Some(queries) = action.get("queries").and_then(|v| v.as_array()) {
+        for q in queries {
+            if let Some(s) = q.as_str() {
+                return s.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
+fn server_tool_use_id_from_codex_web_search_id(id: &str) -> String {
+    let suffix: String = id
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("srvtoolu_{suffix}")
+}
+
+fn upstream_failure_kind(payload: &serde_json::Value, message: &str) -> UpstreamErrorKind {
+    let status = payload
+        .get("status")
+        .or_else(|| payload.get("status_code"))
+        .and_then(|v| v.as_u64());
+    let code = payload
+        .get("response")
+        .and_then(|r| r.get("error"))
+        .and_then(|e| e.get("code"))
+        .or_else(|| payload.get("error").and_then(|e| e.get("code")))
+        .and_then(|v| v.as_str());
+    let err_type = payload
+        .get("response")
+        .and_then(|r| r.get("error"))
+        .and_then(|e| e.get("type"))
+        .or_else(|| payload.get("error").and_then(|e| e.get("type")))
+        .and_then(|v| v.as_str());
+    let lower_msg = message.to_lowercase();
+
+    if status == Some(529)
+        || code == Some("overloaded_error")
+        || err_type == Some("overloaded_error")
+        || lower_msg.contains("overloaded")
+    {
+        return UpstreamErrorKind::Overloaded;
+    }
+
+    if (status.is_some_and(|s| (500..600).contains(&s)))
+        || code == Some("server_error")
+        || code == Some("internal_server_error")
+        || code == Some("internal_error")
+        || err_type == Some("server_error")
+        || err_type == Some("internal_server_error")
+        || err_type == Some("internal_error")
+        || is_retryable_transport_message(&lower_msg)
+    {
+        return UpstreamErrorKind::Transient;
+    }
+
+    UpstreamErrorKind::Failed
+}
+
+fn retry_after_from_payload(payload: &serde_json::Value) -> Option<u64> {
+    let raw = payload
+        .get("response")
+        .and_then(|r| r.get("error"))
+        .and_then(|e| e.get("retry_after_seconds"))
+        .or_else(|| {
+            payload
+                .get("error")
+                .and_then(|e| e.get("retry_after_seconds"))
+        })
+        .or_else(|| payload.get("retry_after_seconds"))
+        .or_else(|| payload.get("headers").and_then(|h| h.get("retry-after")))
+        .or_else(|| payload.get("headers").and_then(|h| h.get("Retry-After")));
+    let value = match raw {
+        Some(v) if v.is_number() => v.as_f64(),
+        Some(v) if v.is_string() => v.as_str().and_then(|s| s.parse::<f64>().ok()),
+        _ => None,
+    };
+    value.map(|f| f as u64)
+}
+
+fn is_retryable_transport_message(msg: &str) -> bool {
+    msg.contains("you can retry your request")
+        || msg.contains("socket connection was closed unexpectedly")
+        || msg.contains("connection closed unexpectedly")
+        || msg.contains("connection reset")
+        || msg.contains("operation timed out")
+        || msg.contains("econnreset")
+        || msg.contains("epipe")
+        || msg.contains("etimedout")
+        || msg.contains("und_err_socket")
+        || msg.contains("fetch failed")
+}
+
+pub fn map_codex_usage_to_anthropic(
+    u: &Option<CodexUsage>,
+    web_search_requests: Option<usize>,
+) -> AnthropicUsage {
+    let usage = match u {
+        Some(u) => u,
+        None => return AnthropicUsage::default(),
+    };
+    let cached = usage.input_tokens_details_cached.unwrap_or(0);
+    let total_input = usage.input_tokens.unwrap_or(0);
+    let input_tokens = total_input.saturating_sub(cached);
+
+    let mut result = AnthropicUsage {
+        input_tokens,
+        output_tokens: usage.output_tokens.unwrap_or(0),
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: cached,
+        server_tool_use: None,
+    };
+
+    if let Some(requests) = web_search_requests
+        && requests > 0
+    {
+        result.server_tool_use = Some(WebSearchUsage {
+            web_search_requests: requests,
+        });
+    }
+
+    result
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct AnthropicUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub cache_read_input_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_tool_use: Option<WebSearchUsage>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WebSearchUsage {
+    pub web_search_requests: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sse(type_name: &str, payload: serde_json::Value) -> String {
+        let mut obj = payload.as_object().cloned().unwrap_or_default();
+        obj.insert("type".into(), json!(type_name));
+        format!("data: {}\n\n", serde_json::to_string(&obj).unwrap())
+    }
+
+    #[test]
+    fn reduce_text_response() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index": 0,
+                    "item": {"type":"message","id":"msg_up"}
+                })
+            ),
+            sse(
+                "response.output_text.delta",
+                json!({
+                    "output_index":0,"delta":"hello"
+                })
+            ),
+            sse(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,"item":{"type":"message"}
+                })
+            ),
+            sse(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","status":"completed","incomplete_details":null,"usage":{"input_tokens":5,"output_tokens":1}}
+                })
+            ),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let last = out.last().unwrap();
+        if let ReducerEvent::Finish {
+            stop_reason,
+            response_id,
+            usage,
+            ..
+        } = last
+        {
+            assert_eq!(*stop_reason, "end_turn");
+            assert_eq!(response_id.as_deref(), Some("resp_1"));
+            assert_eq!(usage.as_ref().unwrap().input_tokens, Some(5));
+        } else {
+            panic!("expected Finish");
+        }
+    }
+
+    #[test]
+    fn reduce_tool_use_response() {
+        let upstream = format!(
+            "{}{}{}{}{}",
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"function_call","call_id":"call_1","name":"Read"}
+                })
+            ),
+            sse(
+                "response.function_call_arguments.delta",
+                json!({
+                    "output_index":0,"delta":"{\"file_path\":"
+                })
+            ),
+            sse(
+                "response.function_call_arguments.delta",
+                json!({
+                    "output_index":0,"delta":"\"/tmp/a\"}"
+                })
+            ),
+            sse(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"function_call","call_id":"call_1","name":"Read","arguments":"{\"file_path\":\"/tmp/a\"}"}
+                })
+            ),
+            sse(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","usage":{}}
+                })
+            ),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let last = out.last().unwrap();
+        if let ReducerEvent::Finish { stop_reason, .. } = last {
+            assert_eq!(*stop_reason, "tool_use");
+        } else {
+            panic!("expected Finish");
+        }
+    }
+
+    #[test]
+    fn reduce_rate_limit_throws() {
+        let upstream = sse(
+            "codex.rate_limits",
+            json!({"rate_limits":{"limit_reached":true,"primary":{"reset_after_seconds":30}}}),
+        );
+        let result = reduce_upstream_bytes(upstream.as_bytes());
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind, UpstreamErrorKind::RateLimit);
+    }
+
+    #[test]
+    fn reduce_repairs_whitespace_stalled_read_args() {
+        let upstream = format!(
+            "{}{}",
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"function_call","call_id":"call_1","name":"Read"}
+                })
+            ),
+            sse(
+                "response.function_call_arguments.delta",
+                json!({
+                    "output_index":0,
+                    "delta": format!("{{\"file_path\":\"/tmp/a\",\"pages\":\"\"{}", " ".repeat(1024))
+                })
+            )
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        assert!(out.iter().any(|event| {
+            matches!(
+                event,
+                ReducerEvent::ToolDelta { partial_json, .. }
+                    if partial_json == "{\"file_path\":\"/tmp/a\"}"
+            )
+        }));
+        let last = out.last().unwrap();
+        if let ReducerEvent::Finish {
+            stop_reason,
+            continuation_eligible,
+            ..
+        } = last
+        {
+            assert_eq!(*stop_reason, "tool_use");
+            assert!(!continuation_eligible);
+        } else {
+            panic!("expected Finish");
+        }
+    }
+
+    #[test]
+    fn reduce_upstream_error_event() {
+        let upstream = sse("error", json!({"error":{"message":"upstream failure"}}));
+        let result = reduce_upstream_bytes(upstream.as_bytes());
+        assert!(result.is_err());
+        match result.unwrap_err().kind {
+            UpstreamErrorKind::Failed => {}
+            _ => panic!("expected Failed"),
+        }
+    }
+
+    #[test]
+    fn reduce_web_search_output() {
+        let upstream = format!(
+            "{}{}{}{}{}{}",
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"web_search_call","id":"ws_1"}
+                })
+            ),
+            sse(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"web_search_call","id":"ws_1","action":{"query":"test query"}}
+                })
+            ),
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index":1,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse(
+                "response.output_text.delta",
+                json!({
+                    "output_index":1,"delta":"result"
+                })
+            ),
+            sse(
+                "response.output_item.done",
+                json!({
+                    "output_index":1,"item":{"type":"message"}
+                })
+            ),
+            sse(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","usage":{"input_tokens":3}}
+                })
+            ),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let has_web_search = out
+            .iter()
+            .any(|e| matches!(e, ReducerEvent::WebSearch { .. }));
+        assert!(has_web_search, "expected WebSearch event");
+        let last = out.last().unwrap();
+        if let ReducerEvent::Finish {
+            web_search_requests,
+            ..
+        } = last
+        {
+            assert_eq!(*web_search_requests, 1);
+        } else {
+            panic!("expected Finish");
+        }
+    }
+
+    #[test]
+    fn reduce_missing_terminal_is_error() {
+        let upstream = format!(
+            "{}{}{}",
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index": 0,
+                    "item": {"type":"message","id":"msg_up"}
+                })
+            ),
+            sse(
+                "response.output_text.delta",
+                json!({
+                    "output_index":0,"delta":"partial"
+                })
+            ),
+            sse(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,"item":{"type":"message"}
+                })
+            ),
+        );
+        let err = reduce_upstream_bytes(upstream.as_bytes()).unwrap_err();
+        assert_eq!(err.kind, UpstreamErrorKind::Transient);
+        assert!(err.message.contains("terminal"));
+    }
+
+    #[test]
+    fn reduce_incomplete_is_max_tokens() {
+        let upstream = sse(
+            "response.incomplete",
+            json!({"response":{"id":"resp_1","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{}}}),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let last = out.last().unwrap();
+        if let ReducerEvent::Finish {
+            stop_reason,
+            continuation_eligible,
+            ..
+        } = last
+        {
+            assert_eq!(*stop_reason, "max_tokens");
+            assert!(!continuation_eligible);
+        } else {
+            panic!("expected Finish");
+        }
+    }
+
+    #[test]
+    fn reduce_completed_with_null_incomplete_details_is_end_turn() {
+        let upstream = sse(
+            "response.completed",
+            json!({"response":{"id":"resp_1","status":"completed","incomplete_details":null,"usage":{}}}),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let last = out.last().unwrap();
+        if let ReducerEvent::Finish {
+            stop_reason,
+            continuation_eligible,
+            ..
+        } = last
+        {
+            assert_eq!(*stop_reason, "end_turn");
+            assert!(continuation_eligible);
+        } else {
+            panic!("expected Finish");
+        }
+    }
+
+    #[test]
+    fn reduce_completed_is_continuation_eligible() {
+        let upstream = sse(
+            "response.completed",
+            json!({"response":{"id":"resp_1","usage":{}}}),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let last = out.last().unwrap();
+        if let ReducerEvent::Finish {
+            continuation_eligible,
+            ..
+        } = last
+        {
+            assert!(continuation_eligible);
+        } else {
+            panic!("expected Finish");
+        }
+    }
+
+    #[test]
+    fn finish_metadata_extracts_continuation_state() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index": 0,
+                    "item": {"type":"message","id":"msg_up"}
+                })
+            ),
+            sse(
+                "response.output_text.delta",
+                json!({
+                    "output_index":0,"delta":"hello"
+                })
+            ),
+            sse(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,"item":{"type":"message"}
+                })
+            ),
+            sse(
+                "response.completed",
+                json!({
+                    "response":{"id":"resp_1","usage":{}}
+                })
+            ),
+        );
+        let metadata = finish_metadata_from_upstream(upstream.as_bytes())
+            .unwrap()
+            .unwrap();
+        assert!(metadata.continuation_eligible);
+        assert_eq!(metadata.response_id.as_deref(), Some("resp_1"));
+        assert_eq!(metadata.output_items.len(), 1);
+    }
+
+    #[test]
+    fn sanitize_tool_args_removes_empty_pages() {
+        let args = r#"{"file_path":"/tmp/a","pages":""}"#;
+        let sanitized = sanitize_read_args("Read", args, None);
+        let parsed: serde_json::Value = serde_json::from_str(&sanitized).unwrap();
+        assert!(parsed.get("pages").is_none());
+        assert_eq!(
+            parsed.get("file_path").and_then(|v| v.as_str()),
+            Some("/tmp/a")
+        );
+    }
+
+    #[test]
+    fn map_usage_reports_cached_prompt_tokens() {
+        let usage = CodexUsage {
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+            input_tokens_details_cached: Some(20),
+            output_tokens_details_reasoning: None,
+        };
+        let mapped = map_codex_usage_to_anthropic(&Some(usage), None);
+        assert_eq!(mapped.input_tokens, 80);
+        assert_eq!(mapped.output_tokens, 50);
+        assert_eq!(mapped.cache_read_input_tokens, 20);
+    }
+
+    #[test]
+    fn reduce_reasoning_summary_before_text() {
+        let upstream = format!(
+            "{}{}{}{}{}{}",
+            sse(
+                "response.reasoning_summary_text.delta",
+                json!({"output_index":0,"summary_index":0,"delta":"Plan"})
+            ),
+            sse(
+                "response.reasoning_summary_text.delta",
+                json!({"output_index":0,"summary_index":0,"delta":"ning"})
+            ),
+            sse(
+                "response.output_item.done",
+                json!({"output_index":0,"item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}})
+            ),
+            sse(
+                "response.output_item.added",
+                json!({"output_index":1,"item":{"type":"message","id":"msg_up"}})
+            ),
+            sse(
+                "response.output_text.delta",
+                json!({"output_index":1,"delta":"answer"})
+            ),
+            format!(
+                "{}{}",
+                sse(
+                    "response.output_item.done",
+                    json!({"output_index":1,"item":{"type":"message"}})
+                ),
+                sse(
+                    "response.completed",
+                    json!({"response":{"id":"resp_1","usage":{}}})
+                )
+            ),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        assert!(matches!(
+            out.iter()
+                .find(|event| matches!(event, ReducerEvent::ThinkingStart { .. })),
+            Some(ReducerEvent::ThinkingStart { index: 0 })
+        ));
+        let thinking_text: String = out
+            .iter()
+            .filter_map(|event| match event {
+                ReducerEvent::ThinkingDelta { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(thinking_text, "Planning");
+        let thinking_stop = out
+            .iter()
+            .position(|event| matches!(event, ReducerEvent::ThinkingStop { .. }))
+            .unwrap();
+        let text_start = out
+            .iter()
+            .position(|event| matches!(event, ReducerEvent::TextStart { .. }))
+            .unwrap();
+        assert!(thinking_stop < text_start);
+        assert!(matches!(
+            out.iter()
+                .find(|event| matches!(event, ReducerEvent::TextStart { .. })),
+            Some(ReducerEvent::TextStart { index: 1 })
+        ));
+    }
+
+    #[test]
+    fn reduce_empty_reasoning_summary_emits_no_thinking() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse(
+                "response.output_item.added",
+                json!({"output_index":0,"item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}})
+            ),
+            sse(
+                "response.output_item.done",
+                json!({"output_index":0,"item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}})
+            ),
+            sse(
+                "response.output_item.added",
+                json!({"output_index":1,"item":{"type":"message","id":"msg_up"}})
+            ),
+            format!(
+                "{}{}{}",
+                sse(
+                    "response.output_text.delta",
+                    json!({"output_index":1,"delta":"answer"})
+                ),
+                sse(
+                    "response.output_item.done",
+                    json!({"output_index":1,"item":{"type":"message"}})
+                ),
+                sse(
+                    "response.completed",
+                    json!({"response":{"id":"resp_1","usage":{}}})
+                )
+            ),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        assert!(!out.iter().any(|event| matches!(
+            event,
+            ReducerEvent::ThinkingStart { .. }
+                | ReducerEvent::ThinkingDelta { .. }
+                | ReducerEvent::ThinkingStop { .. }
+        )));
+    }
+
+    #[test]
+    fn reduce_multiple_reasoning_summary_parts() {
+        let upstream = format!(
+            "{}{}{}{}{}",
+            sse(
+                "response.reasoning_summary_text.delta",
+                json!({"output_index":0,"summary_index":0,"delta":"part one"})
+            ),
+            sse(
+                "response.reasoning_summary_part.added",
+                json!({"output_index":0,"summary_index":1,"part":{"type":"summary_text","text":""}})
+            ),
+            sse(
+                "response.reasoning_summary_text.delta",
+                json!({"output_index":0,"summary_index":1,"delta":"part two"})
+            ),
+            sse(
+                "response.output_item.done",
+                json!({"output_index":0,"item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}})
+            ),
+            sse(
+                "response.completed",
+                json!({"response":{"id":"resp_1","usage":{}}})
+            ),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let deltas: Vec<&str> = out
+            .iter()
+            .filter_map(|event| match event {
+                ReducerEvent::ThinkingDelta { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(deltas, vec!["part one", "\n\n", "part two"]);
+        assert_eq!(
+            out.iter()
+                .filter(|event| matches!(event, ReducerEvent::ThinkingStop { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn reduce_two_reasoning_items() {
+        let upstream = format!(
+            "{}{}{}{}{}",
+            sse(
+                "response.reasoning_summary_text.delta",
+                json!({"output_index":0,"summary_index":0,"delta":"first"})
+            ),
+            sse(
+                "response.output_item.done",
+                json!({"output_index":0,"item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}})
+            ),
+            sse(
+                "response.reasoning_summary_text.delta",
+                json!({"output_index":1,"summary_index":0,"delta":"second"})
+            ),
+            sse(
+                "response.output_item.done",
+                json!({"output_index":1,"item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}})
+            ),
+            sse(
+                "response.completed",
+                json!({"response":{"id":"resp_1","usage":{}}})
+            ),
+        );
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        assert_eq!(
+            out.iter()
+                .filter(|event| matches!(event, ReducerEvent::ThinkingStart { .. }))
+                .count(),
+            2
+        );
+        assert_eq!(
+            out.iter()
+                .filter(|event| matches!(event, ReducerEvent::ThinkingStop { .. }))
+                .count(),
+            2
+        );
+        let deltas: Vec<&str> = out
+            .iter()
+            .filter_map(|event| match event {
+                ReducerEvent::ThinkingDelta { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(deltas, vec!["first", "second"]);
+    }
+}

--- a/src/providers/xai/translate/request.rs
+++ b/src/providers/xai/translate/request.rs
@@ -1,0 +1,1475 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::anthropic::schema::MessagesRequest;
+use crate::config;
+use crate::providers::translate_shared::{
+    ContentBlock, flatten_system_text, image_source_to_url, normalize_content, read_effort,
+};
+
+use super::read_rewrite::{ReadOffsetRewrite, read_offset_rewrite};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Effort {
+    None,
+    Low,
+    Medium,
+    High,
+    Xhigh,
+    Max,
+}
+
+impl std::fmt::Display for Effort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Effort::None => write!(f, "none"),
+            Effort::Low => write!(f, "low"),
+            Effort::Medium => write!(f, "medium"),
+            Effort::High => write!(f, "high"),
+            Effort::Xhigh => write!(f, "xhigh"),
+            Effort::Max => write!(f, "max"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTier {
+    Priority,
+    Flex,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ResponsesToolChoice {
+    Auto,
+    None,
+    Required,
+    Function { r#type: String, name: String },
+    WebSearch { r#type: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponsesRequest {
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    pub input: Vec<ResponsesInputItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ResponsesTool>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ResponsesToolChoice>,
+    pub store: bool,
+    pub stream: bool,
+    pub parallel_tool_calls: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_metadata: Option<std::collections::HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<ServiceTier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+    pub text: ResponsesText,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<ResponsesReasoning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponsesReasoning {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<Effort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponsesText {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verbosity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<ResponsesTextFormat>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum ResponsesTextFormat {
+    Text,
+    JsonObject,
+    JsonSchema {
+        name: String,
+        schema: Value,
+        #[serde(default)]
+        strict: Option<bool>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ResponsesInputItem {
+    #[serde(rename = "additional_tools")]
+    AdditionalTools {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        role: String,
+        tools: Vec<Value>,
+    },
+    #[serde(rename = "message")]
+    Message {
+        role: String,
+        content: Vec<ResponsesContentPart>,
+    },
+    #[serde(rename = "function_call")]
+    FunctionCall {
+        #[serde(default)]
+        call_id: String,
+        name: String,
+        arguments: String,
+    },
+    #[serde(rename = "function_call_output")]
+    FunctionCallOutput {
+        #[serde(default)]
+        call_id: String,
+        output: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ResponsesContentPart {
+    #[serde(rename = "input_text")]
+    InputText { text: String },
+    #[serde(rename = "output_text")]
+    OutputText { text: String },
+    #[serde(rename = "input_image")]
+    InputImage {
+        image_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ResponsesTool {
+    Function(ResponsesFunctionTool),
+    WebSearch(ResponsesWebSearchTool),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponsesFunctionTool {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub parameters: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponsesWebSearchTool {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub external_web_access: bool,
+    pub search_content_types: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filters: Option<ResponsesWebSearchFilters>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponsesWebSearchFilters {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_domains: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_domains: Option<Vec<String>>,
+}
+
+pub struct TranslateOptions {
+    pub session_id: Option<String>,
+    pub service_tier: Option<ServiceTier>,
+    pub model: String,
+    pub use_responses_lite: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Translation entry point
+// ---------------------------------------------------------------------------
+
+fn to_codex_effort(effort: Option<&str>) -> Option<Effort> {
+    match effort {
+        Some("max") => Some(Effort::Max),
+        Some("xhigh") => Some(Effort::Xhigh),
+        Some("low") => Some(Effort::Low),
+        Some("medium") => Some(Effort::Medium),
+        Some("high") => Some(Effort::High),
+        _ => None,
+    }
+}
+
+fn resolve_effort(effort: Option<Effort>) -> Result<Option<Effort>, anyhow::Error> {
+    let override_effort: Option<String> = config::xai_effort();
+    if let Some(ref val) = override_effort {
+        let valid = ["none", "low", "medium", "high", "xhigh", "max"];
+        if !valid.contains(&val.as_str()) {
+            anyhow::bail!(
+                "Invalid effort override: \"{val}\". Must be one of: none, low, medium, high, xhigh, max"
+            );
+        }
+        return Ok(Some(match val.as_str() {
+            "max" => Effort::Max,
+            "xhigh" => Effort::Xhigh,
+            "high" => Effort::High,
+            "medium" => Effort::Medium,
+            "low" => Effort::Low,
+            _ => Effort::None,
+        }));
+    }
+    Ok(effort)
+}
+
+fn reasoning_summary_requested(summary: Option<&str>) -> bool {
+    !matches!(summary, Some("off" | "none"))
+}
+
+const VALID_SERVICE_TIERS: &[&str] = &["fast", "priority", "flex"];
+
+fn normalize_service_tier(tier: &str) -> Result<ServiceTier, anyhow::Error> {
+    if !VALID_SERVICE_TIERS.contains(&tier) {
+        anyhow::bail!(
+            "Invalid service tier override: \"{tier}\". Must be one of: {}",
+            VALID_SERVICE_TIERS.join(", ")
+        );
+    }
+    match tier {
+        "flex" => Ok(ServiceTier::Flex),
+        _ => Ok(ServiceTier::Priority),
+    }
+}
+
+fn resolve_service_tier(
+    model_tier: Option<ServiceTier>,
+) -> Result<Option<ServiceTier>, anyhow::Error> {
+    let tier: Option<String> = None; // xAI has no ChatGPT service tiers
+    match tier {
+        Some(ref val) => Ok(Some(normalize_service_tier(val)?)),
+        None => Ok(model_tier),
+    }
+}
+
+pub fn normalize_strict_json_schema(schema: &Value) -> Value {
+    match schema {
+        Value::Array(arr) => Value::Array(arr.iter().map(normalize_strict_json_schema).collect()),
+        Value::Object(map) => {
+            let mut out = map.clone();
+            if let Some(properties) = out.get("properties").and_then(|v| v.as_object()) {
+                let keys: Vec<String> = properties.keys().cloned().collect();
+                out.insert(
+                    "required".into(),
+                    Value::Array(keys.into_iter().map(Value::String).collect()),
+                );
+            }
+            for (key, val) in out.clone().iter() {
+                out.insert(key.clone(), normalize_strict_json_schema(val));
+            }
+            Value::Object(out)
+        }
+        _ => schema.clone(),
+    }
+}
+
+pub fn translate_request(
+    req: &MessagesRequest,
+    opts: TranslateOptions,
+) -> Result<ResponsesRequest, anyhow::Error> {
+    let instructions = flatten_system_text(req.extra.get("system"));
+    let input = build_input(req);
+    let tools = read_tools(req)?;
+    let tool_choice = map_tool_choice(req)?;
+
+    let mut text = ResponsesText {
+        verbosity: Some("low".to_string()),
+        format: None,
+    };
+
+    if let Some(fmt) = read_output_format(req) {
+        text.format = Some(fmt);
+    }
+
+    let mut out = ResponsesRequest {
+        model: opts.model,
+        instructions,
+        input,
+        store: false,
+        stream: true,
+        parallel_tool_calls: true,
+        tool_choice,
+        text,
+        tools: None,
+        include: None,
+        client_metadata: None,
+        service_tier: None,
+        prompt_cache_key: None,
+        reasoning: None,
+    };
+
+    if opts.use_responses_lite {
+        out.client_metadata = Some(std::collections::HashMap::from([(
+            "ws_request_header_x_openai_internal_codex_responses_lite".to_string(),
+            "true".to_string(),
+        )]));
+        out.parallel_tool_calls = false;
+
+        let mut prefix = Vec::new();
+        if let Some(ref tools) = tools
+            && !tools.is_empty()
+        {
+            let tools = tools
+                .iter()
+                .map(serde_json::to_value)
+                .collect::<Result<Vec<_>, _>>()?;
+            prefix.push(ResponsesInputItem::AdditionalTools {
+                id: None,
+                role: "developer".to_string(),
+                tools,
+            });
+        }
+        if let Some(instructions) = out.instructions.take()
+            && !instructions.is_empty()
+        {
+            prefix.push(ResponsesInputItem::Message {
+                role: "developer".to_string(),
+                content: vec![ResponsesContentPart::InputText { text: instructions }],
+            });
+        }
+        if !prefix.is_empty() {
+            prefix.extend(out.input);
+            out.input = prefix;
+        }
+    } else if let Some(tools) = tools
+        && !tools.is_empty()
+    {
+        out.tools = Some(tools);
+    }
+
+    if let Some(sid) = opts.session_id {
+        out.prompt_cache_key = Some(sid);
+    }
+
+    let service_tier = resolve_service_tier(opts.service_tier)?;
+    if let Some(ref tier) = service_tier {
+        out.service_tier = Some(tier.clone());
+    }
+
+    let effort = read_effort(req)?;
+    let codex_effort = to_codex_effort(effort);
+    let resolved_effort = resolve_effort(codex_effort)?;
+    if resolved_effort.is_some() || opts.use_responses_lite {
+        let summary = if resolved_effort.is_some()
+            && reasoning_summary_requested(config::xai_reasoning_summary().as_deref())
+        {
+            Some("auto".to_string())
+        } else {
+            None
+        };
+        out.reasoning = Some(ResponsesReasoning {
+            effort: resolved_effort.clone(),
+            summary,
+            context: opts.use_responses_lite.then_some("all_turns".to_string()),
+        });
+    }
+    if resolved_effort.is_some() {
+        out.include = Some(vec!["reasoning.encrypted_content".to_string()]);
+    }
+
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn read_output_format(req: &MessagesRequest) -> Option<ResponsesTextFormat> {
+    let output_config = req.extra.get("output_config")?.as_object()?;
+    let format = output_config.get("format")?.as_object()?;
+    let kind = format.get("type")?.as_str()?;
+    match kind {
+        "json_schema" => {
+            let name = format
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("response")
+                .to_string();
+            let schema = format.get("schema")?;
+            let normalized = normalize_strict_json_schema(schema);
+            Some(ResponsesTextFormat::JsonSchema {
+                name,
+                schema: normalized,
+                strict: Some(true),
+            })
+        }
+        "json_object" => Some(ResponsesTextFormat::JsonObject),
+        _ => Some(ResponsesTextFormat::Text),
+    }
+}
+
+fn read_tools(req: &MessagesRequest) -> Result<Option<Vec<ResponsesTool>>, anyhow::Error> {
+    let Some(tools) = req.extra.get("tools") else {
+        return Ok(None);
+    };
+    let tools_arr = match tools {
+        Value::Array(a) => a,
+        _ => return Ok(None),
+    };
+    let mut out = Vec::new();
+    for tool in tools_arr {
+        let tool_type = tool
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("function");
+        if tool_type == "web_search_20250305" {
+            let mut filters = ResponsesWebSearchFilters {
+                allowed_domains: None,
+                blocked_domains: None,
+            };
+            let allowed = tool.get("allowed_domains").and_then(|v| v.as_array());
+            if allowed.is_some_and(|a| !a.is_empty()) {
+                filters.allowed_domains = allowed.map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                });
+            }
+            let blocked = tool.get("blocked_domains").and_then(|v| v.as_array());
+            if blocked.is_some_and(|a| !a.is_empty()) {
+                filters.blocked_domains = blocked.map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                });
+            }
+            let has_filters =
+                filters.allowed_domains.is_some() || filters.blocked_domains.is_some();
+            out.push(ResponsesTool::WebSearch(ResponsesWebSearchTool {
+                kind: "web_search".to_string(),
+                external_web_access: false,
+                search_content_types: vec!["text".to_string(), "image".to_string()],
+                filters: if has_filters { Some(filters) } else { None },
+            }));
+        } else {
+            let name = tool
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let description = tool
+                .get("description")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let parameters = tool
+                .get("input_schema")
+                .cloned()
+                .unwrap_or(serde_json::json!({}));
+            let description = codex_tool_description(&name, description);
+            let parameters = codex_tool_parameters(&name, parameters);
+            out.push(ResponsesTool::Function(ResponsesFunctionTool {
+                kind: "function".to_string(),
+                name,
+                description,
+                parameters,
+            }));
+        }
+    }
+    if out.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(out))
+    }
+}
+
+fn codex_tool_description(name: &str, description: Option<String>) -> Option<String> {
+    if name != "Read" {
+        return description;
+    }
+
+    let base = description.unwrap_or_else(|| "Reads a file from the local filesystem.".to_string());
+    Some(format!("{base}\n\n{}", read_offset_guidance()))
+}
+
+fn codex_tool_parameters(name: &str, mut parameters: Value) -> Value {
+    if name != "Read" {
+        return parameters;
+    }
+
+    let Some(props) = parameters
+        .get_mut("properties")
+        .and_then(Value::as_object_mut)
+    else {
+        return parameters;
+    };
+
+    if let Some(offset) = props.get_mut("offset").and_then(Value::as_object_mut) {
+        offset.insert(
+            "description".to_string(),
+            Value::String(
+                "Optional continuation index. Use only after a prior Read of the same file returned content and more lines are needed. Compute as prior offset plus returned line count. Displayed line numbers, grep line numbers, byte counts, token counts, file sizes, and guessed positions are invalid offsets. Omit when unsure.".to_string(),
+            ),
+        );
+    }
+
+    if let Some(limit) = props.get_mut("limit").and_then(Value::as_object_mut) {
+        limit.insert(
+            "description".to_string(),
+            Value::String(
+                "Optional number of lines to read. Omit when opening a file. Use with offset only when continuing a large file."
+                    .to_string(),
+            ),
+        );
+    }
+
+    parameters
+}
+
+fn map_tool_choice(req: &MessagesRequest) -> Result<Option<ResponsesToolChoice>, anyhow::Error> {
+    let choice = match req.extra.get("tool_choice") {
+        Some(Value::Object(m)) => m,
+        Some(Value::String(s)) => {
+            return Ok(Some(match s.as_str() {
+                "auto" => ResponsesToolChoice::Auto,
+                "none" => ResponsesToolChoice::None,
+                "any" | "required" => ResponsesToolChoice::Required,
+                _ => ResponsesToolChoice::Auto,
+            }));
+        }
+        _ => return Ok(None),
+    };
+
+    let choice_type = choice
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("auto");
+    match choice_type {
+        "auto" => Ok(Some(ResponsesToolChoice::Auto)),
+        "none" => Ok(Some(ResponsesToolChoice::None)),
+        "any" | "required" => Ok(Some(ResponsesToolChoice::Required)),
+        "tool" => {
+            let name = choice.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let tools = req.extra.get("tools").and_then(|v| v.as_array());
+            let is_web_search = tools.is_some_and(|t| {
+                t.iter().any(|tool| {
+                    (tool.get("type").and_then(|v| v.as_str()) == Some("web_search_20250305"))
+                        && tool.get("name").and_then(|v| v.as_str()) == Some(name)
+                })
+            });
+            if is_web_search {
+                Ok(Some(ResponsesToolChoice::WebSearch {
+                    r#type: "web_search".to_string(),
+                }))
+            } else {
+                Ok(Some(ResponsesToolChoice::Function {
+                    r#type: "function".to_string(),
+                    name: name.to_string(),
+                }))
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+fn build_input(req: &MessagesRequest) -> Vec<ResponsesInputItem> {
+    let mut out: Vec<ResponsesInputItem> = Vec::new();
+    let mut read_tool_uses_with_offset = HashSet::new();
+
+    for msg in &req.messages {
+        let blocks = normalize_content(&msg.content, Value::Null);
+        match msg.role.as_str() {
+            "user" => {
+                let mut parts: Vec<ResponsesContentPart> = Vec::new();
+                for block in &blocks {
+                    match block {
+                        ContentBlock::Text { text } => {
+                            parts.push(ResponsesContentPart::InputText { text: text.clone() });
+                        }
+                        ContentBlock::Image { source } => {
+                            parts.push(ResponsesContentPart::InputImage {
+                                image_url: image_source_to_url(source),
+                                detail: None,
+                            });
+                        }
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                            is_error,
+                        } => {
+                            if !parts.is_empty() {
+                                out.push(ResponsesInputItem::Message {
+                                    role: "user".to_string(),
+                                    content: std::mem::take(&mut parts),
+                                });
+                            }
+                            let body = tool_result_to_string(content);
+                            let output = if is_error.unwrap_or(false) {
+                                format!("[tool execution error]\n{body}")
+                            } else {
+                                body
+                            };
+                            let output =
+                                maybe_append_rewritten_read_offset_note(output, tool_use_id);
+                            let output = maybe_append_read_offset_guidance(
+                                output,
+                                read_tool_uses_with_offset.contains(tool_use_id),
+                                is_error.unwrap_or(false),
+                            );
+                            out.push(ResponsesInputItem::FunctionCallOutput {
+                                call_id: tool_use_id.clone(),
+                                output,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                if !parts.is_empty() {
+                    out.push(ResponsesInputItem::Message {
+                        role: "user".to_string(),
+                        content: parts,
+                    });
+                }
+            }
+            "system" => {
+                let parts: Vec<ResponsesContentPart> = blocks
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text { text } => {
+                            Some(ResponsesContentPart::InputText { text: text.clone() })
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if !parts.is_empty() {
+                    out.push(ResponsesInputItem::Message {
+                        role: "developer".to_string(),
+                        content: parts,
+                    });
+                }
+            }
+            _ => {
+                let mut text_parts: Vec<ResponsesContentPart> = Vec::new();
+                let flush_text =
+                    |out: &mut Vec<ResponsesInputItem>,
+                     text_parts: &mut Vec<ResponsesContentPart>| {
+                        if !text_parts.is_empty() {
+                            out.push(ResponsesInputItem::Message {
+                                role: "assistant".to_string(),
+                                content: std::mem::take(text_parts),
+                            });
+                        }
+                    };
+                for block in &blocks {
+                    match block {
+                        ContentBlock::Text { text } => {
+                            text_parts
+                                .push(ResponsesContentPart::OutputText { text: text.clone() });
+                        }
+                        ContentBlock::ToolUse { id, name, input } => {
+                            flush_text(&mut out, &mut text_parts);
+                            if is_read_tool_use_with_offset(name, input) {
+                                read_tool_uses_with_offset.insert(id.clone());
+                            }
+                            let args =
+                                serde_json::to_string(input).unwrap_or_else(|_| "{}".to_string());
+                            out.push(ResponsesInputItem::FunctionCall {
+                                call_id: id.clone(),
+                                name: name.clone(),
+                                arguments: args,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                flush_text(&mut out, &mut text_parts);
+            }
+        }
+    }
+
+    out
+}
+
+fn is_read_tool_use_with_offset(name: &str, input: &Value) -> bool {
+    name == "Read" && input.get("offset").is_some()
+}
+
+fn maybe_append_rewritten_read_offset_note(output: String, tool_use_id: &str) -> String {
+    if output.contains("Proxy Read offset note:") {
+        return output;
+    }
+    let Some(rewrite) = read_offset_rewrite(tool_use_id) else {
+        return output;
+    };
+    format!("{output}\n\n{}", read_offset_rewrite_note(&rewrite))
+}
+
+fn read_offset_rewrite_note(rewrite: &ReadOffsetRewrite) -> String {
+    let file = rewrite
+        .file_path
+        .as_deref()
+        .map(|path| format!(" for {path}"))
+        .unwrap_or_default();
+    format!(
+        "Proxy Read offset note:\n\
+         - Requested Read offset {}{} exceeds the proxy rewrite threshold of 1000000.\n\
+         - This Read starts at the beginning of the file.\n\
+         - For continuation reads, use offset after a prior Read of the same file returned content and more lines are needed.\n\
+         - Compute offset as prior offset plus the number of lines returned by that prior Read.",
+        rewrite.offset, file
+    )
+}
+
+fn maybe_append_read_offset_guidance(
+    output: String,
+    read_call_had_offset: bool,
+    is_error: bool,
+) -> String {
+    if !read_call_had_offset
+        || output.contains("Codex Read guidance:")
+        || !looks_like_read_offset_result(&output)
+        || (!is_error && !looks_like_read_offset_warning(&output))
+    {
+        return output;
+    }
+    format!("{output}\n\n{}", read_offset_guidance())
+}
+
+fn looks_like_read_offset_result(output: &str) -> bool {
+    let lower = output.to_ascii_lowercase();
+    lower.contains("offset")
+        && (lower.contains("file has")
+            || lower.contains("out of range")
+            || (lower.contains("line") && lower.contains("requested")))
+}
+
+fn looks_like_read_offset_warning(output: &str) -> bool {
+    let lower = output.to_ascii_lowercase();
+    lower.contains("warning") || lower.contains("system-reminder")
+}
+
+fn read_offset_guidance() -> &'static str {
+    "Codex Read guidance:\n\
+     - offset is an optional zero based continuation index, not a line number lookup.\n\
+     - Use offset only after a prior Read of the same file returned content and more lines are needed.\n\
+     - Compute offset as prior offset plus the number of lines returned by that prior Read.\n\
+     - Displayed line numbers, grep line numbers, byte counts, token counts, file sizes, and guessed positions are invalid offsets.\n\
+     - Omit offset and limit when opening a file or when unsure."
+}
+
+// ---------------------------------------------------------------------------
+// Tool result rendering
+// ---------------------------------------------------------------------------
+
+fn tool_result_to_string(content: &Value) -> String {
+    match content {
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => {
+            let mut parts = Vec::new();
+            for b in arr {
+                match b.get("type").and_then(|v| v.as_str()) {
+                    Some("text") => match b.get("text").and_then(|v| v.as_str()) {
+                        Some(text) => parts.push(text.to_string()),
+                        None => parts.push(unsupported_tool_result_block_to_string(b)),
+                    },
+                    Some("image") => {
+                        if let Some(source) = b.get("source").and_then(|v| v.as_object()) {
+                            match source.get("type").and_then(|v| v.as_str()) {
+                                Some("url")
+                                    if source.get("url").and_then(|v| v.as_str()).is_some() =>
+                                {
+                                    parts.push("[image omitted: url]".to_string());
+                                }
+                                Some("base64")
+                                    if source
+                                        .get("media_type")
+                                        .and_then(|v| v.as_str())
+                                        .is_some()
+                                        && source
+                                            .get("data")
+                                            .and_then(|v| v.as_str())
+                                            .is_some() =>
+                                {
+                                    let media_type = source
+                                        .get("media_type")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("image");
+                                    parts.push(format!("[image omitted: {media_type}]"));
+                                }
+                                _ => parts.push(unsupported_tool_result_block_to_string(b)),
+                            }
+                        } else {
+                            parts.push(unsupported_tool_result_block_to_string(b));
+                        }
+                    }
+                    Some(other) => {
+                        parts.push(format!("[unsupported content block omitted: {other}]"));
+                    }
+                    None => parts.push(unsupported_tool_result_block_to_string(b)),
+                }
+            }
+            parts.join("\n")
+        }
+        _ => String::new(),
+    }
+}
+
+fn unsupported_tool_result_block_to_string(block: &Value) -> String {
+    let kind = block
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    format!("[unsupported content block omitted: {kind}]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use serde_json::json;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    struct EnvVarGuard {
+        _lock: MutexGuard<'static, ()>,
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self {
+                _lock: lock,
+                key,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    fn opts() -> TranslateOptions {
+        TranslateOptions {
+            session_id: None,
+            service_tier: None,
+            model: "gpt-5.5".to_string(),
+            use_responses_lite: false,
+        }
+    }
+
+    #[test]
+    fn translate_web_search_tool_to_codex_tool() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"find it"}],
+            "tools": [{
+                "type":"web_search_20250305",
+                "name":"web_search",
+                "allowed_domains":["example.com"]
+            }],
+            "tool_choice": {"type":"tool", "name":"web_search"}
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                session_id: Some("s".into()),
+                service_tier: None,
+                model: "gpt-5.5".to_string(),
+                use_responses_lite: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(out.prompt_cache_key.as_deref(), Some("s"));
+        assert!(matches!(
+            out.tool_choice,
+            Some(ResponsesToolChoice::WebSearch { .. })
+        ));
+    }
+
+    #[test]
+    fn translate_read_tool_adds_codex_offset_guidance() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"read it"}],
+            "tools": [{
+                "name": "Read",
+                "description": "Reads a file from the local filesystem.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "offset": {"type": "integer", "description": "old offset"},
+                        "limit": {"type": "integer", "description": "old limit"}
+                    },
+                    "required": ["file_path"]
+                }
+            }]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        let tools = out.tools.as_ref().unwrap();
+        let ResponsesTool::Function(tool) = &tools[0] else {
+            panic!("expected function tool");
+        };
+        let description = tool.description.as_deref().unwrap();
+        assert!(description.contains("Codex Read guidance"));
+        assert!(description.contains("zero based continuation index"));
+        assert!(description.contains("guessed positions are invalid offsets"));
+
+        let props = tool
+            .parameters
+            .get("properties")
+            .and_then(Value::as_object)
+            .unwrap();
+        assert_eq!(
+            props
+                .get("offset")
+                .and_then(|v| v.get("description"))
+                .and_then(Value::as_str),
+            Some(
+                "Optional continuation index. Use only after a prior Read of the same file returned content and more lines are needed. Compute as prior offset plus returned line count. Displayed line numbers, grep line numbers, byte counts, token counts, file sizes, and guessed positions are invalid offsets. Omit when unsure."
+            )
+        );
+        assert_eq!(
+            props
+                .get("limit")
+                .and_then(|v| v.get("description"))
+                .and_then(Value::as_str),
+            Some(
+                "Optional number of lines to read. Omit when opening a file. Use with offset only when continuing a large file."
+            )
+        );
+    }
+
+    #[test]
+    fn translate_non_read_tool_preserves_tool_metadata() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"search"}],
+            "tools": [{
+                "name": "Search",
+                "description": "Find matching records.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "offset": {"type": "integer", "description": "record offset"}
+                    }
+                }
+            }]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        let tools = out.tools.as_ref().unwrap();
+        let ResponsesTool::Function(tool) = &tools[0] else {
+            panic!("expected function tool");
+        };
+        assert_eq!(tool.description.as_deref(), Some("Find matching records."));
+        assert_eq!(
+            tool.parameters
+                .get("properties")
+                .and_then(|v| v.get("offset"))
+                .and_then(|v| v.get("description"))
+                .and_then(Value::as_str),
+            Some("record offset")
+        );
+    }
+
+    #[test]
+    fn translate_omits_reasoning_when_not_enabled() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hello"}]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert!(out.reasoning.is_none());
+        assert!(out.include.is_none());
+    }
+
+    #[test]
+    fn translate_includes_reasoning_when_enabled() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "medium"}
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        let reasoning = out.reasoning.unwrap();
+        assert!(matches!(reasoning.effort, Some(Effort::Medium)));
+        assert_eq!(reasoning.summary.as_deref(), Some("auto"));
+        assert_eq!(
+            out.include,
+            Some(vec!["reasoning.encrypted_content".to_string()])
+        );
+    }
+
+    #[test]
+    fn translate_effort_max_maps_to_max() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "max"}
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::Max)));
+    }
+
+    #[test]
+    fn translate_effort_override_max_maps_to_max() {
+        let _env = EnvVarGuard::set("CCP_XAI_EFFORT", "max");
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "low"}
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::Max)));
+    }
+
+    #[test]
+    fn max_tokens_is_not_serialized_for_codex() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "max_tokens": 4096,
+            "messages": [{"role":"user", "content":"hello"}]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        let value = serde_json::to_value(out).unwrap();
+        assert!(value.get("max_output_tokens").is_none());
+    }
+
+    #[test]
+    fn translate_effort_xhigh_maps_to_xhigh() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "xhigh"}
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::Xhigh)));
+        assert_eq!(
+            out.include,
+            Some(vec!["reasoning.encrypted_content".to_string()])
+        );
+    }
+
+    #[test]
+    fn reasoning_summary_override_values() {
+        assert!(reasoning_summary_requested(None));
+        assert!(reasoning_summary_requested(Some("auto")));
+        assert!(reasoning_summary_requested(Some("detailed")));
+        assert!(!reasoning_summary_requested(Some("off")));
+        assert!(!reasoning_summary_requested(Some("none")));
+    }
+
+    #[test]
+    fn translate_user_text_and_image() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content": [
+                {"type":"text", "text":"describe"},
+                {"type":"image", "source": {"type":"base64", "media_type":"image/jpeg", "data":"xyz"}}
+            ]}]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert_eq!(out.input.len(), 1);
+        if let ResponsesInputItem::Message { role, content } = &out.input[0] {
+            assert_eq!(role, "user");
+            assert_eq!(content.len(), 2);
+        } else {
+            panic!("expected Message");
+        }
+    }
+
+    #[test]
+    fn translate_assistant_with_text_and_tool_use() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"assistant", "content": [
+                {"type":"text", "text":"answer"},
+                {"type":"tool_use", "id":"tu_1", "name":"search", "input": {"q":"rust"}}
+            ]}]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert_eq!(out.input.len(), 2);
+    }
+
+    #[test]
+    fn translate_strict_json_schema_normalization() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"hi"}],
+            "output_config": {"format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {"ok": {"type": "boolean"}, "reason": {"type": "string"}},
+                    "required": ["ok"]
+                }
+            }}
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        if let Some(ResponsesTextFormat::JsonSchema { schema, .. }) = &out.text.format {
+            let required = schema.get("required").and_then(|v| v.as_array()).unwrap();
+            assert!(required.iter().any(|v| v == "ok"));
+            assert!(required.iter().any(|v| v == "reason"));
+        } else {
+            panic!("expected JsonSchema format");
+        }
+    }
+
+    #[test]
+    fn translate_tool_result_content() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content": [{
+                "type": "tool_result",
+                "tool_use_id": "tu_1",
+                "content": [{"type":"text", "text":"result"}]
+            }]}]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert_eq!(out.input.len(), 1);
+        if let ResponsesInputItem::FunctionCallOutput { call_id, .. } = &out.input[0] {
+            assert_eq!(call_id, "tu_1");
+        } else {
+            panic!("expected FunctionCallOutput");
+        }
+    }
+
+    #[test]
+    fn translate_read_offset_error_adds_guidance() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [
+                {"role":"assistant", "content": [{
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/a", "offset": 2952, "limit": 200}
+                }]},
+                {"role":"user", "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tu_1",
+                    "is_error": true,
+                    "content": [{"type":"text", "text":"File has 331 lines, but offset 2952 was requested."}]
+                }]}
+            ]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert_eq!(out.input.len(), 2);
+        if let ResponsesInputItem::FunctionCallOutput { output, .. } = &out.input[1] {
+            assert!(output.contains("[tool execution error]"));
+            assert!(output.contains("File has 331 lines"));
+            assert!(output.contains("Codex Read guidance:"));
+            assert!(output.contains("zero based continuation index"));
+        } else {
+            panic!("expected FunctionCallOutput");
+        }
+    }
+
+    #[test]
+    fn translate_read_unrelated_error_keeps_original_output() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [
+                {"role":"assistant", "content": [{
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/a", "offset": 10, "limit": 20}
+                }]},
+                {"role":"user", "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tu_1",
+                    "is_error": true,
+                    "content": [{"type":"text", "text":"File does not exist."}]
+                }]}
+            ]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert_eq!(out.input.len(), 2);
+        if let ResponsesInputItem::FunctionCallOutput { output, .. } = &out.input[1] {
+            assert_eq!(output, "[tool execution error]\nFile does not exist.");
+        } else {
+            panic!("expected FunctionCallOutput");
+        }
+    }
+
+    #[test]
+    fn translate_rewritten_read_result_adds_proxy_note() {
+        crate::providers::xai::translate::read_rewrite::sanitize_read_args(
+            "Read",
+            r#"{"file_path":"/tmp/a","offset":1300000,"limit":20}"#,
+            Some("tu_rewritten_read"),
+        );
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [
+                {"role":"assistant", "content": [{
+                    "type": "tool_use",
+                    "id": "tu_rewritten_read",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/a", "limit": 20}
+                }]},
+                {"role":"user", "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tu_rewritten_read",
+                    "content": [{"type":"text", "text":"1\tcontent"}]
+                }]}
+            ]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert_eq!(out.input.len(), 2);
+        if let ResponsesInputItem::FunctionCallOutput { output, .. } = &out.input[1] {
+            assert!(output.contains("1\tcontent"));
+            assert!(output.contains("Proxy Read offset note:"));
+            assert!(output.contains("1300000"));
+            assert!(output.contains("/tmp/a"));
+        } else {
+            panic!("expected FunctionCallOutput");
+        }
+    }
+
+    #[test]
+    fn translate_read_success_with_offset_words_keeps_original_output() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [
+                {"role":"assistant", "content": [{
+                    "type": "tool_use",
+                    "id": "tu_1",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/a", "offset": 10, "limit": 20}
+                }]},
+                {"role":"user", "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tu_1",
+                    "content": [{"type":"text", "text":"File has 331 lines, and the requested offset is shown in this fixture."}]
+                }]}
+            ]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert_eq!(out.input.len(), 2);
+        if let ResponsesInputItem::FunctionCallOutput { output, .. } = &out.input[1] {
+            assert_eq!(
+                output,
+                "File has 331 lines, and the requested offset is shown in this fixture."
+            );
+        } else {
+            panic!("expected FunctionCallOutput");
+        }
+    }
+
+    #[test]
+    fn tool_result_stringifies_images_and_malformed_blocks() {
+        let rendered = tool_result_to_string(&json!([
+            {"type": "text", "text": "caption"},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc"}},
+            {"type": "image", "source": {"type": "url", "url": "https://example.invalid/a.png"}},
+            {"type": "text"},
+            {"type": "image"},
+            {}
+        ]));
+        assert_eq!(
+            rendered,
+            "caption\n[image omitted: image/png]\n[image omitted: url]\n[unsupported content block omitted: text]\n[unsupported content block omitted: image]\n[unsupported content block omitted: unknown]"
+        );
+    }
+
+    #[test]
+    fn luna_preserves_high_effort() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-luna",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "high"}
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                model: "gpt-5.6-luna".to_string(),
+                use_responses_lite: true,
+                ..opts()
+            },
+        )
+        .unwrap();
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::High)));
+    }
+
+    #[test]
+    fn sol_preserves_high_effort() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "high"}
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                model: "gpt-5.6-sol".to_string(),
+                use_responses_lite: true,
+                ..opts()
+            },
+        )
+        .unwrap();
+        assert!(matches!(out.reasoning.unwrap().effort, Some(Effort::High)));
+    }
+
+    #[test]
+    fn responses_lite_moves_instructions_and_tools_into_input() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-luna",
+            "messages": [{"role":"user", "content":"hello"}],
+            "system": "be helpful",
+            "tools": [{"name":"test","input_schema":{"type":"object"}}]
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                model: "gpt-5.6-luna".to_string(),
+                use_responses_lite: true,
+                ..opts()
+            },
+        )
+        .unwrap();
+        assert!(out.instructions.is_none());
+        assert!(out.tools.is_none());
+        assert!(!out.parallel_tool_calls);
+        assert!(out.client_metadata.is_some());
+        assert_eq!(out.input.len(), 3);
+        assert!(matches!(
+            out.input[0],
+            ResponsesInputItem::AdditionalTools { .. }
+        ));
+        if let ResponsesInputItem::Message { role, content } = &out.input[1] {
+            assert_eq!(role, "developer");
+            assert!(matches!(content[0], ResponsesContentPart::InputText { .. }));
+        } else {
+            panic!("expected developer message");
+        }
+    }
+
+    #[test]
+    fn responses_lite_without_effort_uses_all_turns_context() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "claude-haiku-4-5",
+            "messages": [{"role":"user", "content":"hello"}]
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                model: "gpt-5.6-luna".to_string(),
+                use_responses_lite: true,
+                ..opts()
+            },
+        )
+        .unwrap();
+        let reasoning = out.reasoning.unwrap();
+        assert!(reasoning.effort.is_none());
+        assert!(reasoning.summary.is_none());
+        assert_eq!(reasoning.context.as_deref(), Some("all_turns"));
+        assert!(out.include.is_none());
+    }
+
+    #[test]
+    fn responses_lite_reasoning_uses_all_turns_context() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-luna",
+            "messages": [{"role":"user", "content":"hello"}],
+            "output_config": {"effort": "medium"}
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                model: "gpt-5.6-luna".to_string(),
+                use_responses_lite: true,
+                ..opts()
+            },
+        )
+        .unwrap();
+        assert_eq!(out.reasoning.unwrap().context.as_deref(), Some("all_turns"));
+    }
+
+    #[test]
+    fn translate_returns_only_expected_top_level_fields() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role":"user", "content":"hello"}],
+            "system": "be helpful",
+            "tools": [{"name":"test","input_schema":{"type":"object"}}],
+            "tool_choice": {"type":"tool", "name":"test"}
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                model: "gpt-5.4".to_string(),
+                ..opts()
+            },
+        )
+        .unwrap();
+        assert_eq!(out.model, "gpt-5.4");
+        let out_value = serde_json::to_value(&out).unwrap();
+        let keys: std::collections::BTreeSet<String> =
+            out_value.as_object().unwrap().keys().cloned().collect();
+        for key in &[
+            "model",
+            "input",
+            "store",
+            "stream",
+            "parallel_tool_calls",
+            "text",
+        ] {
+            assert!(keys.contains(*key), "missing key: {key}");
+        }
+    }
+}

--- a/src/providers/xai/translate/stream.rs
+++ b/src/providers/xai/translate/stream.rs
@@ -1,0 +1,690 @@
+use std::collections::BTreeMap;
+
+use crate::anthropic::sse::encode_sse_event;
+use crate::traffic::TrafficCapture;
+
+use super::reducer::{
+    ReducerEvent, UpstreamStreamError, map_codex_usage_to_anthropic, reduce_upstream_bytes,
+};
+use super::web_search_compat::build_web_search_compat_blocks;
+
+#[allow(dead_code)]
+enum OpenBlock {
+    Thinking,
+    Text,
+    Tool { id: String, name: String },
+}
+
+fn emit(
+    out: &mut Vec<u8>,
+    traffic: Option<&TrafficCapture>,
+    event: &str,
+    data: &serde_json::Value,
+) {
+    if let Some(traffic) = traffic {
+        traffic.write_json_event(
+            "050-downstream-event",
+            &serde_json::json!({
+                "event": event,
+                "data": data,
+            }),
+        );
+    }
+    out.extend_from_slice(&encode_sse_event(Some(event), &data.to_string()));
+}
+
+fn ensure_message_start(
+    out: &mut Vec<u8>,
+    traffic: Option<&TrafficCapture>,
+    message_started: &mut bool,
+    message_id: &str,
+    model: &str,
+) {
+    if !*message_started {
+        *message_started = true;
+        let data = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": null,
+                "stop_sequence": null,
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                }
+            }
+        });
+        emit(out, traffic, "message_start", &data);
+    }
+}
+
+fn emit_content_event(
+    out: &mut Vec<u8>,
+    traffic: Option<&TrafficCapture>,
+    message_started: &mut bool,
+    open_blocks: &mut BTreeMap<usize, OpenBlock>,
+    message_id: &str,
+    model: &str,
+    event: &ReducerEvent,
+) -> bool {
+    match event {
+        ReducerEvent::ThinkingStart { index } => {
+            ensure_message_start(out, traffic, message_started, message_id, model);
+            open_blocks.insert(*index, OpenBlock::Thinking);
+            emit(
+                out,
+                traffic,
+                "content_block_start",
+                &serde_json::json!({
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {"type": "thinking", "thinking": "", "signature": ""}
+                }),
+            );
+            true
+        }
+        ReducerEvent::ThinkingDelta { index, text } => {
+            emit(
+                out,
+                traffic,
+                "content_block_delta",
+                &serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {"type": "thinking_delta", "thinking": text}
+                }),
+            );
+            true
+        }
+        ReducerEvent::ThinkingStop { index } => {
+            open_blocks.remove(index);
+            emit(
+                out,
+                traffic,
+                "content_block_stop",
+                &serde_json::json!({
+                    "type": "content_block_stop",
+                    "index": index,
+                }),
+            );
+            true
+        }
+        ReducerEvent::TextStart { index } => {
+            ensure_message_start(out, traffic, message_started, message_id, model);
+            open_blocks.insert(*index, OpenBlock::Text);
+            emit(
+                out,
+                traffic,
+                "content_block_start",
+                &serde_json::json!({
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {"type": "text", "text": ""}
+                }),
+            );
+            true
+        }
+        ReducerEvent::TextDelta { index, text } => {
+            emit(
+                out,
+                traffic,
+                "content_block_delta",
+                &serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {"type": "text_delta", "text": text}
+                }),
+            );
+            true
+        }
+        ReducerEvent::TextStop { index } => {
+            open_blocks.remove(index);
+            emit(
+                out,
+                traffic,
+                "content_block_stop",
+                &serde_json::json!({
+                    "type": "content_block_stop",
+                    "index": index,
+                }),
+            );
+            true
+        }
+        ReducerEvent::ToolStart { index, id, name } => {
+            ensure_message_start(out, traffic, message_started, message_id, model);
+            open_blocks.insert(
+                *index,
+                OpenBlock::Tool {
+                    id: id.clone(),
+                    name: name.clone(),
+                },
+            );
+            emit(
+                out,
+                traffic,
+                "content_block_start",
+                &serde_json::json!({
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": id,
+                        "name": name,
+                        "input": {}
+                    }
+                }),
+            );
+            true
+        }
+        ReducerEvent::ToolDelta {
+            index,
+            partial_json,
+        } => {
+            emit(
+                out,
+                traffic,
+                "content_block_delta",
+                &serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": partial_json
+                    }
+                }),
+            );
+            true
+        }
+        ReducerEvent::ToolStop { index } => {
+            open_blocks.remove(index);
+            emit(
+                out,
+                traffic,
+                "content_block_stop",
+                &serde_json::json!({
+                    "type": "content_block_stop",
+                    "index": index,
+                }),
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
+fn is_content_event(event: &ReducerEvent) -> bool {
+    matches!(
+        event,
+        ReducerEvent::ThinkingStart { .. }
+            | ReducerEvent::ThinkingDelta { .. }
+            | ReducerEvent::ThinkingStop { .. }
+            | ReducerEvent::TextStart { .. }
+            | ReducerEvent::TextDelta { .. }
+            | ReducerEvent::TextStop { .. }
+            | ReducerEvent::ToolStart { .. }
+            | ReducerEvent::ToolDelta { .. }
+            | ReducerEvent::ToolStop { .. }
+    )
+}
+
+pub fn translate_stream_bytes(
+    upstream: &[u8],
+    message_id: &str,
+    model: &str,
+) -> Result<Vec<u8>, anyhow::Error> {
+    translate_stream_bytes_with_traffic(upstream, message_id, model, None)
+}
+
+pub fn translate_stream_bytes_with_traffic(
+    upstream: &[u8],
+    message_id: &str,
+    model: &str,
+    traffic: Option<&TrafficCapture>,
+) -> Result<Vec<u8>, anyhow::Error> {
+    let events = match reduce_upstream_bytes(upstream) {
+        Ok(events) => events,
+        Err(err) => {
+            write_reducer_error_capture(traffic, &err);
+            return Err(anyhow::anyhow!(
+                "upstream stream error: {} ({:?})",
+                err.message,
+                err.kind
+            ));
+        }
+    };
+
+    let mut out = Vec::new();
+    let mut message_started = false;
+    let mut open_blocks: BTreeMap<usize, OpenBlock> = BTreeMap::new();
+    let mut web_search_events: Vec<ReducerEvent> = Vec::new();
+    let mut deferred_content_events: Vec<ReducerEvent> = Vec::new();
+
+    for event in &events {
+        if matches!(event, ReducerEvent::WebSearch { .. }) {
+            web_search_events.push(event.clone());
+            continue;
+        }
+        if !web_search_events.is_empty() && is_content_event(event) {
+            deferred_content_events.push(event.clone());
+            continue;
+        }
+
+        if emit_content_event(
+            &mut out,
+            traffic,
+            &mut message_started,
+            &mut open_blocks,
+            message_id,
+            model,
+            event,
+        ) {
+            continue;
+        }
+
+        match event {
+            ReducerEvent::ToolProgress { .. } | ReducerEvent::Progress => {}
+            ReducerEvent::Finish {
+                stop_reason,
+                usage,
+                web_search_requests,
+                ..
+            } => {
+                // Emit web search compat blocks
+                if !web_search_events.is_empty() {
+                    let text_from_deferred: String = deferred_content_events
+                        .iter()
+                        .filter_map(|e| match e {
+                            ReducerEvent::TextDelta { text, .. } => Some(text.as_str()),
+                            _ => None,
+                        })
+                        .collect();
+                    let compat_blocks =
+                        build_web_search_compat_blocks(&web_search_events, &text_from_deferred);
+                    for block in &compat_blocks {
+                        use super::web_search_compat::WebSearchCompatContent;
+                        match &block.content {
+                            WebSearchCompatContent::ServerToolUse { id, name, input } => {
+                                ensure_message_start(
+                                    &mut out,
+                                    traffic,
+                                    &mut message_started,
+                                    message_id,
+                                    model,
+                                );
+                                emit(
+                                    &mut out,
+                                    traffic,
+                                    "content_block_start",
+                                    &serde_json::json!({
+                                        "type": "content_block_start",
+                                        "index": block.index,
+                                        "content_block": {
+                                            "type": "server_tool_use",
+                                            "id": id,
+                                            "name": name,
+                                            "input": {}
+                                        }
+                                    }),
+                                );
+                                emit(
+                                    &mut out,
+                                    traffic,
+                                    "content_block_delta",
+                                    &serde_json::json!({
+                                        "type": "content_block_delta",
+                                        "index": block.index,
+                                        "delta": {
+                                            "type": "input_json_delta",
+                                            "partial_json": serde_json::to_string(input).unwrap_or_default()
+                                        }
+                                    }),
+                                );
+                                emit(
+                                    &mut out,
+                                    traffic,
+                                    "content_block_stop",
+                                    &serde_json::json!({
+                                        "type": "content_block_stop",
+                                        "index": block.index,
+                                    }),
+                                );
+                            }
+                            WebSearchCompatContent::WebSearchToolResult {
+                                tool_use_id,
+                                content: results,
+                            } => {
+                                let result_content: Vec<serde_json::Value> = results
+                                    .iter()
+                                    .map(|r| {
+                                        serde_json::json!({
+                                            "type": "web_search_result",
+                                            "title": r.title,
+                                            "url": r.url,
+                                        })
+                                    })
+                                    .collect();
+                                emit(
+                                    &mut out,
+                                    traffic,
+                                    "content_block_start",
+                                    &serde_json::json!({
+                                        "type": "content_block_start",
+                                        "index": block.index,
+                                        "content_block": {
+                                            "type": "web_search_tool_result",
+                                            "tool_use_id": tool_use_id,
+                                            "content": result_content,
+                                        }
+                                    }),
+                                );
+                                emit(
+                                    &mut out,
+                                    traffic,
+                                    "content_block_stop",
+                                    &serde_json::json!({
+                                        "type": "content_block_stop",
+                                        "index": block.index,
+                                    }),
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // Emit deferred content
+                for deferred in &deferred_content_events {
+                    emit_content_event(
+                        &mut out,
+                        traffic,
+                        &mut message_started,
+                        &mut open_blocks,
+                        message_id,
+                        model,
+                        deferred,
+                    );
+                }
+
+                ensure_message_start(&mut out, traffic, &mut message_started, message_id, model);
+
+                let mapped = map_codex_usage_to_anthropic(usage, Some(*web_search_requests));
+                emit(
+                    &mut out,
+                    traffic,
+                    "message_delta",
+                    &serde_json::json!({
+                        "type": "message_delta",
+                        "delta": {
+                            "stop_reason": stop_reason,
+                            "stop_sequence": null
+                        },
+                        "usage": mapped,
+                    }),
+                );
+                emit(
+                    &mut out,
+                    traffic,
+                    "message_stop",
+                    &serde_json::json!({"type": "message_stop"}),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    Ok(out)
+}
+
+fn write_reducer_error_capture(traffic: Option<&TrafficCapture>, err: &UpstreamStreamError) {
+    let Some(traffic) = traffic else {
+        return;
+    };
+    traffic.write_json(
+        "060-codex-stream-reducer-error",
+        &serde_json::json!({
+            "kind": format!("{:?}", err.kind),
+            "message": err.message,
+            "retryAfterSeconds": err.retry_after_seconds,
+            "diagnostics": err.diagnostics,
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sse_event(type_name: &str, payload: serde_json::Value) -> String {
+        let mut obj = if let serde_json::Value::Object(m) = payload {
+            m
+        } else {
+            return String::new();
+        };
+        obj.insert("type".into(), serde_json::json!(type_name));
+        format!(
+            "data: {}\n\n",
+            serde_json::to_string(&serde_json::Value::Object(obj)).unwrap()
+        )
+    }
+
+    #[test]
+    fn stream_translates_text_response() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "output_index": 0,
+                    "item": {"type":"message","id":"item_1"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                serde_json::json!({
+                    "output_index":0,"delta":"hello"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                serde_json::json!({
+                    "output_index":0,"item":{"type":"message"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                serde_json::json!({
+                    "response":{"id":"resp_1","usage":{"input_tokens":5,"output_tokens":1}}
+                })
+            ),
+        );
+        let out = String::from_utf8(
+            translate_stream_bytes(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap(),
+        )
+        .unwrap();
+        assert!(out.contains("message_start"));
+        assert!(out.contains("text_delta"));
+        assert!(out.contains("message_stop"));
+    }
+
+    #[test]
+    fn stream_translates_web_search_response() {
+        let upstream = format!(
+            "{}{}{}{}{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "output_index":0,
+                    "item":{"type":"web_search_call","id":"ws_1"}
+                })
+            ),
+            sse_event(
+                "response.web_search_call.in_progress",
+                serde_json::json!({
+                    "output_index":0,"item_id":"ws_1"
+                })
+            ),
+            sse_event(
+                "response.web_search_call.completed",
+                serde_json::json!({
+                    "output_index":0,"item_id":"ws_1"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                serde_json::json!({
+                    "output_index":0,
+                    "item":{"type":"web_search_call","id":"ws_1","action":{"query":"test query"}}
+                })
+            ),
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "output_index":1,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                serde_json::json!({
+                    "output_index":1,"delta":"See [Result](https://result.com)"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                serde_json::json!({
+                    "output_index":1,"item":{"type":"message"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                serde_json::json!({
+                    "response":{"id":"resp_1","usage":{"input_tokens":3,"output_tokens":1}}
+                })
+            ),
+        );
+        let result = translate_stream_bytes(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap();
+        let out = String::from_utf8(result).unwrap();
+        assert!(out.contains("server_tool_use"), "missing server_tool_use");
+        assert!(
+            out.contains("web_search_tool_result"),
+            "missing web_search_tool_result"
+        );
+    }
+
+    #[test]
+    fn stream_translates_reasoning_summary_to_thinking() {
+        let upstream = format!(
+            "{}{}{}{}{}{}",
+            sse_event(
+                "response.reasoning_summary_text.delta",
+                serde_json::json!({
+                    "output_index":0,"summary_index":0,"delta":"Working it out"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                serde_json::json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}
+                })
+            ),
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "output_index":1,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                serde_json::json!({
+                    "output_index":1,"delta":"answer"
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                serde_json::json!({
+                    "output_index":1,"item":{"type":"message"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                serde_json::json!({
+                    "response":{"id":"resp_1","usage":{}}
+                })
+            ),
+        );
+        let out = String::from_utf8(
+            translate_stream_bytes(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap(),
+        )
+        .unwrap();
+        assert!(out.contains("\"type\":\"thinking\""));
+        assert!(out.contains("\"signature\":\"\""));
+        assert!(out.contains("\"type\":\"thinking_delta\""));
+        assert!(out.contains("\"thinking\":\"Working it out\""));
+        assert!(out.contains("event: message_stop"));
+        assert!(
+            out.find("\"type\":\"thinking_delta\"").unwrap()
+                < out.find("\"type\":\"text_delta\"").unwrap()
+        );
+    }
+
+    #[test]
+    fn stream_omits_empty_reasoning_summary() {
+        let upstream = format!(
+            "{}{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                serde_json::json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","summary":[],"encrypted_content":"enc"}
+                })
+            ),
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "output_index":1,
+                    "item":{"type":"message","id":"msg_up"}
+                })
+            ),
+            sse_event(
+                "response.output_text.delta",
+                serde_json::json!({
+                    "output_index":1,"delta":"answer"
+                })
+            ),
+            format!(
+                "{}{}",
+                sse_event(
+                    "response.output_item.done",
+                    serde_json::json!({
+                        "output_index":1,"item":{"type":"message"}
+                    })
+                ),
+                sse_event(
+                    "response.completed",
+                    serde_json::json!({
+                        "response":{"id":"resp_1","usage":{}}
+                    })
+                )
+            ),
+        );
+        let out = String::from_utf8(
+            translate_stream_bytes(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap(),
+        )
+        .unwrap();
+        assert!(!out.contains("\"type\":\"thinking\""));
+        assert!(!out.contains("\"type\":\"thinking_delta\""));
+        assert!(out.contains("event: message_stop"));
+    }
+}

--- a/src/providers/xai/translate/web_search_compat.rs
+++ b/src/providers/xai/translate/web_search_compat.rs
@@ -1,0 +1,205 @@
+use serde_json::Value;
+
+pub struct WebSearchCompatBlock {
+    pub index: usize,
+    pub content: WebSearchCompatContent,
+}
+
+pub enum WebSearchCompatContent {
+    ServerToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: Vec<WebSearchResult>,
+    },
+}
+
+#[derive(Clone)]
+pub struct WebSearchResult {
+    pub title: String,
+    pub url: String,
+}
+
+pub fn server_tool_use_id_from_codex_web_search_id(id: &str) -> String {
+    let suffix: String = id
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("srvtoolu_{suffix}")
+}
+
+fn extract_web_search_results_from_text(text: &str) -> Vec<WebSearchResult> {
+    let mut results: Vec<WebSearchResult> = Vec::new();
+    let mut seen_urls: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Match markdown links [title](url)
+    let re = regex_lite::Regex::new(r#"\[([^\]\n]+)\]\((https?://[^)\s]+)\)"#).unwrap();
+    for cap in re.captures_iter(text) {
+        let title = clean_title(cap.get(1).map(|m| m.as_str()).unwrap_or(""));
+        let url = clean_url(cap.get(2).map(|m| m.as_str()).unwrap_or(""));
+        if url.is_empty() || seen_urls.contains(&url) {
+            continue;
+        }
+        seen_urls.insert(url.clone());
+        let display_title = if title.is_empty() {
+            fallback_title(&url)
+        } else {
+            title
+        };
+        results.push(WebSearchResult {
+            title: display_title,
+            url,
+        });
+    }
+
+    // Match bare URLs
+    let re2 = regex_lite::Regex::new(r"https?://[^\s<>()|]+").unwrap();
+    for cap in re2.captures_iter(text) {
+        let raw_url = cap.get(0).map(|m| m.as_str()).unwrap_or("");
+        let url = clean_url(raw_url);
+        if url.is_empty() || seen_urls.contains(&url) {
+            continue;
+        }
+        seen_urls.insert(url.clone());
+        results.push(WebSearchResult {
+            title: fallback_title(&url),
+            url,
+        });
+    }
+
+    results
+}
+
+pub fn build_web_search_compat_blocks(
+    searches: &[super::reducer::ReducerEvent],
+    text: &str,
+) -> Vec<WebSearchCompatBlock> {
+    let results = extract_web_search_results_from_text(text);
+    let mut blocks = Vec::new();
+
+    for event in searches {
+        if let super::reducer::ReducerEvent::WebSearch {
+            index,
+            result_index,
+            id,
+            query,
+        } = event
+        {
+            blocks.push(WebSearchCompatBlock {
+                index: *index,
+                content: WebSearchCompatContent::ServerToolUse {
+                    id: id.clone(),
+                    name: "web_search".to_string(),
+                    input: serde_json::json!({"query": query}),
+                },
+            });
+            blocks.push(WebSearchCompatBlock {
+                index: *result_index,
+                content: WebSearchCompatContent::WebSearchToolResult {
+                    tool_use_id: id.clone(),
+                    content: results.clone(),
+                },
+            });
+        }
+    }
+
+    blocks
+}
+
+fn clean_url(value: &str) -> String {
+    let mut out = value.trim().to_string();
+    while out.ends_with('.')
+        || out.ends_with(',')
+        || out.ends_with(';')
+        || out.ends_with(':')
+        || out.ends_with('!')
+        || out.ends_with('?')
+    {
+        out.pop();
+    }
+    out
+}
+
+fn clean_title(value: &str) -> String {
+    let no_markers = value
+        .trim_start()
+        .trim_start_matches(|c: char| c == '-' || c == '*' || c == '+' || c.is_ascii_digit())
+        .trim_start_matches(['.', ')', ' '])
+        .replace("**", "")
+        .replace('`', "")
+        .trim()
+        .to_string();
+    // Take text before dash or em-dash
+    if let Some(pos) = no_markers.find(" - ") {
+        no_markers[..pos].trim().to_string()
+    } else if let Some(find_pos) = no_markers.find(" \u{2013} ") {
+        no_markers[..find_pos].trim().to_string()
+    } else {
+        no_markers
+    }
+}
+
+fn fallback_title(url: &str) -> String {
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split('/')
+        .next()
+        .unwrap_or(url)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_tool_use_id_format() {
+        let id = server_tool_use_id_from_codex_web_search_id("ws_123");
+        assert_eq!(id, "srvtoolu_ws_123");
+    }
+
+    #[test]
+    fn extract_results_from_text() {
+        let text = "Check [Example](https://example.com) and https://other.com/page.";
+        let results = extract_web_search_results_from_text(text);
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().any(|r| r.url == "https://example.com"));
+        assert!(results.iter().any(|r| r.url == "https://other.com/page"));
+    }
+
+    #[test]
+    fn build_compat_blocks() {
+        let searches = vec![super::super::reducer::ReducerEvent::WebSearch {
+            index: 0,
+            result_index: 1,
+            id: "ws_1".to_string(),
+            query: "test".to_string(),
+        }];
+        let text = "See [Result](https://result.com)";
+        let blocks = build_web_search_compat_blocks(&searches, text);
+        assert_eq!(blocks.len(), 2);
+        match &blocks[0].content {
+            WebSearchCompatContent::ServerToolUse { name, input, .. } => {
+                assert_eq!(name, "web_search");
+                assert_eq!(input.get("query").and_then(|v| v.as_str()), Some("test"));
+            }
+            _ => panic!("expected ServerToolUse"),
+        }
+        match &blocks[1].content {
+            WebSearchCompatContent::WebSearchToolResult { content, .. } => {
+                assert_eq!(content.len(), 1);
+                assert_eq!(content[0].url, "https://result.com");
+            }
+            _ => panic!("expected WebSearchToolResult"),
+        }
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -50,6 +50,17 @@ pub(crate) const CODEX_MODELS: &[&str] = &[
 
 pub(crate) const KIMI_MODELS: &[&str] = &["kimi-for-coding", "kimi-k2.6", "k2.6"];
 
+/// Explicit allowlist for SuperGrok OAuth (Hermes pins build + composer first).
+pub(crate) const XAI_MODELS: &[&str] = &[
+    "grok-build-0.1",
+    "grok-composer-2.5-fast",
+    "grok-4.3",
+    "grok-4.5",
+    "grok-4.20-0309-reasoning",
+    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-multi-agent-0309",
+];
+
 pub struct Registry {
     alias_provider: AliasProvider,
     models: BTreeMap<String, Vec<String>>,
@@ -65,6 +76,10 @@ impl Registry {
             KIMI_MODELS.iter().map(|m| (*m).to_string()).collect(),
         );
         models.insert("cursor".into(), build_cursor_models());
+        models.insert(
+            "xai".into(),
+            XAI_MODELS.iter().map(|m| (*m).to_string()).collect(),
+        );
 
         let mut handlers = BTreeMap::new();
         for (name, entries) in &models {
@@ -72,6 +87,7 @@ impl Registry {
                 "codex" => Arc::new(crate::providers::codex::CodexProvider::new()),
                 "kimi" => Arc::new(crate::providers::kimi::KimiProvider::new()),
                 "cursor" => Arc::new(crate::providers::cursor::CursorProvider::new()),
+                "xai" => Arc::new(crate::providers::xai::XaiProvider::new()),
                 _ => Arc::new(PlaceholderProvider::new(name, entries.clone())),
             };
             handlers.insert(name.clone(), handler);
@@ -196,6 +212,7 @@ impl PlaceholderProvider {
             "codex" => "codex",
             "kimi" => "kimi",
             "cursor" => "cursor",
+            "xai" => "xai",
             _ => "codex",
         };
         Self { name, models }
@@ -217,6 +234,7 @@ impl Provider for PlaceholderProvider {
             "codex" => &CODEX_CLI,
             "kimi" => &KIMI_CLI,
             "cursor" => &CURSOR_CLI,
+            "xai" => &XAI_CLI,
             _ => &CODEX_CLI,
         }
     }
@@ -275,6 +293,7 @@ impl CliHandlers for PlaceholderCli {
 const CODEX_CLI: PlaceholderCli = PlaceholderCli { provider: "codex" };
 const KIMI_CLI: PlaceholderCli = PlaceholderCli { provider: "kimi" };
 const CURSOR_CLI: PlaceholderCli = PlaceholderCli { provider: "cursor" };
+const XAI_CLI: PlaceholderCli = PlaceholderCli { provider: "xai" };
 
 fn expand_codex_models() -> Vec<String> {
     let mut set = HashSet::new();
@@ -317,6 +336,21 @@ mod tests {
         let p = registry.provider_for_model("haiku", None);
         assert!(p.is_some());
         assert_eq!(p.expect("provider").name(), "kimi");
+    }
+
+    #[test]
+    fn alias_routes_to_xai() {
+        let registry = Registry::new(AliasProvider::Xai);
+        let p = registry.provider_for_model("haiku", None);
+        assert!(p.is_some());
+        assert_eq!(p.expect("provider").name(), "xai");
+        assert_eq!(
+            registry
+                .provider_for_model("grok-build-0.1", None)
+                .unwrap()
+                .name(),
+            "xai"
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -25,6 +25,7 @@ fn models_prints_all_providers() -> Result<(), Box<dyn std::error::Error>> {
     assert!(out.contains("codex:"));
     assert!(out.contains("kimi:"));
     assert!(out.contains("cursor:"));
+    assert!(out.contains("xai:"));
 
     let mut cmd = Command::cargo_bin("claude-code-proxy")?;
     cmd.args(["models", "--full"]);
@@ -90,8 +91,10 @@ fn models_output_is_stable_order() -> Result<(), Box<dyn std::error::Error>> {
     let codex_pos = out.find("codex:").unwrap_or(0);
     let kimi_pos = out.find("kimi:").unwrap_or(0);
     let cursor_pos = out.find("cursor:").unwrap_or(0);
+    let xai_pos = out.find("xai:").unwrap_or(0);
     assert!(codex_pos < kimi_pos);
     assert!(kimi_pos < cursor_pos);
+    assert!(cursor_pos < xai_pos);
     Ok(())
 }
 
@@ -108,5 +111,46 @@ fn kimi_auth_status_reads_stored_auth() -> Result<(), Box<dyn std::error::Error>
     cmd.args(["kimi", "auth", "status"]);
     cmd.env("CCP_CONFIG_DIR", temp.path());
     cmd.assert().success().stdout(contains("User: u"));
+    Ok(())
+}
+
+#[test]
+fn xai_auth_status_reads_stored_auth() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let auth_dir = temp.path().join("xai");
+    std::fs::create_dir_all(&auth_dir)?;
+    std::fs::write(
+        auth_dir.join("auth.json"),
+        r#"{"access":"a","refresh":"r","expires":4102444800000,"scope":"openid profile email offline_access"}"#,
+    )?;
+    let mut cmd = Command::cargo_bin("claude-code-proxy")?;
+    cmd.args(["xai", "auth", "status"]);
+    cmd.env("CCP_CONFIG_DIR", temp.path());
+    cmd.assert()
+        .success()
+        .stdout(contains("Authenticated: true"))
+        .stdout(contains("Scope:"));
+    Ok(())
+}
+
+#[test]
+fn xai_auth_status_unauthenticated() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("claude-code-proxy")?;
+    cmd.args(["xai", "auth", "status"]);
+    cmd.env("CCP_CONFIG_DIR", temp.path());
+    let output = cmd.output()?;
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8(output.stdout)?.contains("Not authenticated"));
+    Ok(())
+}
+
+#[test]
+fn xai_auth_logout_without_auth_is_success() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let mut cmd = Command::cargo_bin("claude-code-proxy")?;
+    cmd.args(["xai", "auth", "logout"]);
+    cmd.env("CCP_CONFIG_DIR", temp.path());
+    cmd.assert().success();
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Adds an **xAI SuperGrok / X Premium+** OAuth provider so Claude Code can use a SuperGrok subscription through the existing Anthropic-compatible proxy surface (same pattern as Codex / Kimi / Cursor).
- Dual auth: browser PKCE (`xai auth login`) and device-code (`xai auth device`); Responses API at `https://api.x.ai/v1/responses` with tools, reasoning/effort, streaming, and optional `previous_response_id` continuity.
- Explicit model allowlist (`grok-build-0.1`, `grok-composer-2.5-fast`, Grok 4.x variants); `aliasProvider: "xai"`; optional `CCP_XAI_API_KEY` / `XAI_API_KEY` fallback for known OAuth tier 403s (tokens kept on entitlement denial).

Closes https://github.com/raine/claude-code-proxy/issues/25

## Test plan

- [ ] `cargo test --lib -- --test-threads=1`
- [ ] `cargo test --test cli`
- [ ] `claude-code-proxy models` lists `xai: …`
- [ ] `claude-code-proxy xai auth status` → Not authenticated without tokens
- [ ] `claude-code-proxy xai auth login` or `device` with SuperGrok / X Premium+; `status` shows path + expiry
- [ ] `serve` with `ANTHROPIC_MODEL=grok-build-0.1` and Claude Code streaming + tool call
- [ ] Confirm 403 entitlement path surfaces actionable message; API key fallback works when set