### PR TITLE
fix(codex): route hosted web_search requests off the Responses Lite lane

### DIFF
--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -37,7 +37,7 @@ use self::translate::model_allowlist::{
     assert_allowed_model, resolve_model_request, uses_responses_lite,
 };
 use self::translate::reducer::finish_metadata_from_upstream;
-use self::translate::request::{TranslateOptions, translate_request};
+use self::translate::request::{TranslateOptions, has_hosted_web_search, translate_request};
 
 const MAX_RETRYABLE_LIVE_STREAM_RETRIES: u32 = 10;
 use self::translate::stream::translate_stream_bytes_with_traffic;
@@ -109,7 +109,8 @@ impl Provider for CodexProvider {
                 session_id: ctx.session_id.clone(),
                 service_tier: resolved.service_tier.clone(),
                 model: resolved.model.clone(),
-                use_responses_lite: uses_responses_lite(&resolved.model),
+                use_responses_lite: uses_responses_lite(&resolved.model)
+                    && !has_hosted_web_search(&body),
             },
         ) {
             Ok(t) => t,
@@ -256,7 +257,8 @@ impl Provider for CodexProvider {
                 session_id: None,
                 service_tier: resolved.service_tier.clone(),
                 model: resolved.model.clone(),
-                use_responses_lite: uses_responses_lite(&resolved.model),
+                use_responses_lite: uses_responses_lite(&resolved.model)
+                    && !has_hosted_web_search(&body),
             },
         ) {
             Ok(t) => t,

--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -293,6 +293,20 @@ pub fn normalize_strict_json_schema(schema: &Value) -> Value {
     }
 }
 
+/// Hosted tools (web_search) are rejected by the Responses Lite lane, which
+/// only supports function and custom tools. Requests carrying them must use
+/// the full Responses API.
+pub fn has_hosted_web_search(req: &MessagesRequest) -> bool {
+    req.extra
+        .get("tools")
+        .and_then(|v| v.as_array())
+        .is_some_and(|tools| {
+            tools
+                .iter()
+                .any(|tool| tool.get("type").and_then(|v| v.as_str()) == Some("web_search_20250305"))
+        })
+}
+
 pub fn translate_request(
     req: &MessagesRequest,
     opts: TranslateOptions,
@@ -365,6 +379,21 @@ pub fn translate_request(
         && !tools.is_empty()
     {
         out.tools = Some(tools);
+    }
+
+    // Never force a web_search tool_choice the request didn't register —
+    // upstream 502s instead of ignoring it.
+    if matches!(
+        out.tool_choice,
+        Some(ResponsesToolChoice::WebSearch { .. })
+    ) {
+        let has_web_search = out
+            .tools
+            .as_ref()
+            .is_some_and(|t| t.iter().any(|tool| matches!(tool, ResponsesTool::WebSearch(_))));
+        if !has_web_search {
+            out.tool_choice = Some(ResponsesToolChoice::Auto);
+        }
     }
 
     if let Some(sid) = opts.session_id {
@@ -879,6 +908,90 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out.prompt_cache_key.as_deref(), Some("s"));
+        assert!(matches!(
+            out.tool_choice,
+            Some(ResponsesToolChoice::WebSearch { .. })
+        ));
+    }
+
+    #[test]
+    fn has_hosted_web_search_detects_web_search_tool() {
+        let with: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role":"user", "content":"find it"}],
+            "tools": [
+                {"name":"Bash", "input_schema":{}},
+                {"type":"web_search_20250305", "name":"web_search"}
+            ]
+        }))
+        .unwrap();
+        assert!(has_hosted_web_search(&with));
+
+        let without: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role":"user", "content":"run it"}],
+            "tools": [{"name":"Bash", "input_schema":{}}]
+        }))
+        .unwrap();
+        assert!(!has_hosted_web_search(&without));
+    }
+
+    #[test]
+    fn responses_lite_downgrades_unregistered_web_search_tool_choice() {
+        // On the lite lane tools travel in the AdditionalTools developer
+        // prefix, so a top-level web_search tool_choice would reference a
+        // tool upstream doesn't know about and 502.
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role":"user", "content":"find it"}],
+            "tools": [{
+                "type":"web_search_20250305",
+                "name":"web_search"
+            }],
+            "tool_choice": {"type":"tool", "name":"web_search"}
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                session_id: None,
+                service_tier: None,
+                model: "gpt-5.6-sol".to_string(),
+                use_responses_lite: true,
+            },
+        )
+        .unwrap();
+        assert!(out.tools.is_none());
+        assert!(matches!(out.tool_choice, Some(ResponsesToolChoice::Auto)));
+    }
+
+    #[test]
+    fn full_lane_keeps_web_search_tool_choice_registered() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-sol",
+            "messages": [{"role":"user", "content":"find it"}],
+            "tools": [{
+                "type":"web_search_20250305",
+                "name":"web_search"
+            }],
+            "tool_choice": {"type":"tool", "name":"web_search"}
+        }))
+        .unwrap();
+        let out = translate_request(
+            &req,
+            TranslateOptions {
+                session_id: None,
+                service_tier: None,
+                model: "gpt-5.6-sol".to_string(),
+                use_responses_lite: false,
+            },
+        )
+        .unwrap();
+        assert!(
+            out.tools
+                .as_ref()
+                .is_some_and(|t| t.iter().any(|tool| matches!(tool, ResponsesTool::WebSearch(_))))
+        );
         assert!(matches!(
             out.tool_choice,
             Some(ResponsesToolChoice::WebSearch { .. })


### PR DESCRIPTION
Fixes #26.

## Problem

On the Responses Lite lane (`gpt-5.6-sol` / `-terra` / `-luna`), every tool is moved into the `AdditionalTools` developer prefix and the top-level `tools` param is sent as `null`. A hosted `web_search_20250305` tool therefore never registers upstream:

- **Forced search** — Claude Code sends `tool_choice: {type: "tool", name: "web_search"}`, which translates to a top-level `web_search` tool_choice referencing no registered tool. Upstream rejects with **502 `Tool choice 'web_search_preview' not found in 'tools' parameter`** (the exact error in #26).
- **Unforced search** — the search never engages real web infrastructure, so Claude Code's WebSearch reports zero results / the model claims it has no live search (the lingering symptom in #10).

Registering `web_search` top-level *on* the lite lane is not an option — upstream rejects the request with `X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.` (verified empirically).

## Fix

- `has_hosted_web_search()`: requests carrying a hosted `web_search_20250305` tool skip the lite lane and use the full Responses API, where `web_search` registers top-level and executes for real.
- Fail-safe in `translate_request`: if a `web_search` tool_choice would be emitted without a registered `web_search` tool (e.g. anything still on the lite lane), it downgrades to `auto` — no request shape can reproduce the 502.

## Testing

- 3 new unit tests (detection, lite-lane downgrade, full-lane registration); full suite passes (410 passed).
- Verified live against the ChatGPT backend with `ANTHROPIC_MODEL=gpt-5.6-sol`: forced and unforced WebSearch return real results in Claude Code, e.g. `Web Search("raine claude-code-proxy github")` → the repo/issues/releases URLs. WebFetch unaffected (client-side) and confirmed working alongside.

🤖 Opened by Barsik — generated with [Claude Code](https://claude.com/claude-code)