### PR TITLE
fix(codex): make hosted web search return real results

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,11 @@ so simple prompts can emit no thinking block. Set `codex.reasoningSummary` /
 keeping `reasoning.effort` and encrypted continuation content.
 
 Claude Code's hosted `web_search_20250305` tool is translated to Codex's native
-Responses `web_search` tool, including non-empty domain filters. Codex hosted
+Responses `web_search` tool with `external_web_access` enabled. Domain filters
+are not forwarded as the Responses `filters` parameter — the Codex backend
+returns zero results whenever it is present — and are instead enforced through
+injected instructions that scope queries with `site:` / `-site:` operators.
+Codex hosted
 search calls are emitted back to Claude Code as Anthropic `server_tool_use` and
 `web_search_tool_result` blocks with `usage.server_tool_use.web_search_requests`
 so Claude Code can account for completed searches.

--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -35,7 +35,7 @@ use self::count_tokens::count_translated_tokens;
 use self::translate::accumulate::accumulate_response_with_traffic;
 use self::translate::live_stream::LiveStreamTranslator;
 use self::translate::model_allowlist::{
-    assert_allowed_model, resolve_model_request, uses_responses_lite,
+    assert_allowed_model, full_lane_web_search_model, resolve_model_request, uses_responses_lite,
 };
 use self::translate::reducer::finish_metadata_from_upstream;
 use self::translate::request::{TranslateOptions, has_hosted_web_search, translate_request};
@@ -93,7 +93,7 @@ impl Provider for CodexProvider {
         let want_stream = body.stream;
         let model = body.model.as_deref().unwrap_or("gpt-5.6-sol");
 
-        let resolved = resolve_model_request(model);
+        let mut resolved = resolve_model_request(model);
         if let Err(e) = assert_allowed_model(&resolved.model) {
             return json_error(
                 StatusCode::BAD_REQUEST,
@@ -104,6 +104,7 @@ impl Provider for CodexProvider {
                 ),
             );
         }
+        let use_responses_lite = apply_model_lane_for_request(&mut resolved.model, &body);
         if let Some(monitor) = ctx.monitor.as_ref() {
             monitor.model_resolved(&ctx.req_id, &resolved.model);
         }
@@ -114,8 +115,7 @@ impl Provider for CodexProvider {
                 session_id: ctx.session_id.clone(),
                 service_tier: resolved.service_tier.clone(),
                 model: resolved.model.clone(),
-                use_responses_lite: uses_responses_lite(&resolved.model)
-                    && !has_hosted_web_search(&body),
+                use_responses_lite,
             },
         ) {
             Ok(t) => t,
@@ -241,7 +241,7 @@ impl Provider for CodexProvider {
 
     async fn handle_count_tokens(&self, body: MessagesRequest, ctx: RequestContext) -> Response {
         let model = body.model.as_deref().unwrap_or("gpt-5.6-sol");
-        let resolved = resolve_model_request(model);
+        let mut resolved = resolve_model_request(model);
         if let Err(e) = assert_allowed_model(&resolved.model) {
             return json_error(
                 StatusCode::BAD_REQUEST,
@@ -252,6 +252,7 @@ impl Provider for CodexProvider {
                 ),
             );
         }
+        let use_responses_lite = apply_model_lane_for_request(&mut resolved.model, &body);
         if let Some(monitor) = ctx.monitor.as_ref() {
             monitor.model_resolved(&ctx.req_id, &resolved.model);
         }
@@ -262,8 +263,7 @@ impl Provider for CodexProvider {
                 session_id: None,
                 service_tier: resolved.service_tier.clone(),
                 model: resolved.model.clone(),
-                use_responses_lite: uses_responses_lite(&resolved.model)
-                    && !has_hosted_web_search(&body),
+                use_responses_lite,
             },
         ) {
             Ok(t) => t,
@@ -288,6 +288,18 @@ impl Provider for CodexProvider {
         )
             .into_response()
     }
+}
+
+/// Picks the upstream model and lane for a request. Hosted web_search must
+/// run on the full Responses API (the lite lane rejects hosted tools), and
+/// lite-only models like gpt-5.6-luna don't exist there, so such requests
+/// are upgraded to a full-lane model. Returns whether to use the lite lane.
+fn apply_model_lane_for_request(model: &mut String, body: &MessagesRequest) -> bool {
+    if has_hosted_web_search(body) {
+        *model = full_lane_web_search_model(model).to_string();
+        return false;
+    }
+    uses_responses_lite(model)
 }
 
 fn count_sse_events(bytes: &[u8]) -> u64 {
@@ -912,6 +924,50 @@ mod tests {
     use std::sync::{Mutex, OnceLock};
 
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn request_with_tools(tools: serde_json::Value) -> MessagesRequest {
+        serde_json::from_value(serde_json::json!({
+            "model": "gpt-5.6-luna",
+            "messages": [{"role":"user", "content":"find it"}],
+            "tools": tools
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn web_search_requests_leave_lite_lane_and_upgrade_luna() {
+        let body = request_with_tools(serde_json::json!([
+            {"type":"web_search_20250305", "name":"web_search"}
+        ]));
+        for (resolved, expected) in [
+            ("gpt-5.6-luna", "gpt-5.6-sol"),
+            ("gpt-5.6-sol", "gpt-5.6-sol"),
+            ("gpt-5.6-terra", "gpt-5.6-terra"),
+            ("gpt-5.4", "gpt-5.4"),
+        ] {
+            let mut model = resolved.to_string();
+            let lite = apply_model_lane_for_request(&mut model, &body);
+            assert!(!lite, "{resolved} with web_search must use the full lane");
+            assert_eq!(model, expected);
+        }
+    }
+
+    #[test]
+    fn requests_without_web_search_keep_model_and_lite_lane() {
+        let body = request_with_tools(serde_json::json!([
+            {"name":"Bash", "input_schema":{}}
+        ]));
+        for (resolved, lite_expected) in [
+            ("gpt-5.6-luna", true),
+            ("gpt-5.6-sol", true),
+            ("gpt-5.4", false),
+        ] {
+            let mut model = resolved.to_string();
+            let lite = apply_model_lane_for_request(&mut model, &body);
+            assert_eq!(model, resolved, "model must not change without web_search");
+            assert_eq!(lite, lite_expected);
+        }
+    }
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         ENV_LOCK

--- a/src/providers/codex/translate/model_allowlist.rs
+++ b/src/providers/codex/translate/model_allowlist.rs
@@ -112,6 +112,18 @@ pub fn uses_responses_lite(model: &str) -> bool {
     matches!(model, "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra")
 }
 
+/// `gpt-5.6-luna` exists only behind the Responses Lite lane; the full
+/// Responses API resolves it to a `-free` variant and returns 404 (Model not
+/// found gpt-5.6-luna-free-...). Hosted web_search requests must run on the
+/// full lane, so luna is upgraded to its nearest full-lane sibling.
+pub fn full_lane_web_search_model(model: &str) -> &str {
+    if model == "gpt-5.6-luna" {
+        "gpt-5.6-sol"
+    } else {
+        model
+    }
+}
+
 pub fn is_valid_model_for_codex(model: &str) -> bool {
     if ALLOWED_MODELS.contains(&model) {
         return true;
@@ -131,6 +143,14 @@ mod tests {
     fn haiku_resolves_to_luna() {
         let r = resolve_model_request("haiku");
         assert_eq!(r.model, "gpt-5.6-luna");
+    }
+
+    #[test]
+    fn web_search_upgrades_luna_to_full_lane_sibling() {
+        assert_eq!(full_lane_web_search_model("gpt-5.6-luna"), "gpt-5.6-sol");
+        assert_eq!(full_lane_web_search_model("gpt-5.6-sol"), "gpt-5.6-sol");
+        assert_eq!(full_lane_web_search_model("gpt-5.6-terra"), "gpt-5.6-terra");
+        assert_eq!(full_lane_web_search_model("gpt-5.4"), "gpt-5.4");
     }
 
     #[test]

--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -182,16 +182,6 @@ pub struct ResponsesWebSearchTool {
     pub kind: String,
     pub external_web_access: bool,
     pub search_content_types: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub filters: Option<ResponsesWebSearchFilters>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ResponsesWebSearchFilters {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub allowed_domains: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub blocked_domains: Option<Vec<String>>,
 }
 
 pub struct TranslateOptions {
@@ -307,11 +297,60 @@ pub fn has_hosted_web_search(req: &MessagesRequest) -> bool {
         })
 }
 
+/// The Codex backend accepts the `filters` object on `web_search` but returns
+/// zero results for every query while it is present, so allowed/blocked
+/// domains can't be forwarded as-is. `site:` / `-site:` query operators do
+/// work, so filters are emulated by instructing the model to scope its
+/// queries with them.
+fn web_search_domain_instructions(req: &MessagesRequest) -> Option<String> {
+    let tools = req.extra.get("tools")?.as_array()?;
+    let tool = tools
+        .iter()
+        .find(|t| t.get("type").and_then(|v| v.as_str()) == Some("web_search_20250305"))?;
+    let domains = |key: &str| -> Vec<String> {
+        tool.get(key)
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    let allowed = domains("allowed_domains");
+    let blocked = domains("blocked_domains");
+    if allowed.is_empty() && blocked.is_empty() {
+        return None;
+    }
+    let mut out = String::from("Domain filters are in effect for web_search.");
+    if !allowed.is_empty() {
+        out.push_str(&format!(
+            " Only results from these domains may be used: {}. Scope every web_search query to them with site: operators (e.g. \"site:{}\") and discard results from any other domain.",
+            allowed.join(", "),
+            allowed[0],
+        ));
+    }
+    if !blocked.is_empty() {
+        out.push_str(&format!(
+            " Never use or cite results from these domains: {}. Exclude them from every web_search query with -site: operators (e.g. \"-site:{}\") and discard any results from them.",
+            blocked.join(", "),
+            blocked[0],
+        ));
+    }
+    Some(out)
+}
+
 pub fn translate_request(
     req: &MessagesRequest,
     opts: TranslateOptions,
 ) -> Result<ResponsesRequest, anyhow::Error> {
-    let instructions = flatten_system_text(req.extra.get("system"));
+    let mut instructions = flatten_system_text(req.extra.get("system"));
+    if let Some(domain_instructions) = web_search_domain_instructions(req) {
+        instructions = Some(match instructions {
+            Some(text) => format!("{text}\n\n{domain_instructions}"),
+            None => domain_instructions,
+        });
+    }
     let input = build_input(req);
     let tools = read_tools(req)?;
     let tool_choice = map_tool_choice(req)?;
@@ -469,33 +508,14 @@ fn read_tools(req: &MessagesRequest) -> Result<Option<Vec<ResponsesTool>>, anyho
             .and_then(|v| v.as_str())
             .unwrap_or("function");
         if tool_type == "web_search_20250305" {
-            let mut filters = ResponsesWebSearchFilters {
-                allowed_domains: None,
-                blocked_domains: None,
-            };
-            let allowed = tool.get("allowed_domains").and_then(|v| v.as_array());
-            if allowed.is_some_and(|a| !a.is_empty()) {
-                filters.allowed_domains = allowed.map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                });
-            }
-            let blocked = tool.get("blocked_domains").and_then(|v| v.as_array());
-            if blocked.is_some_and(|a| !a.is_empty()) {
-                filters.blocked_domains = blocked.map(|a| {
-                    a.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                });
-            }
-            let has_filters =
-                filters.allowed_domains.is_some() || filters.blocked_domains.is_some();
+            // The Codex backend returns zero results whenever a `filters`
+            // object is present on `web_search`, so domain filters are
+            // enforced through query instructions instead (see
+            // web_search_domain_instructions).
             out.push(ResponsesTool::WebSearch(ResponsesWebSearchTool {
                 kind: "web_search".to_string(),
-                external_web_access: false,
+                external_web_access: true,
                 search_content_types: vec!["text".to_string(), "image".to_string()],
-                filters: if has_filters { Some(filters) } else { None },
             }));
         } else {
             let name = tool
@@ -909,6 +929,65 @@ mod tests {
             out.tool_choice,
             Some(ResponsesToolChoice::WebSearch { .. })
         ));
+        let tool = serde_json::to_value(out.tools.as_ref().unwrap()[0].clone()).unwrap();
+        assert_eq!(tool.get("external_web_access"), Some(&json!(true)));
+        assert!(tool.get("filters").is_none());
+        let instructions = out.instructions.unwrap();
+        assert!(instructions.contains("example.com"));
+        assert!(instructions.contains("site:example.com"));
+    }
+
+    #[test]
+    fn web_search_lists_all_allowed_and_blocked_domains() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"find it"}],
+            "tools": [{
+                "type":"web_search_20250305",
+                "name":"web_search",
+                "allowed_domains":["a.example", "b.example"],
+                "blocked_domains":["c.example", "d.example"]
+            }]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        let instructions = out.instructions.unwrap();
+        for domain in ["a.example", "b.example", "c.example", "d.example"] {
+            assert!(instructions.contains(domain), "missing {domain}");
+        }
+        assert!(instructions.contains("site:a.example"));
+        assert!(instructions.contains("-site:c.example"));
+    }
+
+    #[test]
+    fn web_search_without_domains_adds_no_filter_instructions() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"find it"}],
+            "tools": [{"type":"web_search_20250305", "name":"web_search"}]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        assert!(out.instructions.is_none());
+    }
+
+    #[test]
+    fn web_search_blocked_domains_add_exclusion_instructions() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [{"role":"user", "content":"find it"}],
+            "system": "Be brief.",
+            "tools": [{
+                "type":"web_search_20250305",
+                "name":"web_search",
+                "blocked_domains":["spam.example"]
+            }]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        let instructions = out.instructions.unwrap();
+        assert!(instructions.starts_with("Be brief."));
+        assert!(instructions.contains("-site:spam.example"));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #35. After the lane-routing fix, hosted web search stopped 502ing but still returned zero results in Claude Code. Three independent causes, each verified live against the ChatGPT backend on a Plus plan (`gpt-5.6-sol` / `-luna`).

## Problems and fixes

### 1. `external_web_access` was `false`
With `false` the backend doesn't hit the live web — queries return stale or unrelated results (as @olegbrok observed on #35). Now sent as `true`; results come back with `utm_source=openai` live-search markers.

### 2. The `filters` object zeroes out all results
Deterministic repro, including with `external_web_access: true`: the query `raine claude-code-proxy repository` with `allowed_domains: ["github.com"]` returns 0 results; the identical query without `filters` returns the correct repo URLs. `site:`/`-site:` operators in the query itself **do** work when `filters` is absent (every result correctly domain-scoped).

Fix: stop forwarding `filters` and emulate domain filtering by injecting system instructions that tell the model to scope every `web_search` query with `site:`/`-site:` operators and discard out-of-scope results. README updated accordingly.

### 3. Claude Code's WebSearch subrequests 404 on `gpt-5.6-luna`
Claude Code sends WebSearch subrequests to the small fast model with `tool_choice: {"type":"auto"}` (traffic-captured). Since #35 those requests correctly leave the lite lane — but luna only exists *behind* the lite lane: the full Responses API resolves it to `gpt-5.6-luna-free-1p-codexswic-ev3` and returns 404 `Model not found`. Claude Code silently retries ~10x and reports "Did 0 searches in 25s". sol and terra were verified to serve `web_search` on the full lane; luna requests carrying the hosted tool are therefore upgraded to `gpt-5.6-sol`. The model+lane decision is extracted into `apply_model_lane_for_request()` shared by both handlers.

## Verification

- Live through the proxy: forced and unforced searches return real results; `allowed_domains: ["github.com"]` yields 12 results, all on github.com; luna WebSearch subrequest (previously 404) performs a real search; streaming path (with the v0.1.13 live-stream fix) emits `server_tool_use`/`web_search_tool_result` blocks and correct `web_search_requests` usage.
- 534 tests pass; new coverage: tool serialization (`external_web_access`, no `filters`), domain-instruction injection (allowed/blocked/multiple/none), luna upgrade helper, and the handler wiring via `apply_model_lane_for_request`.

## Known limitations (worth reviewer eyes)

- **The backend facts above are empirical** (filters → 0 results; luna missing from the full lane; `site:` honored). Tests prove what the proxy sends, not backend behavior — if the backend changes, tests stay green. The repro curls are in the commit messages / reproducible with `CCP_TRAFFIC_LOG=1`.
- **Domain filtering is best-effort, not enforcement.** Instructions steer the model rather than constraining search infrastructure. In live testing, allowed_domains held; blocked_domains shifted results but the model still cited one blocked-domain URL. Users relying on `blocked_domains` for compliance should know it's advisory. The README wording reflects this.
- **Multiple allowed domains** are listed in the instruction, but how the model combines them in a single query is untested empirically.
- **The luna→sol substitution is invisible to the client** (the response echoes the requested model). Whether upstream accounts these requests against sol's quota window is unobservable; WebSearch subrequests are small, but heavy-search sessions shift some load to sol.
- If any of this warrants an escape hatch (config flag to disable the filter emulation or the model upgrade), happy to add it.