### PR TITLE
Add generic Anthropic-compatible upstream (Merge, Anthropic models only)

### DIFF
--- a/docs/adr/0001-generic-anthropic-upstream.md
+++ b/docs/adr/0001-generic-anthropic-upstream.md
@@ -1,0 +1,52 @@
+# Design: Generic Anthropic-compatible upstream (Merge as first consumer)
+
+## Intent
+
+Upstream contribution to [raine/claude-code-proxy](https://github.com/raine/claude-code-proxy)
+should land as a **generic Anthropic Messages-compatible provider**, not a
+Merge-only one-off.
+
+Merge Gateway is the first configured consumer:
+
+- Default base URL: `https://api-gateway.merge.dev/v1/anthropic`
+- Default catalog prefix: `merge:`
+- Default Anthropic model slugs (v1): matching the existing `claude-mg` helper
+  (`anthropic/claude-opus-4-8`, `anthropic/fable-5`, `anthropic/claude-sonnet-5`,
+  `anthropic/claude-haiku-4-5-20251001`)
+
+Any other host that speaks Anthropic Messages can reuse the same provider by
+setting `CCP_MERGE_BASE_URL` / `merge.baseUrl` and `CCP_MERGE_AUTH_TOKEN`.
+
+## Why passthrough (not translation)
+
+Claude Code already emits Anthropic Messages JSON/SSE. Merge’s Anthropic path
+accepts the same shape. Unlike Codex/Kimi/Grok/Cursor, there is no proprietary
+upstream protocol to translate — we rewrite the model id (strip `merge:`),
+attach auth, and forward bytes.
+
+## Configuration surface
+
+| Concern | Env | Config file |
+| --- | --- | --- |
+| Base URL | `CCP_MERGE_BASE_URL` | `merge.baseUrl` |
+| Auth token | `CCP_MERGE_AUTH_TOKEN` / `MERGE_AUTH_TOKEN` / `CCP_MERGE_API_KEY` | `merge/auth.json` `{"access":"..."}` |
+
+Auth injection from 1Password is intentionally owned by the macOS app
+(`claude-code-routes`); this proxy only requires a resolved bearer/token.
+
+## v1 scope
+
+- Anthropic models only under `merge:`
+- No Merge-hosted OpenAI/GPT catalog entries yet
+- Unknown / non-claimed models continue to 400 with a clear error
+
+## Upstream PR shape (later)
+
+When contributing back to raine:
+
+1. Keep the provider implementation generic (Anthropic Messages forwarder).
+2. Treat Merge defaults as configuration examples / docs, not hard-coded
+   product branding inside the request path.
+3. Consider renaming the public provider id from `merge` to something like
+   `anthropic` if raine prefers a host-agnostic name, while preserving a
+   configurable model-id prefix for gateway discovery.

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ struct FileConfig {
     pub codex: Option<CodexConfig>,
     pub cursor: Option<CursorConfig>,
     pub grok: Option<GrokConfig>,
+    pub merge: Option<MergeConfig>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -88,6 +89,13 @@ struct GrokConfig {
     pub base_url: Option<String>,
     #[serde(rename = "clientVersion")]
     pub client_version: Option<String>,
+}
+
+#[derive(Deserialize, Clone)]
+struct MergeConfig {
+    /// Anthropic Messages-compatible base URL (Merge Gateway by default).
+    #[serde(rename = "baseUrl")]
+    pub base_url: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -221,6 +229,9 @@ pub fn config_override_summary_lines(cfg: &LoadedConfig) -> Vec<String> {
     if env.contains_key("CCP_GROK_CLIENT_VERSION") {
         out.push("grok.clientVersion (env)".to_string());
     }
+    if env.contains_key("CCP_MERGE_BASE_URL") {
+        out.push("merge.baseUrl (env)".to_string());
+    }
     if env
         .get("CCP_CODEX_REASONING_SUMMARY")
         .is_some_and(|raw| !raw.is_empty())
@@ -276,6 +287,24 @@ pub fn grok_client_version() -> String {
         return version;
     }
     "0.2.93".to_string()
+}
+
+/// Base URL for the generic Anthropic-compatible upstream.
+///
+/// Default matches the user's `claude-mg` shell helper:
+/// `https://api-gateway.merge.dev/v1/anthropic`. The client appends
+/// `/v1/messages` (same convention as Claude Code's Anthropic SDK).
+pub fn merge_base_url() -> String {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env.get("CCP_MERGE_BASE_URL") {
+        return raw.clone();
+    }
+    if let Some(merge) = read_file_config(&paths::config_dir()).and_then(|f| f.merge)
+        && let Some(url) = merge.base_url
+    {
+        return url;
+    }
+    "https://api-gateway.merge.dev/v1/anthropic".to_string()
 }
 
 pub fn is_verbose() -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,11 @@ enum Commands {
         #[command(subcommand)]
         command: ProviderGroup,
     },
+    /// Generic Anthropic-compatible upstream (Merge Gateway defaults)
+    Merge {
+        #[command(subcommand)]
+        command: ProviderGroup,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -135,6 +140,7 @@ fn main() -> Result<()> {
         Commands::Kimi { command } => run_provider_cli("kimi", command),
         Commands::Cursor { command } => run_provider_cli("cursor", command),
         Commands::Grok { command } => run_provider_cli("grok", command),
+        Commands::Merge { command } => run_provider_cli("merge", command),
     }
 }
 
@@ -194,7 +200,7 @@ fn run_provider_cli(name: &str, command: ProviderGroup) -> Result<()> {
 
 fn print_models(registry: &Registry, full: bool) {
     let grouped = registry.grouped_models();
-    for provider in ["codex", "kimi", "grok", "cursor"] {
+    for provider in ["codex", "kimi", "grok", "cursor", "merge"] {
         let Some(models) = grouped.get(provider) else {
             continue;
         };

--- a/src/providers/merge/auth.rs
+++ b/src/providers/merge/auth.rs
@@ -1,0 +1,143 @@
+//! Bearer/token auth for the generic Anthropic-compatible upstream.
+//!
+//! Env wins over the on-disk auth file. Full 1Password injection is owned by
+//! the macOS app; this provider only needs a configured token + base URL.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::paths;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct StoredMergeAuth {
+    /// Bearer / Anthropic-style auth token for the upstream Messages API.
+    pub access: String,
+}
+
+pub fn load_merge_token() -> Option<String> {
+    if let Some(token) = env_merge_token() {
+        let trimmed = token.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    load_auth_file()
+        .ok()
+        .flatten()
+        .map(|auth| auth.access)
+        .filter(|token| !token.trim().is_empty())
+}
+
+pub fn env_merge_token() -> Option<String> {
+    std::env::var("CCP_MERGE_AUTH_TOKEN")
+        .ok()
+        .or_else(|| std::env::var("MERGE_AUTH_TOKEN").ok())
+        .or_else(|| std::env::var("CCP_MERGE_API_KEY").ok())
+}
+
+pub fn auth_file_path() -> PathBuf {
+    paths::provider_auth_file("merge")
+}
+
+pub fn load_auth_file() -> anyhow::Result<Option<StoredMergeAuth>> {
+    let path = auth_file_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path)?;
+    let auth: StoredMergeAuth = serde_json::from_str(&raw)?;
+    Ok(Some(auth))
+}
+
+pub fn save_auth_file(auth: &StoredMergeAuth) -> anyhow::Result<()> {
+    if auth.access.trim().is_empty() {
+        anyhow::bail!("merge auth token is required");
+    }
+    let path = auth_file_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = fs::File::create(&path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+    }
+    file.write_all(serde_json::to_string_pretty(auth)?.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+pub fn clear_auth_file() -> anyhow::Result<()> {
+    let path = auth_file_path();
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+pub fn missing_auth_message() -> String {
+    [
+        "Merge / Anthropic-compatible authentication was not found.",
+        "Set CCP_MERGE_AUTH_TOKEN (or MERGE_AUTH_TOKEN), or write merge/auth.json with {\"access\":\"...\"}.",
+        "Default upstream is Merge Gateway; any Anthropic Messages-compatible base URL works via CCP_MERGE_BASE_URL.",
+    ]
+    .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_cell::sync::Lazy;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn clear(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn env_token_wins() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        let _config = EnvGuard::set("CCP_CONFIG_DIR", dir.path());
+        let _clear_merge = EnvGuard::clear("MERGE_AUTH_TOKEN");
+        let _clear_key = EnvGuard::clear("CCP_MERGE_API_KEY");
+        let _token = EnvGuard::set("CCP_MERGE_AUTH_TOKEN", "env-token");
+        assert_eq!(load_merge_token().as_deref(), Some("env-token"));
+    }
+}

--- a/src/providers/merge/client.rs
+++ b/src/providers/merge/client.rs
@@ -1,0 +1,239 @@
+//! HTTP client that forwards Anthropic Messages requests to a compatible upstream.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use http::StatusCode;
+
+use crate::anthropic::schema::MessagesRequest;
+use crate::traffic::TrafficCapture;
+
+use super::auth::{load_merge_token, missing_auth_message};
+
+const MAX_BUFFERED_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub struct MergeClient {
+    client: Arc<reqwest::Client>,
+    messages_url: String,
+}
+
+pub struct MergeResponse {
+    response: reqwest::Response,
+}
+
+pub struct MergeError {
+    pub status: StatusCode,
+    pub retry_after: Option<String>,
+    pub message: String,
+}
+
+impl MergeResponse {
+    pub fn status(&self) -> StatusCode {
+        self.response.status()
+    }
+
+    pub fn into_stream(
+        self,
+    ) -> impl futures_util::Stream<Item = Result<bytes::Bytes, MergeError>> + Send {
+        self.response.bytes_stream().map(|chunk| {
+            chunk.map_err(|_| MergeError {
+                status: StatusCode::BAD_GATEWAY,
+                retry_after: None,
+                message: "Anthropic-compatible upstream stream failed".into(),
+            })
+        })
+    }
+
+    pub async fn into_bytes(self) -> Result<Vec<u8>, MergeError> {
+        let mut stream = self.into_stream();
+        let mut bytes = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            if bytes.len().saturating_add(chunk.len()) > MAX_BUFFERED_RESPONSE_BYTES {
+                return Err(MergeError {
+                    status: StatusCode::BAD_GATEWAY,
+                    retry_after: None,
+                    message: "Anthropic-compatible upstream response exceeds the size limit".into(),
+                });
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(bytes)
+    }
+}
+
+impl MergeClient {
+    pub fn new(base_url: String) -> anyhow::Result<Self> {
+        let client = Arc::new(
+            reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .connect_timeout(Duration::from_secs(10))
+                .timeout(Duration::from_secs(120))
+                .build()?,
+        );
+        Ok(Self {
+            client,
+            messages_url: messages_url_for(&base_url),
+        })
+    }
+
+    pub async fn post_messages(
+        &self,
+        body: &MessagesRequest,
+        traffic: Option<Arc<TrafficCapture>>,
+    ) -> Result<MergeResponse, MergeError> {
+        let Some(token) = load_merge_token() else {
+            if let Some(capture) = traffic.as_ref() {
+                capture.write_json(
+                    "031-upstream-error-body",
+                    &serde_json::json!({"error":"missing_auth"}),
+                );
+            }
+            return Err(MergeError {
+                status: StatusCode::UNAUTHORIZED,
+                retry_after: None,
+                message: missing_auth_message(),
+            });
+        };
+
+        if let Some(capture) = traffic.as_ref() {
+            let body_value = serde_json::to_value(body).unwrap_or(serde_json::Value::Null);
+            capture.write_json("020-upstream-request", &body_value);
+            capture.write_json(
+                "021-upstream-request-metadata",
+                &serde_json::json!({
+                    "method": "POST",
+                    "url": self.messages_url,
+                    "provider": "merge",
+                    "transport": "http",
+                    "headers": {
+                        "accept": "application/json",
+                        "content-type": "application/json",
+                        "authorization": "[redacted]",
+                        "x-api-key": "[redacted]",
+                        "anthropic-version": "2023-06-01",
+                    },
+                    "body_bytes": serde_json::to_vec(body).map(|v| v.len()).unwrap_or(0),
+                }),
+            );
+        }
+
+        let mut request = self
+            .client
+            .post(&self.messages_url)
+            .header("content-type", "application/json")
+            .header("anthropic-version", "2023-06-01")
+            .header("authorization", format!("Bearer {token}"))
+            .header("x-api-key", &token)
+            .json(body);
+
+        if body.stream {
+            request = request.header("accept", "text/event-stream");
+        } else {
+            request = request.header("accept", "application/json");
+        }
+
+        let response = request.send().await.map_err(|_| MergeError {
+            status: StatusCode::BAD_GATEWAY,
+            retry_after: None,
+            message: "Anthropic-compatible upstream request failed".into(),
+        })?;
+
+        let status = response.status();
+        if let Some(capture) = traffic.as_ref() {
+            capture.write_json(
+                "030-upstream-response-headers",
+                &serde_json::json!({
+                    "status": status.as_u16(),
+                }),
+            );
+        }
+
+        if !status.is_success() {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            let body_bytes = response.bytes().await.unwrap_or_default();
+            let message = extract_error_message(&body_bytes)
+                .unwrap_or_else(|| format!("upstream returned HTTP {status}"));
+            if let Some(capture) = traffic.as_ref() {
+                let detail = serde_json::from_slice::<serde_json::Value>(&body_bytes)
+                    .unwrap_or_else(|_| {
+                        serde_json::json!({"body_bytes": body_bytes.len()})
+                    });
+                capture.write_json(
+                    "031-upstream-error-body",
+                    &serde_json::json!({
+                        "status": status.as_u16(),
+                        "body": detail,
+                    }),
+                );
+            }
+            return Err(MergeError {
+                status,
+                retry_after,
+                message,
+            });
+        }
+
+        Ok(MergeResponse { response })
+    }
+}
+
+fn messages_url_for(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/v1/messages") {
+        trimmed.to_string()
+    } else if trimmed.ends_with("/v1") {
+        format!("{trimmed}/messages")
+    } else {
+        // Merge Gateway Anthropic path is already `.../v1/anthropic`; append Messages.
+        format!("{trimmed}/v1/messages")
+    }
+}
+
+fn extract_error_message(body: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    value
+        .pointer("/error/message")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            value
+                .get("message")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn messages_url_appends_v1_messages() {
+        assert_eq!(
+            messages_url_for("https://api-gateway.merge.dev/v1/anthropic"),
+            "https://api-gateway.merge.dev/v1/anthropic/v1/messages"
+        );
+    }
+
+    #[test]
+    fn messages_url_respects_existing_messages_path() {
+        assert_eq!(
+            messages_url_for("http://127.0.0.1:9/v1/messages"),
+            "http://127.0.0.1:9/v1/messages"
+        );
+    }
+
+    #[test]
+    fn messages_url_appends_to_v1() {
+        assert_eq!(
+            messages_url_for("https://example.com/v1"),
+            "https://example.com/v1/messages"
+        );
+    }
+}

--- a/src/providers/merge/count_tokens.rs
+++ b/src/providers/merge/count_tokens.rs
@@ -1,0 +1,64 @@
+//! Local heuristic token counts for Anthropic-compatible upstreams that may
+//! not expose `/v1/messages/count_tokens`.
+
+use crate::anthropic::schema::MessagesRequest;
+
+pub const IMAGE_TOKEN_ESTIMATE: u64 = 2000;
+pub const MESSAGE_OVERHEAD_TOKENS: u64 = 4;
+
+pub fn count_tokens(req: &MessagesRequest) -> u64 {
+    let mut total = 0u64;
+
+    if let Some(system) = req.extra.get("system") {
+        total += count_value_tokens(system);
+    }
+
+    for msg in &req.messages {
+        total += count_value_tokens(&msg.content);
+        total += MESSAGE_OVERHEAD_TOKENS;
+    }
+
+    if let Some(tools) = req.extra.get("tools").and_then(|v| v.as_array()) {
+        for tool in tools {
+            total += count_value_tokens(tool);
+        }
+    }
+
+    total.max(1)
+}
+
+fn count_value_tokens(value: &serde_json::Value) -> u64 {
+    match value {
+        serde_json::Value::String(s) => approx_token_count(s),
+        serde_json::Value::Array(items) => items.iter().map(count_value_tokens).sum(),
+        serde_json::Value::Object(map) => {
+            if map.get("type").and_then(|v| v.as_str()) == Some("image") {
+                return IMAGE_TOKEN_ESTIMATE;
+            }
+            map.values().map(count_value_tokens).sum()
+        }
+        _ => 0,
+    }
+}
+
+fn approx_token_count(text: &str) -> u64 {
+    if text.is_empty() {
+        return 0;
+    }
+    let mut count = 0u64;
+    let mut in_word = false;
+    for ch in text.chars() {
+        if ch.is_alphanumeric() || ch == '-' || ch == '_' {
+            if !in_word {
+                count += 1;
+                in_word = true;
+            }
+        } else {
+            in_word = false;
+            if !ch.is_whitespace() {
+                count += 1;
+            }
+        }
+    }
+    count.max(1)
+}

--- a/src/providers/merge/mod.rs
+++ b/src/providers/merge/mod.rs
@@ -1,0 +1,300 @@
+//! Generic Anthropic Messages upstream, configured for Merge Gateway by default.
+//!
+//! This is intentionally a thin passthrough (not a proprietary translator):
+//! Claude Code already speaks Anthropic Messages, and Merge's Anthropic path
+//! does too. The provider exists so the same shape can be upstreamed to raine
+//! as a generic Anthropic-compatible backend — Merge is configuration, not a
+//! hard-coded one-off.
+
+pub mod auth;
+pub mod client;
+pub mod count_tokens;
+pub mod model;
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::{
+    Json,
+    body::Body,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use bytes::Bytes;
+use futures_util::{Stream, StreamExt};
+
+use crate::anthropic::{
+    error::json_error,
+    schema::{CountTokensResponse, MessagesRequest},
+};
+use crate::provider::{CliHandlers, Provider, RequestContext};
+
+use self::auth::{
+    clear_auth_file, load_auth_file, load_merge_token, save_auth_file, StoredMergeAuth,
+};
+use self::client::{MergeClient, MergeError};
+use self::model::{catalog_models, resolve_upstream_model};
+
+pub struct MergeProvider {
+    client: Arc<MergeClient>,
+}
+
+impl MergeProvider {
+    pub fn new() -> Self {
+        Self {
+            client: Arc::new(
+                MergeClient::new(crate::config::merge_base_url())
+                    .expect("Merge / Anthropic-compatible transport is unavailable"),
+            ),
+        }
+    }
+
+    pub fn with_client(client: MergeClient) -> Self {
+        Self {
+            client: Arc::new(client),
+        }
+    }
+}
+
+impl Default for MergeProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Provider for MergeProvider {
+    fn name(&self) -> &'static str {
+        "merge"
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        catalog_models()
+    }
+
+    fn cli(&self) -> &'static dyn CliHandlers {
+        &MERGE_CLI
+    }
+
+    async fn handle_messages(&self, body: MessagesRequest, ctx: RequestContext) -> Response {
+        let requested = body
+            .model
+            .clone()
+            .unwrap_or_else(|| "merge:anthropic/claude-sonnet-5".into());
+        let upstream_model = match resolve_upstream_model(&requested) {
+            Ok(model) => model,
+            Err(error) => {
+                return json_error(StatusCode::BAD_REQUEST, "invalid_request_error", error);
+            }
+        };
+
+        let mut forward = body.clone();
+        forward.model = Some(upstream_model.clone());
+
+        if let Some(monitor) = &ctx.monitor {
+            monitor.model_resolved(&ctx.req_id, &upstream_model);
+            monitor.upstream_started(&ctx.req_id);
+        }
+
+        let upstream = match self.client.post_messages(&forward, ctx.traffic.clone()).await {
+            Ok(response) => response,
+            Err(error) => return map_error(error),
+        };
+
+        if body.stream {
+            passthrough_sse(
+                upstream,
+                ctx.monitor.clone(),
+                ctx.req_id.clone(),
+                ctx.traffic.clone(),
+            )
+        } else {
+            let upstream_bytes = match upstream.into_bytes().await {
+                Ok(bytes) => bytes,
+                Err(error) => return map_error(error),
+            };
+            match serde_json::from_slice::<serde_json::Value>(&upstream_bytes) {
+                Ok(value) => {
+                    if let Some(traffic) = ctx.traffic.as_ref() {
+                        traffic.write_json("051-downstream-response", &value);
+                    }
+                    if let Some(monitor) = ctx.monitor.as_ref() {
+                        monitor.usage_updated(
+                            &ctx.req_id,
+                            value
+                                .pointer("/usage/input_tokens")
+                                .and_then(|v| v.as_u64()),
+                            value
+                                .pointer("/usage/output_tokens")
+                                .and_then(|v| v.as_u64()),
+                        );
+                    }
+                    (StatusCode::OK, Json(value)).into_response()
+                }
+                Err(_) => json_error(
+                    StatusCode::BAD_GATEWAY,
+                    "api_error",
+                    "Anthropic-compatible upstream returned invalid JSON",
+                ),
+            }
+        }
+    }
+
+    async fn handle_count_tokens(&self, body: MessagesRequest, ctx: RequestContext) -> Response {
+        let requested = body
+            .model
+            .clone()
+            .unwrap_or_else(|| "merge:anthropic/claude-sonnet-5".into());
+        if let Err(error) = resolve_upstream_model(&requested) {
+            return json_error(StatusCode::BAD_REQUEST, "invalid_request_error", error);
+        }
+        let tokens = count_tokens::count_tokens(&body);
+        if let Some(monitor) = ctx.monitor.as_ref() {
+            monitor.usage_updated(&ctx.req_id, Some(tokens), None);
+        }
+        (
+            StatusCode::OK,
+            Json(CountTokensResponse {
+                input_tokens: tokens,
+            }),
+        )
+            .into_response()
+    }
+}
+
+fn passthrough_sse(
+    response: client::MergeResponse,
+    monitor: Option<crate::monitor::MonitorHandle>,
+    req_id: String,
+    traffic: Option<Arc<crate::traffic::TrafficCapture>>,
+) -> Response {
+    let stream = response.into_stream();
+    let body = Body::from_stream(map_stream(stream, monitor, req_id, traffic));
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "text/event-stream")
+        .header(http::header::CACHE_CONTROL, "no-cache")
+        .header(http::header::CONNECTION, "keep-alive")
+        .body(body)
+        .expect("valid SSE response")
+}
+
+fn map_stream(
+    stream: impl Stream<Item = Result<Bytes, MergeError>> + Send + 'static,
+    monitor: Option<crate::monitor::MonitorHandle>,
+    req_id: String,
+    traffic: Option<Arc<crate::traffic::TrafficCapture>>,
+) -> impl Stream<Item = Result<Bytes, Infallible>> + Send + 'static {
+    let mut total_bytes: u64 = 0;
+    let mut event_count: u64 = 0;
+    stream.map(move |item| {
+        match item {
+            Ok(bytes) => {
+                total_bytes = total_bytes.saturating_add(bytes.len() as u64);
+                event_count = event_count
+                    .saturating_add(bytes.windows(2).filter(|w| *w == *b"\n\n").count() as u64);
+                if let Some(monitor) = monitor.as_ref() {
+                    monitor.stream_progress(&req_id, total_bytes, event_count, None, None);
+                }
+                Ok(bytes)
+            }
+            Err(error) => {
+                if let Some(traffic) = traffic.as_ref() {
+                    traffic.write_json(
+                        "060-upstream-stream-error",
+                        &serde_json::json!({"message": error.message}),
+                    );
+                }
+                let payload = format!(
+                    "event: error\ndata: {}\n\n",
+                    serde_json::json!({
+                        "type": "error",
+                        "error": {
+                            "type": "api_error",
+                            "message": error.message,
+                        }
+                    })
+                );
+                Ok(Bytes::from(payload))
+            }
+        }
+    })
+}
+
+fn map_error(error: MergeError) -> Response {
+    let status = error.status;
+    match status.as_u16() {
+        401 | 403 => json_error(
+            StatusCode::UNAUTHORIZED,
+            "authentication_error",
+            error.message,
+        ),
+        429 => {
+            let mut response = json_error(
+                StatusCode::TOO_MANY_REQUESTS,
+                "rate_limit_error",
+                error.message,
+            );
+            if let Some(retry_after) = error.retry_after.as_deref() {
+                if let Ok(value) = retry_after.parse::<http::HeaderValue>() {
+                    response.headers_mut().insert("retry-after", value);
+                }
+            }
+            response
+        }
+        400 => json_error(StatusCode::BAD_REQUEST, "invalid_request_error", error.message),
+        _ if status.is_server_error() || status == StatusCode::BAD_GATEWAY => {
+            json_error(StatusCode::BAD_GATEWAY, "api_error", error.message)
+        }
+        _ => json_error(status, "api_error", error.message),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MergeCli;
+
+impl CliHandlers for MergeCli {
+    fn login(&self) -> anyhow::Result<()> {
+        eprintln!(
+            "Browser login is not used for Merge / Anthropic-compatible upstreams.\n\
+             Set CCP_MERGE_AUTH_TOKEN, or write an auth file:\n\
+               {{\"access\":\"YOUR_TOKEN\"}} → {}",
+            auth::auth_file_path().display()
+        );
+        anyhow::bail!("use CCP_MERGE_AUTH_TOKEN or merge/auth.json instead of login");
+    }
+
+    fn device(&self) -> anyhow::Result<()> {
+        self.login()
+    }
+
+    fn status(&self) -> anyhow::Result<()> {
+        if load_merge_token().is_some() {
+            println!("Authenticated (token available)");
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Not authenticated"))
+        }
+    }
+
+    fn logout(&self) -> anyhow::Result<()> {
+        clear_auth_file()?;
+        Ok(())
+    }
+}
+
+const MERGE_CLI: MergeCli = MergeCli;
+
+/// Helper used by tests / CLI helpers that want to seed auth without env.
+#[allow(dead_code)]
+pub fn write_test_auth(access: &str) -> anyhow::Result<()> {
+    save_auth_file(&StoredMergeAuth {
+        access: access.to_string(),
+    })
+}
+
+#[allow(dead_code)]
+pub fn read_test_auth() -> anyhow::Result<Option<StoredMergeAuth>> {
+    load_auth_file()
+}

--- a/src/providers/merge/model.rs
+++ b/src/providers/merge/model.rs
@@ -1,0 +1,96 @@
+//! Model id resolution for the generic Anthropic-compatible upstream.
+//!
+//! Public catalog ids use a configurable prefix (default `merge:`). The
+//! upstream Messages API receives the id with the prefix stripped.
+
+use crate::registry::MERGE_MODELS;
+
+pub const DEFAULT_PREFIX: &str = "merge:";
+
+/// Resolve a Claude Code model id into the upstream Anthropic model slug.
+///
+/// Accepts:
+/// - Prefixed ids: `merge:anthropic/claude-sonnet-5` → `anthropic/claude-sonnet-5`
+/// - Bare catalog ids listed in [`MERGE_MODELS`] (already prefixed)
+pub fn resolve_upstream_model(requested: &str) -> Result<String, String> {
+    let stripped = strip_prefix(requested);
+    if !is_allowed_upstream(&stripped) {
+        return Err(format!(
+            "model \"{requested}\" is not in the Anthropic-compatible catalog"
+        ));
+    }
+    Ok(stripped)
+}
+
+pub fn strip_prefix(model: &str) -> String {
+    if let Some(rest) = model.strip_prefix(DEFAULT_PREFIX) {
+        rest.to_string()
+    } else {
+        model.to_string()
+    }
+}
+
+pub fn catalog_models() -> Vec<String> {
+    MERGE_MODELS
+        .iter()
+        .map(|model| {
+            if model.starts_with(DEFAULT_PREFIX) {
+                (*model).to_string()
+            } else {
+                format!("{DEFAULT_PREFIX}{model}")
+            }
+        })
+        .collect()
+}
+
+fn is_allowed_upstream(upstream: &str) -> bool {
+    MERGE_MODELS.iter().any(|entry| {
+        let catalog_upstream = strip_prefix(entry);
+        catalog_upstream == upstream
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_merge_prefix() {
+        assert_eq!(
+            resolve_upstream_model("merge:anthropic/claude-sonnet-5").unwrap(),
+            "anthropic/claude-sonnet-5"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_slug() {
+        assert!(resolve_upstream_model("merge:anthropic/gpt-4o").is_err());
+        assert!(resolve_upstream_model("merge:openai/gpt-5").is_err());
+    }
+
+    #[test]
+    fn catalog_is_prefixed() {
+        let models = catalog_models();
+        assert!(
+            models
+                .iter()
+                .all(|m| m.starts_with(DEFAULT_PREFIX) && m.contains("anthropic/"))
+        );
+        assert!(
+            models
+                .iter()
+                .any(|m| m == "merge:anthropic/claude-opus-4-8")
+        );
+        assert!(models.iter().any(|m| m == "merge:anthropic/fable-5"));
+        assert!(
+            models
+                .iter()
+                .any(|m| m == "merge:anthropic/claude-sonnet-5")
+        );
+        assert!(
+            models
+                .iter()
+                .any(|m| m == "merge:anthropic/claude-haiku-4-5-20251001")
+        );
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,4 +2,5 @@ pub mod codex;
 pub mod cursor;
 pub mod grok;
 pub mod kimi;
+pub mod merge;
 pub mod translate_shared;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -24,6 +24,7 @@ pub const ANTHROPIC_STYLE_ALIASES: &[&str] = &[
 ];
 
 pub const CURSOR_PREFIXES: &[&str] = &["cursor:", "cursor-plan:", "cursor-ask:"];
+pub const MERGE_PREFIXES: &[&str] = &["merge:"];
 
 const CURSOR_LEGACY_MODELS: &[&str] = &[
     "cursor",
@@ -51,6 +52,15 @@ pub(crate) const CODEX_MODELS: &[&str] = &[
 pub(crate) const KIMI_MODELS: &[&str] = &["kimi-for-coding", "kimi-k2.6", "k2.6"];
 pub(crate) const GROK_MODELS: &[&str] = &["grok-composer-2.5-fast", "grok-4.5"];
 
+/// Prefixed catalog for the generic Anthropic-compatible upstream (Merge defaults).
+/// Anthropic models only for v1 — no Merge-hosted OpenAI/GPT ids.
+pub const MERGE_MODELS: &[&str] = &[
+    "merge:anthropic/claude-opus-4-8",
+    "merge:anthropic/fable-5",
+    "merge:anthropic/claude-sonnet-5",
+    "merge:anthropic/claude-haiku-4-5-20251001",
+];
+
 pub struct Registry {
     alias_provider: AliasProvider,
     models: BTreeMap<String, Vec<String>>,
@@ -73,6 +83,13 @@ impl Registry {
                 .map(|model| (*model).to_string())
                 .collect(),
         );
+        models.insert(
+            "merge".into(),
+            MERGE_MODELS
+                .iter()
+                .map(|model| (*model).to_string())
+                .collect(),
+        );
 
         let mut handlers = BTreeMap::new();
         for (name, entries) in &models {
@@ -81,6 +98,7 @@ impl Registry {
                 "kimi" => Arc::new(crate::providers::kimi::KimiProvider::new()),
                 "cursor" => Arc::new(crate::providers::cursor::CursorProvider::new()),
                 "grok" => Arc::new(crate::providers::grok::GrokProvider::new()),
+                "merge" => Arc::new(crate::providers::merge::MergeProvider::new()),
                 _ => Arc::new(PlaceholderProvider::new(name, entries.clone())),
             };
             handlers.insert(name.clone(), handler);
@@ -151,6 +169,9 @@ impl Registry {
         if is_cursor_model(&normalized) {
             return self.handlers.get("cursor").cloned();
         }
+        if is_merge_model(&normalized) {
+            return self.handlers.get("merge").cloned();
+        }
 
         for (name, models) in &self.models {
             if models.iter().any(|candidate| candidate == &normalized) {
@@ -194,6 +215,15 @@ pub fn is_cursor_model(model: &str) -> bool {
         .any(|prefix| model.starts_with(prefix))
 }
 
+pub fn is_merge_model(model: &str) -> bool {
+    if MERGE_MODELS.contains(&model) {
+        return true;
+    }
+    MERGE_PREFIXES
+        .iter()
+        .any(|prefix| model.starts_with(prefix))
+}
+
 struct PlaceholderProvider {
     name: &'static str,
     models: Vec<String>,
@@ -206,6 +236,7 @@ impl PlaceholderProvider {
             "kimi" => "kimi",
             "cursor" => "cursor",
             "grok" => "grok",
+            "merge" => "merge",
             _ => "codex",
         };
         Self { name, models }
@@ -228,6 +259,7 @@ impl Provider for PlaceholderProvider {
             "kimi" => &KIMI_CLI,
             "cursor" => &CURSOR_CLI,
             "grok" => &GROK_CLI,
+            "merge" => &MERGE_CLI,
             _ => &CODEX_CLI,
         }
     }
@@ -287,6 +319,7 @@ const CODEX_CLI: PlaceholderCli = PlaceholderCli { provider: "codex" };
 const KIMI_CLI: PlaceholderCli = PlaceholderCli { provider: "kimi" };
 const CURSOR_CLI: PlaceholderCli = PlaceholderCli { provider: "cursor" };
 const GROK_CLI: PlaceholderCli = PlaceholderCli { provider: "grok" };
+const MERGE_CLI: PlaceholderCli = PlaceholderCli { provider: "merge" };
 
 fn expand_codex_models() -> Vec<String> {
     let mut set = HashSet::new();
@@ -372,6 +405,25 @@ mod tests {
                 .unwrap()
                 .name(),
             "cursor"
+        );
+    }
+
+    #[test]
+    fn merge_prefix_routes() {
+        let registry = Registry::new(AliasProvider::Codex);
+        assert_eq!(
+            registry
+                .provider_for_model("merge:anthropic/claude-sonnet-5", None)
+                .unwrap()
+                .name(),
+            "merge"
+        );
+        assert_eq!(
+            registry
+                .provider_for_model("merge:anthropic/fable-5", None)
+                .unwrap()
+                .name(),
+            "merge"
         );
     }
 }

--- a/tests/merge_anthropic.rs
+++ b/tests/merge_anthropic.rs
@@ -1,0 +1,295 @@
+//! HTTP-level tests for the generic Anthropic-compatible (Merge) upstream.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use claude_code_proxy::{registry::Registry, server::app};
+use serde_json::{Value, json};
+use std::sync::{Arc, Mutex, OnceLock};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tower::util::ServiceExt;
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    let m = ENV_LOCK.get_or_init(|| Mutex::new(()));
+    match m.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn write_merge_auth(config_dir: &std::path::Path) {
+    let dir = config_dir.join("merge");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("auth.json"),
+        serde_json::to_vec(&json!({"access":"test-merge-token"})).unwrap(),
+    )
+    .unwrap();
+}
+
+async fn spawn_json_upstream(
+    captured: Arc<Mutex<Option<(String, Option<String>, Value)>>>,
+    response_body: Value,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let addr_str = format!("http://{addr}");
+    let response_body = Arc::new(response_body);
+
+    let app = axum::Router::new().fallback({
+        let captured = captured.clone();
+        let response_body = response_body.clone();
+        move |req: Request<Body>| {
+            let captured = captured.clone();
+            let response_body = response_body.clone();
+            async move {
+                let auth = req
+                    .headers()
+                    .get("authorization")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string);
+                let path = req.uri().path().to_string();
+                let bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+                    .await
+                    .unwrap_or_default();
+                let json: Value = serde_json::from_slice(&bytes).unwrap_or_default();
+                let _ = captured.lock().map(|mut g| *g = Some((path, auth, json)));
+                http::Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "application/json")
+                    .body(Body::from(response_body.to_string()))
+                    .unwrap()
+            }
+        }
+    });
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.ok();
+    });
+
+    addr_str
+}
+
+async fn call_messages(model: &str, stream: bool) -> axum::response::Response {
+    app(Arc::new(Registry::with_default_alias()))
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/v1/messages")
+                .header("content-type", "application/json")
+                .header("x-claude-code-session-id", "merge-smoke")
+                .body(Body::from(
+                    json!({
+                        "model": model,
+                        "max_tokens": 64,
+                        "stream": stream,
+                        "messages": [{"role":"user","content":"hello"}]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn merge_prefixed_model_forwards_to_anthropic_upstream() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_merge_auth(config.path());
+
+    let captured = Arc::new(Mutex::new(None));
+    let upstream = spawn_json_upstream(
+        captured.clone(),
+        json!({
+            "id": "msg_upstream",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type":"text","text":"merge ok"}],
+            "model": "anthropic/claude-sonnet-5",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 3, "output_tokens": 2}
+        }),
+    )
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_MERGE_BASE_URL", &upstream);
+    let _token_env = EnvGuard::set("CCP_MERGE_AUTH_TOKEN", "env-merge-token");
+
+    let response = call_messages("merge:anthropic/claude-sonnet-5", false).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["content"][0]["text"], "merge ok");
+
+    let (path, auth, sent) = captured.lock().unwrap().clone().unwrap();
+    assert_eq!(path, "/v1/messages");
+    assert_eq!(auth.as_deref(), Some("Bearer env-merge-token"));
+    assert_eq!(sent["model"], "anthropic/claude-sonnet-5");
+    assert_eq!(sent["stream"], false);
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn merge_unknown_catalog_model_returns_400() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_merge_auth(config.path());
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _token_env = EnvGuard::set("CCP_MERGE_AUTH_TOKEN", "env-merge-token");
+
+    // OpenAI-on-Merge is intentionally out of v1 scope.
+    let response = call_messages("merge:openai/gpt-5", false).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["error"]["type"], "invalid_request_error");
+    assert!(
+        value["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not in the Anthropic-compatible catalog")
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn completely_unknown_model_still_lists_supported() {
+    let _guard = env_lock();
+    let response = call_messages("totally-unknown-model", false).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let message = value["error"]["message"].as_str().unwrap_or_default();
+    assert!(message.contains("Supported:"));
+    assert!(message.contains("merge:"));
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn merge_stream_passthrough_returns_anthropic_sse() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_merge_auth(config.path());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let upstream = format!("http://{addr}");
+    let captured_model = Arc::new(Mutex::new(None));
+
+    {
+        let captured_model = captured_model.clone();
+        let app = axum::Router::new().fallback(move |body: String| {
+            let captured_model = captured_model.clone();
+            async move {
+                let json: Value = serde_json::from_str(&body).unwrap_or_default();
+                let _ = captured_model
+                    .lock()
+                    .map(|mut g| *g = json.get("model").and_then(|v| v.as_str()).map(str::to_string));
+                let sse = concat!(
+                    "event: message_start\n",
+                    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"anthropic/claude-haiku-4-5-20251001\",\"content\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\n",
+                    "event: content_block_delta\n",
+                    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"stream ok\"}}\n\n",
+                    "event: message_stop\n",
+                    "data: {\"type\":\"message_stop\"}\n\n"
+                );
+                http::Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "text/event-stream")
+                    .body(Body::from(sse))
+                    .unwrap()
+            }
+        });
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+    }
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_MERGE_BASE_URL", &upstream);
+    let _token_env = EnvGuard::set("CCP_MERGE_AUTH_TOKEN", "env-merge-token");
+
+    let response = call_messages("merge:anthropic/claude-haiku-4-5-20251001", true).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("text/event-stream")
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8_lossy(&body);
+    assert!(text.contains("stream ok"));
+    assert!(text.contains("message_stop"));
+    assert_eq!(
+        captured_model.lock().unwrap().as_deref(),
+        Some("anthropic/claude-haiku-4-5-20251001")
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn merge_defaults_cover_claude_mg_slugs() {
+    let registry = Registry::with_default_alias();
+    let models = registry.supported_models_for("merge");
+    for expected in [
+        "merge:anthropic/claude-opus-4-8",
+        "merge:anthropic/fable-5",
+        "merge:anthropic/claude-sonnet-5",
+        "merge:anthropic/claude-haiku-4-5-20251001",
+    ] {
+        assert!(
+            models.iter().any(|m| m == expected),
+            "missing catalog entry {expected}; have {models:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Fork work for [claude-code-routes#3](https://github.com/noahpatterson/claude-code-routes/issues/3): add a **generic Anthropic Messages passthrough** provider, configured for Merge Gateway by default (`merge:` prefix).
- Catalog defaults match `claude-mg` Anthropic slugs only (no Merge-hosted OpenAI/GPT in v1).
- HTTP tests against a fake upstream cover routing, auth forwarding, stream passthrough, and unknown-model 400s.
- Design notes in `docs/adr/0001-generic-anthropic-upstream.md` call out intent to upstream as generic (Merge is configuration).

## Test plan
- [x] `cargo test --test merge_anthropic`
- [x] `cargo test --lib providers::merge`
- [x] `cargo build --release` produces a runnable `claude-code-proxy`
- [x] `claude-code-proxy models` lists the four `merge:anthropic/...` entries
- [ ] Manual smoke (optional): set `CCP_MERGE_AUTH_TOKEN` from `op read 'op://Personal/Merge/apikey'`, `serve`, point Claude Code at localhost, `/model` to a `merge:` id


Made with [Cursor](https://cursor.com)