### PR TITLE
ci: preserve tap service block in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,16 @@ jobs:
               bin.install "claude-code-proxy"
             end
 
+            service do
+              state_home = ENV.fetch("XDG_STATE_HOME", "#{Dir.home}/.local/state")
+
+              run [opt_bin/"claude-code-proxy", "serve", "--no-monitor"]
+              keep_alive true
+              environment_variables XDG_STATE_HOME: state_home
+              log_path "#{state_home}/claude-code-proxy/service.log"
+              error_log_path "#{state_home}/claude-code-proxy/service.log"
+            end
+
             test do
               assert_match version.to_s, shell_output("\#{bin}/claude-code-proxy --version")
             end


### PR DESCRIPTION
The release workflow generates `Formula/claude-code-proxy.rb` from a heredoc template and force-writes it to the tap, so the `service` block merged in raine/homebrew-claude-code-proxy#1 was silently removed again by the 0.1.16 release commit (`edb9b43` in the tap).

This adds the identical service block to the workflow template. Verified by rendering the heredoc locally with dummy values — the generated `service do … end` section is byte-identical to the merged formula (the unquoted heredoc leaves Ruby `#{…}` interpolation untouched while still expanding `${VERSION}` and the sha vars).

The tap's current 0.1.16 formula is missing the block, so `brew services start claude-code-proxy` fails for anyone on 0.1.16 until the next release regenerates it with this template (or the tap is patched directly again).