### PR TITLE
Strip [1m] model hints before provider dispatch

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -207,7 +207,7 @@ async fn dispatch_request(
         }
     };
 
-    let body: crate::anthropic::schema::MessagesRequest = match parse_json_body(&body_bytes) {
+    let mut body: crate::anthropic::schema::MessagesRequest = match parse_json_body(&body_bytes) {
         Ok(body) => body,
         Err(response) => {
             let status = response.status();
@@ -295,6 +295,7 @@ async fn dispatch_request(
     };
 
     let normalized_model = normalize_incoming_model(model);
+    body.model = Some(normalized_model.clone());
     let session_state = if let Some(session_id) = session_id.as_deref() {
         session::existing_session(Some(session_id), now)
     } else {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -212,6 +212,26 @@ async fn count_tokens_routes_to_provider() {
 }
 
 #[tokio::test]
+async fn context_window_hint_is_removed_before_provider_dispatch() {
+    let app = app(Arc::new(Registry::with_default_alias()));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/v1/messages/count_tokens")
+                .header("content-type", "application/json")
+                .body(body_string(
+                    r#"{"model":"gpt-5.6-luna[1m]","messages":[{"role":"user","content":"hello"}]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn unknown_routes_use_anthropic_not_found_error() {
     let app = app(Arc::new(Registry::with_default_alias()));
     let response = app


### PR DESCRIPTION
## Summary

- write the normalized incoming model back into the request before provider dispatch
- keep `[1m]` as a Claude Code-only context hint, matching the documented behavior
- add an integration regression test through `/v1/messages/count_tokens`

## Problem

Provider selection already strips a trailing `[1m]`, but the selected provider still receives the original model string. For example, `gpt-5.6-luna[1m]` reaches the Codex provider and is then rejected as an unsupported model with HTTP 400.

## Verification

- regression test failed before the fix with `400` instead of `200`
- `cargo test --locked` (541 passed)
- targeted regression test passed again after rebasing onto the latest `main`
- `git diff --check`