### PR TITLE
Preserve Codex encrypted reasoning across Claude turns

### DIFF
--- a/src/providers/codex/count_tokens.rs
+++ b/src/providers/codex/count_tokens.rs
@@ -50,7 +50,20 @@ fn count_input_item_tokens(item: &ResponsesInputItem) -> u64 {
             name, arguments, ..
         } => approx_token_count(name) + approx_token_count(arguments),
         ResponsesInputItem::FunctionCallOutput { output, .. } => approx_token_count(output),
+        ResponsesInputItem::Reasoning {
+            encrypted_content, ..
+        } => approx_reasoning_token_count(encrypted_content),
     }
+}
+
+fn approx_reasoning_token_count(encoded_content: &str) -> u64 {
+    let model_visible_bytes = encoded_content
+        .len()
+        .saturating_mul(3)
+        .checked_div(4)
+        .unwrap_or(0)
+        .saturating_sub(650);
+    u64::try_from(model_visible_bytes.saturating_add(3) / 4).unwrap_or(u64::MAX)
 }
 
 fn count_content_part_tokens(part: &ResponsesContentPart) -> u64 {
@@ -162,5 +175,12 @@ mod tests {
         }))
         .unwrap();
         assert!(count_translated_tokens(&long) >= count_translated_tokens(&short));
+    }
+
+    #[test]
+    fn encrypted_reasoning_uses_codex_model_visible_size_estimate() {
+        let encoded_content = "A".repeat(4000);
+        assert_eq!(approx_reasoning_token_count(&encoded_content), 588);
+        assert_eq!(approx_reasoning_token_count("short"), 0);
     }
 }

--- a/src/providers/codex/request_summary.rs
+++ b/src/providers/codex/request_summary.rs
@@ -83,6 +83,7 @@ pub fn summarize_codex_request_size(body: &ResponsesRequest) -> CodexRequestSize
         ResponsesInputItem::Message { .. } => Some("message".to_string()),
         ResponsesInputItem::FunctionCall { .. } => Some("function_call".to_string()),
         ResponsesInputItem::FunctionCallOutput { .. } => Some("function_call_output".to_string()),
+        ResponsesInputItem::Reasoning { .. } => Some("reasoning".to_string()),
     });
 
     let role_counts = count_items_by(&body.input, |item| match item {
@@ -108,6 +109,7 @@ pub fn summarize_codex_request_size(body: &ResponsesRequest) -> CodexRequestSize
                     ResponsesInputItem::FunctionCallOutput { .. } => {
                         ("function_call_output".to_string(), None)
                     }
+                    ResponsesInputItem::Reasoning { .. } => ("reasoning".to_string(), None),
                 };
                 let json_bytes_val =
                     json_bytes(Some(&serde_json::to_value(item).unwrap_or_default()));

--- a/src/providers/codex/translate/accumulate.rs
+++ b/src/providers/codex/translate/accumulate.rs
@@ -43,6 +43,7 @@ pub fn accumulate_response_with_traffic(
     enum BlockKind {
         Thinking {
             text: String,
+            signature: String,
         },
         Text {
             text: String,
@@ -69,14 +70,22 @@ pub fn accumulate_response_with_traffic(
                     index: *index,
                     kind: BlockKind::Thinking {
                         text: String::new(),
+                        signature: String::new(),
                     },
                 });
             }
             ReducerEvent::ThinkingDelta { index, text } => {
                 if let Some(block) = blocks.iter_mut().rev().find(|b| b.index == *index)
-                    && let BlockKind::Thinking { text: t } = &mut block.kind
+                    && let BlockKind::Thinking { text: t, .. } = &mut block.kind
                 {
                     t.push_str(text);
+                }
+            }
+            ReducerEvent::ThinkingSignature { index, signature } => {
+                if let Some(block) = blocks.iter_mut().rev().find(|b| b.index == *index)
+                    && let BlockKind::Thinking { signature: s, .. } = &mut block.kind
+                {
+                    *s = signature.clone();
                 }
             }
             ReducerEvent::TextStart { index } => {
@@ -177,14 +186,14 @@ pub fn accumulate_response_with_traffic(
 
     for block in &blocks {
         match &block.kind {
-            BlockKind::Thinking { text } => {
-                if !text.is_empty() {
+            BlockKind::Thinking { text, signature } => {
+                if !text.is_empty() || !signature.is_empty() {
                     indexed_content.push((
                         block.index,
                         serde_json::json!({
                             "type": "thinking",
                             "thinking": text,
-                            "signature": "",
+                            "signature": signature,
                         }),
                     ));
                 }
@@ -534,5 +543,41 @@ mod tests {
         let upstream = sse_event("error", json!({"error":{"message":"upstream failure"}}));
         let result = accumulate_response(upstream.as_bytes(), "msg_e", "model");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn accumulate_preserves_signature_without_visible_summary() {
+        let upstream = format!(
+            "{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","id":"rs_1","encrypted_content":"opaque"}
+                })
+            ),
+            sse_event(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","id":"rs_1"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                json!({"response":{"id":"resp_1","usage":{}}})
+            ),
+        );
+        let response = accumulate_response(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap();
+        let content = response["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[0]["thinking"], "");
+        assert!(
+            content[0]["signature"]
+                .as_str()
+                .unwrap()
+                .starts_with("ccp:codex:v1:")
+        );
     }
 }

--- a/src/providers/codex/translate/live_stream.rs
+++ b/src/providers/codex/translate/live_stream.rs
@@ -4,6 +4,7 @@ use crate::anthropic::sse::encode_sse_event;
 use crate::traffic::TrafficCapture;
 
 use super::read_rewrite::sanitize_read_args;
+use super::reasoning_signature::{PendingReasoning, encode_reasoning_signature};
 use super::reducer::{
     CodexUsage, STOP_END_TURN, STOP_MAX_TOKENS, STOP_TOOL_USE, map_codex_usage_to_anthropic,
 };
@@ -41,6 +42,12 @@ struct LiveWebSearchResult {
     url: String,
 }
 
+#[derive(Clone, Copy)]
+struct LiveThinking {
+    output_index: usize,
+    anthropic_index: usize,
+}
+
 pub struct LiveStreamTranslator {
     message_id: String,
     model: String,
@@ -48,7 +55,8 @@ pub struct LiveStreamTranslator {
     blocks_by_output_index: HashMap<usize, LiveBlock>,
     item_id_to_output_index: HashMap<String, usize>,
     anthropic_index: usize,
-    thinking_index: Option<usize>,
+    thinking: Option<LiveThinking>,
+    reasoning_by_output_index: HashMap<usize, PendingReasoning>,
     saw_tool_use: bool,
     web_search_requests: usize,
     web_searches: Vec<LiveWebSearch>,
@@ -66,7 +74,8 @@ impl LiveStreamTranslator {
             blocks_by_output_index: HashMap::new(),
             item_id_to_output_index: HashMap::new(),
             anthropic_index: 0,
-            thinking_index: None,
+            thinking: None,
+            reasoning_by_output_index: HashMap::new(),
             saw_tool_use: false,
             web_search_requests: 0,
             web_searches: Vec::new(),
@@ -110,14 +119,18 @@ impl LiveStreamTranslator {
                 self.output_item_added(payload, traffic, &mut out);
             }
             "response.reasoning_summary_part.added" => {
-                if let Some(index) = self.thinking_index {
+                let output_index = output_index(payload);
+                if let Some(thinking) = self
+                    .thinking
+                    .filter(|thinking| thinking.output_index == output_index)
+                {
                     self.emit(
                         traffic,
                         &mut out,
                         "content_block_delta",
                         &serde_json::json!({
                             "type": "content_block_delta",
-                            "index": index,
+                            "index": thinking.anthropic_index,
                             "delta": {"type": "thinking_delta", "thinking": "\n\n"}
                         }),
                     );
@@ -256,6 +269,12 @@ impl LiveStreamTranslator {
         let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
         match item_type {
+            "reasoning" => {
+                self.reasoning_by_output_index
+                    .entry(output_index)
+                    .or_default()
+                    .capture(item);
+            }
             "message" => {
                 self.close_thinking(traffic, out);
                 let index = self.anthropic_index;
@@ -344,14 +363,19 @@ impl LiveStreamTranslator {
         traffic: Option<&TrafficCapture>,
         out: &mut Vec<u8>,
     ) {
+        let output_index = output_index(payload);
         let delta = payload.get("delta").and_then(|v| v.as_str()).unwrap_or("");
         if delta.is_empty() {
             return;
         }
-        if self.thinking_index.is_none() {
+        if self.thinking.map(|thinking| thinking.output_index) != Some(output_index) {
+            self.close_thinking(traffic, out);
             let index = self.anthropic_index;
             self.anthropic_index += 1;
-            self.thinking_index = Some(index);
+            self.thinking = Some(LiveThinking {
+                output_index,
+                anthropic_index: index,
+            });
             self.ensure_message_start(traffic, out);
             self.emit(
                 traffic,
@@ -364,7 +388,10 @@ impl LiveStreamTranslator {
                 }),
             );
         }
-        let index = self.thinking_index.unwrap();
+        let index = self
+            .thinking
+            .expect("thinking block was started")
+            .anthropic_index;
         self.emit(
             traffic,
             out,
@@ -575,13 +602,24 @@ impl LiveStreamTranslator {
         out: &mut Vec<u8>,
     ) {
         let output_index = output_index(payload);
-        if payload
+        if let Some(item) = payload
             .get("item")
             .and_then(|item| item.get("type"))
             .and_then(|v| v.as_str())
-            == Some("reasoning")
+            .filter(|item_type| *item_type == "reasoning")
+            .and_then(|_| payload.get("item"))
         {
+            self.reasoning_by_output_index
+                .entry(output_index)
+                .or_default()
+                .capture(item);
+            let had_active_summary = self
+                .thinking
+                .is_some_and(|thinking| thinking.output_index == output_index);
             self.close_thinking(traffic, out);
+            if !had_active_summary {
+                self.emit_signature_only_reasoning(output_index, traffic, out);
+            }
             return;
         }
 
@@ -896,10 +934,45 @@ impl LiveStreamTranslator {
         }
     }
 
-    fn close_thinking(&mut self, traffic: Option<&TrafficCapture>, out: &mut Vec<u8>) {
-        let Some(index) = self.thinking_index.take() else {
+    fn emit_signature_only_reasoning(
+        &mut self,
+        output_index: usize,
+        traffic: Option<&TrafficCapture>,
+        out: &mut Vec<u8>,
+    ) {
+        let Some(replay) = self
+            .reasoning_by_output_index
+            .remove(&output_index)
+            .and_then(|pending| pending.replay())
+        else {
             return;
         };
+        let Some(signature) = encode_reasoning_signature(&replay) else {
+            return;
+        };
+        let index = self.anthropic_index;
+        self.anthropic_index += 1;
+        self.ensure_message_start(traffic, out);
+        self.emit(
+            traffic,
+            out,
+            "content_block_start",
+            &serde_json::json!({
+                "type": "content_block_start",
+                "index": index,
+                "content_block": {"type": "thinking", "thinking": "", "signature": ""}
+            }),
+        );
+        self.emit(
+            traffic,
+            out,
+            "content_block_delta",
+            &serde_json::json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": {"type": "signature_delta", "signature": signature}
+            }),
+        );
         self.emit(
             traffic,
             out,
@@ -907,6 +980,38 @@ impl LiveStreamTranslator {
             &serde_json::json!({
                 "type": "content_block_stop",
                 "index": index,
+            }),
+        );
+    }
+
+    fn close_thinking(&mut self, traffic: Option<&TrafficCapture>, out: &mut Vec<u8>) {
+        let Some(thinking) = self.thinking.take() else {
+            return;
+        };
+        if let Some(signature) = self
+            .reasoning_by_output_index
+            .remove(&thinking.output_index)
+            .and_then(|pending| pending.replay())
+            .and_then(|replay| encode_reasoning_signature(&replay))
+        {
+            self.emit(
+                traffic,
+                out,
+                "content_block_delta",
+                &serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": thinking.anthropic_index,
+                    "delta": {"type": "signature_delta", "signature": signature}
+                }),
+            );
+        }
+        self.emit(
+            traffic,
+            out,
+            "content_block_stop",
+            &serde_json::json!({
+                "type": "content_block_stop",
+                "index": thinking.anthropic_index,
             }),
         );
     }
@@ -1301,5 +1406,39 @@ mod tests {
             )
             .unwrap_err();
         assert_eq!(err, "rate limit reached");
+    }
+
+    #[test]
+    fn live_stream_emits_signature_delta_before_thinking_stop() {
+        let out = render(vec![
+            json!({
+                "type":"response.output_item.added",
+                "output_index":0,
+                "item":{"type":"reasoning","id":"rs_1","encrypted_content":"opaque"}
+            }),
+            json!({
+                "type":"response.reasoning_summary_text.delta",
+                "output_index":0,
+                "delta":"plan"
+            }),
+            json!({
+                "type":"response.output_item.done",
+                "output_index":0,
+                "item":{"type":"reasoning","id":"rs_1"}
+            }),
+            json!({
+                "type":"response.completed",
+                "response":{"id":"resp_1","usage":{}}
+            }),
+        ]);
+        let thinking_delta = out.find(r#""type":"thinking_delta""#).unwrap();
+        let signature_delta = out.find(r#""type":"signature_delta""#).unwrap();
+        let thinking_stop = out[signature_delta..]
+            .find("event: content_block_stop")
+            .map(|offset| signature_delta + offset)
+            .unwrap();
+        assert!(thinking_delta < signature_delta);
+        assert!(signature_delta < thinking_stop);
+        assert!(out.contains("ccp:codex:v1:"));
     }
 }

--- a/src/providers/codex/translate/mod.rs
+++ b/src/providers/codex/translate/mod.rs
@@ -2,6 +2,7 @@ pub mod accumulate;
 pub mod live_stream;
 pub mod model_allowlist;
 pub mod read_rewrite;
+pub mod reasoning_signature;
 pub mod reducer;
 pub mod request;
 pub mod stream;

--- a/src/providers/codex/translate/reasoning_signature.rs
+++ b/src/providers/codex/translate/reasoning_signature.rs
@@ -1,0 +1,135 @@
+use base64::Engine;
+use serde_json::Value;
+
+const PREFIX: &str = "ccp:codex:v1:";
+const MAX_ID_BYTES: usize = 4 * 1024;
+const MAX_ENCRYPTED_CONTENT_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReasoningReplay {
+    pub id: String,
+    pub encrypted_content: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PendingReasoning {
+    id: Option<String>,
+    encrypted_content: Option<String>,
+}
+
+impl PendingReasoning {
+    pub fn capture(&mut self, item: &Value) {
+        if let Some(id) = non_empty_string(item.get("id")) {
+            self.id = Some(id.to_string());
+        }
+        if let Some(encrypted_content) = non_empty_string(item.get("encrypted_content")) {
+            self.encrypted_content = Some(encrypted_content.to_string());
+        }
+    }
+
+    pub fn replay(&self) -> Option<ReasoningReplay> {
+        Some(ReasoningReplay {
+            id: self.id.clone()?,
+            encrypted_content: self.encrypted_content.clone()?,
+        })
+    }
+}
+
+pub fn encode_reasoning_signature(replay: &ReasoningReplay) -> Option<String> {
+    if replay.id.is_empty()
+        || replay.id.len() > MAX_ID_BYTES
+        || replay.encrypted_content.is_empty()
+        || replay.encrypted_content.len() > MAX_ENCRYPTED_CONTENT_BYTES
+    {
+        return None;
+    }
+    let encoded_id = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(replay.id.as_bytes());
+    Some(format!("{PREFIX}{encoded_id}:{}", replay.encrypted_content))
+}
+
+pub fn decode_reasoning_signature(signature: &str) -> Option<ReasoningReplay> {
+    let payload = signature.strip_prefix(PREFIX)?;
+    if payload.is_empty() || payload.len() > max_payload_len() {
+        return None;
+    }
+    let (encoded_id, encrypted_content) = payload.split_once(':')?;
+    if encoded_id.is_empty()
+        || encoded_id.len() > encoded_id_len_limit()
+        || encrypted_content.is_empty()
+        || encrypted_content.len() > MAX_ENCRYPTED_CONTENT_BYTES
+    {
+        return None;
+    }
+    let id = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded_id)
+        .ok()?;
+    if id.is_empty() || id.len() > MAX_ID_BYTES {
+        return None;
+    }
+    Some(ReasoningReplay {
+        id: String::from_utf8(id).ok()?,
+        encrypted_content: encrypted_content.to_string(),
+    })
+}
+
+fn encoded_id_len_limit() -> usize {
+    (MAX_ID_BYTES + 2) / 3 * 4
+}
+
+fn max_payload_len() -> usize {
+    encoded_id_len_limit() + 1 + MAX_ENCRYPTED_CONTENT_BYTES
+}
+
+fn non_empty_string(value: Option<&Value>) -> Option<&str> {
+    value?.as_str().filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn signature_round_trip_preserves_reasoning_identity() {
+        let replay = ReasoningReplay {
+            id: "rs_1".to_string(),
+            encrypted_content: "gAAAAopaque".to_string(),
+        };
+        let signature = encode_reasoning_signature(&replay).unwrap();
+        assert!(signature.starts_with(PREFIX));
+        assert!(signature.ends_with(":gAAAAopaque"));
+        assert_eq!(decode_reasoning_signature(&signature), Some(replay));
+    }
+
+    #[test]
+    fn foreign_and_malformed_signatures_are_ignored() {
+        assert_eq!(decode_reasoning_signature("anthropic-signature"), None);
+        assert_eq!(decode_reasoning_signature("ccp:codex:v1:not-base64"), None);
+    }
+
+    #[test]
+    fn pending_reasoning_keeps_early_metadata_when_done_omits_it() {
+        let mut pending = PendingReasoning::default();
+        pending.capture(&json!({
+            "id": "rs_1",
+            "encrypted_content": "early"
+        }));
+        pending.capture(&json!({"id": "rs_1"}));
+        assert_eq!(
+            pending.replay(),
+            Some(ReasoningReplay {
+                id: "rs_1".to_string(),
+                encrypted_content: "early".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn oversized_signature_is_ignored_without_decoding() {
+        let signature = format!(
+            "{PREFIX}cnNfMQ:{}",
+            "A".repeat(MAX_ENCRYPTED_CONTENT_BYTES + 1)
+        );
+        assert_eq!(decode_reasoning_signature(&signature), None);
+    }
+}

--- a/src/providers/codex/translate/reducer.rs
+++ b/src/providers/codex/translate/reducer.rs
@@ -1,6 +1,7 @@
 use crate::anthropic::sse::parse_sse_events;
 
 use super::read_rewrite::sanitize_read_args;
+use super::reasoning_signature::{PendingReasoning, ReasoningReplay, encode_reasoning_signature};
 use super::request::ResponsesInputItem;
 
 #[derive(Debug, Clone)]
@@ -71,6 +72,10 @@ pub enum ReducerEvent {
     ThinkingDelta {
         index: usize,
         text: String,
+    },
+    ThinkingSignature {
+        index: usize,
+        signature: String,
     },
     ThinkingStop {
         index: usize,
@@ -143,6 +148,82 @@ enum BlockState {
     },
 }
 
+#[derive(Clone, Copy)]
+struct ActiveThinking {
+    output_index: usize,
+    anthropic_index: usize,
+}
+
+fn reasoning_input_item(replay: ReasoningReplay) -> ResponsesInputItem {
+    ResponsesInputItem::Reasoning {
+        id: replay.id,
+        summary: Vec::new(),
+        encrypted_content: replay.encrypted_content,
+    }
+}
+
+fn finalize_active_thinking(
+    active: ActiveThinking,
+    out: &mut Vec<ReducerEvent>,
+    reasoning_by_output_index: &mut std::collections::HashMap<usize, PendingReasoning>,
+    output_items_by_index: &mut std::collections::BTreeMap<usize, ResponsesInputItem>,
+) {
+    if let Some(replay) = reasoning_by_output_index
+        .remove(&active.output_index)
+        .and_then(|pending| pending.replay())
+        && let Some(signature) = encode_reasoning_signature(&replay)
+    {
+        out.push(ReducerEvent::ThinkingSignature {
+            index: active.anthropic_index,
+            signature,
+        });
+        output_items_by_index.insert(active.output_index, reasoning_input_item(replay));
+    }
+    out.push(ReducerEvent::ThinkingStop {
+        index: active.anthropic_index,
+    });
+}
+
+fn close_thinking(
+    out: &mut Vec<ReducerEvent>,
+    active_thinking: &mut Option<ActiveThinking>,
+    reasoning_by_output_index: &mut std::collections::HashMap<usize, PendingReasoning>,
+    output_items_by_index: &mut std::collections::BTreeMap<usize, ResponsesInputItem>,
+) {
+    if let Some(active) = active_thinking.take() {
+        finalize_active_thinking(
+            active,
+            out,
+            reasoning_by_output_index,
+            output_items_by_index,
+        );
+    }
+}
+
+fn emit_signature_only_reasoning(
+    output_index: usize,
+    anthropic_index: &mut usize,
+    out: &mut Vec<ReducerEvent>,
+    reasoning_by_output_index: &mut std::collections::HashMap<usize, PendingReasoning>,
+    output_items_by_index: &mut std::collections::BTreeMap<usize, ResponsesInputItem>,
+) {
+    let Some(replay) = reasoning_by_output_index
+        .remove(&output_index)
+        .and_then(|pending| pending.replay())
+    else {
+        return;
+    };
+    let Some(signature) = encode_reasoning_signature(&replay) else {
+        return;
+    };
+    let index = *anthropic_index;
+    *anthropic_index += 1;
+    out.push(ReducerEvent::ThinkingStart { index });
+    out.push(ReducerEvent::ThinkingSignature { index, signature });
+    out.push(ReducerEvent::ThinkingStop { index });
+    output_items_by_index.insert(output_index, reasoning_input_item(replay));
+}
+
 pub fn finish_metadata_from_upstream(
     input: &[u8],
 ) -> Result<Option<FinishMetadata>, UpstreamStreamError> {
@@ -172,8 +253,10 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
         std::collections::BTreeMap::new();
     let mut item_id_to_output_index: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
+    let mut reasoning_by_output_index: std::collections::HashMap<usize, PendingReasoning> =
+        std::collections::HashMap::new();
     let mut anthropic_index = 0usize;
-    let mut thinking_index: Option<usize> = None;
+    let mut active_thinking: Option<ActiveThinking> = None;
     let mut saw_tool_use = false;
     let mut final_usage: Option<CodexUsage> = None;
     let mut response_id: Option<String> = None;
@@ -223,12 +306,6 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
                     },
                 );
             }
-        }
-    }
-
-    fn close_thinking(out: &mut Vec<ReducerEvent>, thinking_index: &mut Option<usize>) {
-        if let Some(index) = thinking_index.take() {
-            out.push(ReducerEvent::ThinkingStop { index });
         }
     }
 
@@ -318,6 +395,10 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
 
             let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
             if item_type == "reasoning" {
+                reasoning_by_output_index
+                    .entry(output_index)
+                    .or_default()
+                    .capture(item);
                 continue;
             }
             if item_type == "web_search_call" {
@@ -326,7 +407,12 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
             }
 
             if item_type == "message" {
-                close_thinking(&mut out, &mut thinking_index);
+                close_thinking(
+                    &mut out,
+                    &mut active_thinking,
+                    &mut reasoning_by_output_index,
+                    &mut output_items_by_index,
+                );
                 let idx = anthropic_index;
                 anthropic_index += 1;
                 if let Some(id) = item.get("id").and_then(|v| v.as_str()) {
@@ -344,7 +430,12 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
             }
 
             if item_type == "function_call" {
-                close_thinking(&mut out, &mut thinking_index);
+                close_thinking(
+                    &mut out,
+                    &mut active_thinking,
+                    &mut reasoning_by_output_index,
+                    &mut output_items_by_index,
+                );
                 saw_tool_use = true;
                 let idx = anthropic_index;
                 anthropic_index += 1;
@@ -384,9 +475,12 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
         }
 
         if t == "response.reasoning_summary_part.added" {
-            if let Some(index) = thinking_index {
+            let output_index = p.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+            if let Some(active) =
+                active_thinking.filter(|active| active.output_index == output_index)
+            {
                 out.push(ReducerEvent::ThinkingDelta {
-                    index,
+                    index: active.anthropic_index,
                     text: "\n\n".to_string(),
                 });
             }
@@ -394,25 +488,42 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
         }
 
         if t == "response.reasoning_summary_text.delta" {
+            let output_index = p.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
             let delta = p.get("delta").and_then(|v| v.as_str()).unwrap_or("");
             if delta.is_empty() {
                 continue;
             }
-            if thinking_index.is_none() {
+            if active_thinking.map(|active| active.output_index) != Some(output_index) {
+                close_thinking(
+                    &mut out,
+                    &mut active_thinking,
+                    &mut reasoning_by_output_index,
+                    &mut output_items_by_index,
+                );
                 let index = anthropic_index;
                 anthropic_index += 1;
-                thinking_index = Some(index);
+                active_thinking = Some(ActiveThinking {
+                    output_index,
+                    anthropic_index: index,
+                });
                 out.push(ReducerEvent::ThinkingStart { index });
             }
             out.push(ReducerEvent::ThinkingDelta {
-                index: thinking_index.unwrap(),
+                index: active_thinking
+                    .expect("thinking block was started")
+                    .anthropic_index,
                 text: delta.to_string(),
             });
             continue;
         }
 
         if t == "response.output_text.delta" {
-            close_thinking(&mut out, &mut thinking_index);
+            close_thinking(
+                &mut out,
+                &mut active_thinking,
+                &mut reasoning_by_output_index,
+                &mut output_items_by_index,
+            );
             let output_index = p
                 .get("output_index")
                 .and_then(|v| v.as_u64())
@@ -550,14 +661,39 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
             if let Some(item_val) = item
                 && item_val.get("type").and_then(|v| v.as_str()) == Some("reasoning")
             {
-                close_thinking(&mut out, &mut thinking_index);
+                reasoning_by_output_index
+                    .entry(output_index)
+                    .or_default()
+                    .capture(item_val);
+                let had_active_summary =
+                    active_thinking.is_some_and(|active| active.output_index == output_index);
+                close_thinking(
+                    &mut out,
+                    &mut active_thinking,
+                    &mut reasoning_by_output_index,
+                    &mut output_items_by_index,
+                );
+                if !had_active_summary {
+                    emit_signature_only_reasoning(
+                        output_index,
+                        &mut anthropic_index,
+                        &mut out,
+                        &mut reasoning_by_output_index,
+                        &mut output_items_by_index,
+                    );
+                }
                 continue;
             }
 
             if let Some(item_val) = item
                 && item_val.get("type").and_then(|v| v.as_str()) == Some("web_search_call")
             {
-                close_thinking(&mut out, &mut thinking_index);
+                close_thinking(
+                    &mut out,
+                    &mut active_thinking,
+                    &mut reasoning_by_output_index,
+                    &mut output_items_by_index,
+                );
                 let idx = anthropic_index;
                 anthropic_index += 1;
                 let result_index = anthropic_index;
@@ -673,7 +809,12 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
         });
     }
 
-    close_thinking(&mut out, &mut thinking_index);
+    close_thinking(
+        &mut out,
+        &mut active_thinking,
+        &mut reasoning_by_output_index,
+        &mut output_items_by_index,
+    );
 
     let stop_reason: StopReason = if incomplete {
         STOP_MAX_TOKENS
@@ -1575,5 +1716,64 @@ mod tests {
             })
             .collect();
         assert_eq!(deltas, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn reasoning_signature_precedes_stop_and_enters_continuation_transcript() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse(
+                "response.output_item.added",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"opaque"}
+                })
+            ),
+            sse(
+                "response.reasoning_summary_text.delta",
+                json!({"output_index":0,"summary_index":0,"delta":"plan"})
+            ),
+            sse(
+                "response.output_item.done",
+                json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","id":"rs_1","summary":[]}
+                })
+            ),
+            sse(
+                "response.completed",
+                json!({"response":{"id":"resp_1","usage":{}}})
+            ),
+        );
+        let events = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let signature_index = events
+            .iter()
+            .position(|event| matches!(event, ReducerEvent::ThinkingSignature { .. }))
+            .unwrap();
+        let stop_index = events
+            .iter()
+            .position(|event| matches!(event, ReducerEvent::ThinkingStop { .. }))
+            .unwrap();
+        assert!(signature_index < stop_index);
+
+        let ReducerEvent::ThinkingSignature { signature, .. } = &events[signature_index] else {
+            unreachable!();
+        };
+        let replay =
+            super::super::reasoning_signature::decode_reasoning_signature(signature).unwrap();
+        assert_eq!(replay.id, "rs_1");
+        assert_eq!(replay.encrypted_content, "opaque");
+
+        let ReducerEvent::Finish { output_items, .. } = events.last().unwrap() else {
+            panic!("expected Finish");
+        };
+        assert!(matches!(
+            output_items.as_slice(),
+            [ResponsesInputItem::Reasoning {
+                id,
+                encrypted_content,
+                ..
+            }] if id == "rs_1" && encrypted_content == "opaque"
+        ));
     }
 }

--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -10,6 +10,7 @@ use crate::providers::translate_shared::{
 };
 
 use super::read_rewrite::{ReadOffsetRewrite, read_offset_rewrite};
+use super::reasoning_signature::decode_reasoning_signature;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -151,6 +152,12 @@ pub enum ResponsesInputItem {
         #[serde(default)]
         call_id: String,
         output: String,
+    },
+    #[serde(rename = "reasoning")]
+    Reasoning {
+        id: String,
+        summary: Vec<Value>,
+        encrypted_content: String,
     },
 }
 
@@ -740,6 +747,19 @@ fn build_input(req: &MessagesRequest) -> Vec<ResponsesInputItem> {
                                 call_id: id.clone(),
                                 name: name.clone(),
                                 arguments: args,
+                            });
+                        }
+                        ContentBlock::Thinking { signature, .. } => {
+                            let Some(replay) =
+                                signature.as_deref().and_then(decode_reasoning_signature)
+                            else {
+                                continue;
+                            };
+                            flush_text(&mut out, &mut text_parts);
+                            out.push(ResponsesInputItem::Reasoning {
+                                id: replay.id,
+                                summary: Vec::new(),
+                                encrypted_content: replay.encrypted_content,
                             });
                         }
                         _ => {}
@@ -1665,5 +1685,48 @@ mod tests {
         ] {
             assert!(keys.contains(*key), "missing key: {key}");
         }
+    }
+
+    #[test]
+    fn assistant_thinking_signature_replays_codex_reasoning_item() {
+        let replay = super::super::reasoning_signature::ReasoningReplay {
+            id: "rs_1".to_string(),
+            encrypted_content: "opaque".to_string(),
+        };
+        let signature =
+            super::super::reasoning_signature::encode_reasoning_signature(&replay).unwrap();
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.5",
+            "messages": [
+                {"role":"user","content":"start"},
+                {"role":"assistant","content":[
+                    {"type":"thinking","thinking":"visible summary","signature":signature},
+                    {"type":"text","text":"done"}
+                ]},
+                {"role":"user","content":"continue"}
+            ]
+        }))
+        .unwrap();
+        let out = translate_request(&req, opts()).unwrap();
+        let reasoning_index = out
+            .input
+            .iter()
+            .position(|item| matches!(item, ResponsesInputItem::Reasoning { .. }))
+            .unwrap();
+        let ResponsesInputItem::Reasoning {
+            id,
+            summary,
+            encrypted_content,
+        } = &out.input[reasoning_index]
+        else {
+            unreachable!();
+        };
+        assert_eq!(id, "rs_1");
+        assert!(summary.is_empty());
+        assert_eq!(encrypted_content, "opaque");
+        assert!(matches!(
+            out.input.get(reasoning_index + 1),
+            Some(ResponsesInputItem::Message { role, .. }) if role == "assistant"
+        ));
     }
 }

--- a/src/providers/codex/translate/stream.rs
+++ b/src/providers/codex/translate/stream.rs
@@ -100,6 +100,19 @@ fn emit_content_event(
             );
             true
         }
+        ReducerEvent::ThinkingSignature { index, signature } => {
+            emit(
+                out,
+                traffic,
+                "content_block_delta",
+                &serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {"type": "signature_delta", "signature": signature}
+                }),
+            );
+            true
+        }
         ReducerEvent::ThinkingStop { index } => {
             open_blocks.remove(index);
             emit(
@@ -221,6 +234,7 @@ fn is_content_event(event: &ReducerEvent) -> bool {
         event,
         ReducerEvent::ThinkingStart { .. }
             | ReducerEvent::ThinkingDelta { .. }
+            | ReducerEvent::ThinkingSignature { .. }
             | ReducerEvent::ThinkingStop { .. }
             | ReducerEvent::TextStart { .. }
             | ReducerEvent::TextDelta { .. }
@@ -686,5 +700,47 @@ mod tests {
         assert!(!out.contains("\"type\":\"thinking\""));
         assert!(!out.contains("\"type\":\"thinking_delta\""));
         assert!(out.contains("event: message_stop"));
+    }
+
+    #[test]
+    fn stream_emits_signature_delta_before_thinking_stop() {
+        let upstream = format!(
+            "{}{}{}{}",
+            sse_event(
+                "response.output_item.added",
+                serde_json::json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","id":"rs_1","encrypted_content":"opaque"}
+                })
+            ),
+            sse_event(
+                "response.reasoning_summary_text.delta",
+                serde_json::json!({"output_index":0,"delta":"plan"})
+            ),
+            sse_event(
+                "response.output_item.done",
+                serde_json::json!({
+                    "output_index":0,
+                    "item":{"type":"reasoning","id":"rs_1"}
+                })
+            ),
+            sse_event(
+                "response.completed",
+                serde_json::json!({"response":{"id":"resp_1","usage":{}}})
+            ),
+        );
+        let out = String::from_utf8(
+            translate_stream_bytes(upstream.as_bytes(), "msg_1", "gpt-5.5").unwrap(),
+        )
+        .unwrap();
+        let thinking_delta = out.find(r#""type":"thinking_delta""#).unwrap();
+        let signature_delta = out.find(r#""type":"signature_delta""#).unwrap();
+        let thinking_stop = out[signature_delta..]
+            .find("event: content_block_stop")
+            .map(|offset| signature_delta + offset)
+            .unwrap();
+        assert!(thinking_delta < signature_delta);
+        assert!(signature_delta < thinking_stop);
+        assert!(out.contains("ccp:codex:v1:"));
     }
 }

--- a/src/providers/kimi/translate/request.rs
+++ b/src/providers/kimi/translate/request.rs
@@ -433,7 +433,7 @@ fn push_assistant_message(out: &mut Vec<KimiMessage>, blocks: &[ContentBlock]) {
                     text_parts.push(text.clone());
                 }
             }
-            ContentBlock::Thinking { thinking } => {
+            ContentBlock::Thinking { thinking, .. } => {
                 if !thinking.is_empty() {
                     thinking_parts.push(thinking.clone());
                 }

--- a/src/providers/translate_shared.rs
+++ b/src/providers/translate_shared.rs
@@ -22,6 +22,7 @@ pub enum ContentBlock {
     },
     Thinking {
         thinking: String,
+        signature: Option<String>,
     },
 }
 
@@ -202,7 +203,14 @@ fn parse_content_block(value: &Value, missing_tool_input: Value) -> Option<Conte
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            Some(ContentBlock::Thinking { thinking })
+            let signature = value
+                .get("signature")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            Some(ContentBlock::Thinking {
+                thinking,
+                signature,
+            })
         }
         _ => None,
     }


### PR DESCRIPTION
## Summary

CCP already requests `reasoning.encrypted_content` from the Codex Responses API, but the Claude translation previously discarded it:

- outgoing Claude thinking blocks received an empty `signature`;
- assistant thinking blocks were ignored when the next Claude request was translated back into Responses input.

As a result, encrypted reasoning could not survive stateless multi-turn replay when `previous_response_id` was disabled.

This PR round-trips the Codex reasoning item through a CCP-owned, namespaced Claude thinking signature:

```text
Codex { id, encrypted_content }
  -> Claude thinking.signature
  -> next Codex reasoning input item
```

The encrypted payload is preserved byte-for-byte. CCP does not decrypt or interpret it.

## Protocol rationale

OpenAI documents that reasoning items should be included in subsequent input when application code manages conversation history manually. Requesting `reasoning.encrypted_content` makes the opaque reasoning payload available for this purpose:

- [OpenAI Responses API reasoning documentation](https://platform.openai.com/docs/api-reference/responses-streaming/response/reasoning_summary_part/added)
- [Codex requests `reasoning.encrypted_content`](https://github.com/openai/codex/blob/b24aa20107f365a1d0f06de9e0b28df5c516c7dd/codex-rs/core/src/client.rs#L864-L872)
- [Codex reasoning item representation](https://github.com/openai/codex/blob/b24aa20107f365a1d0f06de9e0b28df5c516c7dd/codex-rs/protocol/src/models.rs#L971-L980)

Claude's extended-thinking protocol provides an opaque `signature` field. During streaming, Anthropic specifies that `signature_delta` is emitted immediately before `content_block_stop`:

- [Claude extended thinking documentation](https://platform.claude.com/docs/en/build-with-claude/extended-thinking)

This PR uses that field only as a transport for a namespaced CCP envelope. Foreign, malformed, or oversized signatures are ignored.

## Prior art

Other Codex-to-Claude adapters use the same general round-trip pattern.

CLIProxyAPI translates Claude thinking signatures into Codex `encrypted_content`, requests encrypted reasoning from Responses, and maps it back into Claude thinking blocks:

- [Claude signature -> Codex encrypted reasoning](https://github.com/router-for-me/CLIProxyAPI/blob/06a4e46f693b4abbd0031dc7e042df3c51771feb/internal/translator/codex/claude/codex_claude_request.go#L154-L157)
- [Requesting `reasoning.encrypted_content`](https://github.com/router-for-me/CLIProxyAPI/blob/06a4e46f693b4abbd0031dc7e042df3c51771feb/internal/translator/codex/claude/codex_claude_request.go#L341-L348)
- [Codex encrypted reasoning -> Claude signature](https://github.com/router-for-me/CLIProxyAPI/blob/06a4e46f693b4abbd0031dc7e042df3c51771feb/internal/translator/codex/claude/codex_claude_response.go#L179-L181)
- [Handling summary and signature-only thinking blocks](https://github.com/router-for-me/CLIProxyAPI/blob/06a4e46f693b4abbd0031dc7e042df3c51771feb/internal/translator/codex/claude/codex_claude_response.go#L257-L265)

The pi-mono multi-provider adapter independently stores complete Responses reasoning items in `thinkingSignature` and restores them on the next request:

- [Restoring the reasoning item](https://github.com/badlogic/pi-mono/blob/0e6909f050eeb15e8f6c05185511f3788357ddb3/packages/ai/src/api/openai-responses-shared.ts#L179-L184)
- [Saving it in `thinkingSignature`](https://github.com/badlogic/pi-mono/blob/0e6909f050eeb15e8f6c05185511f3788357ddb3/packages/ai/src/api/openai-responses-shared.ts#L537-L542)
- [Requesting encrypted reasoning](https://github.com/badlogic/pi-mono/blob/0e6909f050eeb15e8f6c05185511f3788357ddb3/packages/ai/src/api/openai-codex-responses.ts#L492-L500)

## Implementation

- Add a versioned `ccp:codex:v1:` signature envelope containing the reasoning item ID and encrypted payload.
- Capture `id` and `encrypted_content` from Responses streaming events.
- Emit `signature_delta` before `content_block_stop`.
- Support signature-only thinking blocks when Codex returns encrypted reasoning without a visible summary.
- Restore CCP-owned signatures as Responses `reasoning` items in their original transcript position.
- Preserve encrypted content exactly without decoding or modifying it.
- Ignore foreign, malformed, and oversized signatures.
- Support both buffered and streaming translation paths.
- Include signed thinking blocks in token estimation and request summaries.

## Validation

- `cargo test --all-targets`: **559 passed, 0 failed**
- `rustfmt 1.96 --check`: passed
- Tested against the real Codex API through an isolated CCP instance on port `18766`.
- `CCP_CODEX_PREVIOUS_RESPONSE_ID=0` was used to force full transcript replay.
- The second upstream request contained exactly one restored reasoning item.
- Its ID and encrypted payload matched the first response byte-for-byte.
- The two-turn request completed successfully.
- `/v1/messages/count_tokens` accepted the signed transcript.
- The active proxy on port `18765` was not touched.

## Scope

This PR only changes encrypted-reasoning round-trip behavior. It does not change HTTP transport, `previous_response_id` handling, Docker configuration, authentication, or diagnostic logging.
