### PR TITLE
fix(grok): stabilize prefix cache and long-stream timing

### DIFF
--- a/src/providers/grok/client.rs
+++ b/src/providers/grok/client.rs
@@ -12,6 +12,14 @@ use crate::traffic::TrafficCapture;
 const DEFAULT_BASE_URL: &str = "https://cli-chat-proxy.grok.com/v1";
 const MAX_BUFFERED_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Per-request routing / affinity headers for Grok (matches official CLI).
+#[derive(Debug, Clone, Default)]
+pub struct GrokRequestMeta {
+    pub req_id: Option<String>,
+    pub session_id: Option<String>,
+    pub session_seq: Option<u64>,
+}
+
 pub struct GrokClient {
     client: Arc<reqwest::Client>,
     auth: Arc<GrokAuthManager<crate::auth::FileAuthStore<StoredAuth>>>,
@@ -65,11 +73,19 @@ impl GrokResponse {
 
 impl GrokClient {
     pub fn new(base_url: String, client_version: String) -> anyhow::Result<Self> {
+        // No whole-request `.timeout(...)`: long multi-turn / tool streams routinely
+        // exceed 120s. Liveness is left to TCP/H2 keepalive + upstream idle behaviour
+        // (mirrors grok-build's sampling client).
         let client = Arc::new(
             reqwest::Client::builder()
                 .redirect(reqwest::redirect::Policy::none())
                 .connect_timeout(Duration::from_secs(10))
-                .timeout(Duration::from_secs(120))
+                .pool_max_idle_per_host(2)
+                .pool_idle_timeout(Duration::from_secs(90))
+                .tcp_nodelay(true)
+                .http2_keep_alive_interval(Duration::from_secs(15))
+                .http2_keep_alive_timeout(Duration::from_secs(5))
+                .http2_keep_alive_while_idle(true)
                 .build()?,
         );
         let auth = Arc::new(GrokAuthManager::new(file_store())?);
@@ -98,6 +114,7 @@ impl GrokClient {
     pub async fn post(
         &self,
         body: &GrokResponsesRequest,
+        meta: &GrokRequestMeta,
         traffic: Option<Arc<TrafficCapture>>,
     ) -> Result<GrokResponse, GrokError> {
         if let Some(capture) = traffic.as_ref() {
@@ -105,7 +122,14 @@ impl GrokClient {
             capture.write_json("020-upstream-request", &body_value);
             capture.write_json("021-upstream-request-metadata", &serde_json::json!({
                 "method": "POST", "url": safe_url(&self.url), "provider": "grok", "transport": "http",
-                "headers": {"accept":"text/event-stream", "content-type":"application/json", "authorization":"[redacted]", "x-xai-token-auth":"[redacted]"},
+                "headers": {
+                    "accept":"text/event-stream",
+                    "content-type":"application/json",
+                    "authorization":"[redacted]",
+                    "x-xai-token-auth":"[redacted]",
+                    "x-grok-session-id": meta.session_id.as_deref().unwrap_or(""),
+                    "x-grok-req-id": meta.req_id.as_deref().unwrap_or(""),
+                },
                 "body_bytes": serde_json::to_vec(body).map(|v| v.len()).unwrap_or(0),
             }));
         }
@@ -117,7 +141,7 @@ impl GrokClient {
             }
         };
         let response = self
-            .attempt(&auth.access, body, 1, traffic.as_deref())
+            .attempt(&auth.access, body, meta, 1, traffic.as_deref())
             .await?;
         if response.status() == StatusCode::UNAUTHORIZED {
             let refreshed = self
@@ -129,7 +153,7 @@ impl GrokClient {
                     auth_error(error)
                 })?;
             let replay = self
-                .attempt(&refreshed.access, body, 2, traffic.as_deref())
+                .attempt(&refreshed.access, body, meta, 2, traffic.as_deref())
                 .await?;
             if replay.status() == StatusCode::UNAUTHORIZED {
                 capture_failure(traffic.as_deref(), "auth", "unauthorized", 2);
@@ -157,30 +181,42 @@ impl GrokClient {
         &self,
         access: &str,
         body: &GrokResponsesRequest,
+        meta: &GrokRequestMeta,
         attempt: u8,
         traffic: Option<&TrafficCapture>,
     ) -> Result<reqwest::Response, GrokError> {
         let started = Instant::now();
-        let response = self
+        let mut builder = self
             .client
             .post(&self.url)
             .header("accept", "text/event-stream")
             .header("content-type", "application/json")
             .header("authorization", format!("Bearer {access}"))
             .header("x-xai-token-auth", "xai-grok-cli")
-            .header("x-grok-client-identifier", "grok-shell")
+            .header("x-grok-client-identifier", "claude-code-proxy")
             .header("x-grok-client-version", &self.client_version)
-            .json(body)
-            .send()
-            .await
-            .map_err(|_| {
-                capture_failure(traffic, "transport", "transport", attempt);
-                GrokError {
-                    status: StatusCode::BAD_GATEWAY,
-                    retry_after: None,
-                    message: "Grok upstream request failed".into(),
-                }
-            })?;
+            .header("x-grok-agent-id", "claude-code-proxy");
+
+        if let Some(req_id) = meta.req_id.as_deref().filter(|v| !v.is_empty()) {
+            builder = builder.header("x-grok-req-id", req_id);
+        }
+        if let Some(session_id) = meta.session_id.as_deref().filter(|v| !v.is_empty()) {
+            builder = builder
+                .header("x-grok-session-id", session_id)
+                .header("x-grok-conv-id", session_id);
+        }
+        if let Some(seq) = meta.session_seq {
+            builder = builder.header("x-grok-turn-idx", seq.to_string());
+        }
+
+        let response = builder.json(body).send().await.map_err(|_| {
+            capture_failure(traffic, "transport", "transport", attempt);
+            GrokError {
+                status: StatusCode::BAD_GATEWAY,
+                retry_after: None,
+                message: "Grok upstream request failed".into(),
+            }
+        })?;
         let status = response.status();
         if let Some(capture) = traffic {
             capture.write_json("022-upstream-attempt", &serde_json::json!({"attempt":attempt,"status":status.as_u16(),"elapsed_ms":started.elapsed().as_millis(),"headers":safe_headers(response.headers())}));

--- a/src/providers/grok/count_tokens.rs
+++ b/src/providers/grok/count_tokens.rs
@@ -49,6 +49,11 @@ fn count_input_item(item: &GrokInputItem) -> u64 {
             name, arguments, ..
         } => approx_token_count(name) + approx_token_count(arguments),
         GrokInputItem::FunctionCallOutput { output, .. } => approx_token_count(output),
+        GrokInputItem::Reasoning {
+            id,
+            encrypted_content,
+            ..
+        } => approx_token_count(id) + approx_token_count(encrypted_content),
     }
 }
 

--- a/src/providers/grok/mod.rs
+++ b/src/providers/grok/mod.rs
@@ -99,7 +99,16 @@ impl Provider for GrokProvider {
             monitor.model_resolved(&ctx.req_id, &resolved);
             monitor.upstream_started(&ctx.req_id);
         }
-        let upstream = match self.client.post(&translated, ctx.traffic.clone()).await {
+        let meta = client::GrokRequestMeta {
+            req_id: Some(ctx.req_id.clone()),
+            session_id: ctx.session_id.clone(),
+            session_seq: ctx.session_seq,
+        };
+        let upstream = match self
+            .client
+            .post(&translated, &meta, ctx.traffic.clone())
+            .await
+        {
             Ok(response) => response,
             Err(error) => return map_error(error),
         };

--- a/src/providers/grok/translate/accumulate.rs
+++ b/src/providers/grok/translate/accumulate.rs
@@ -80,6 +80,14 @@ pub fn accumulate_response_with_traffic(
                     ));
                 }
             }
+            ReducerEvent::ThinkingSignature(index, signature) => {
+                if let Some(block) = block_positions
+                    .get(&index)
+                    .and_then(|position| blocks.get_mut(*position))
+                {
+                    block["signature"] = Value::String(signature);
+                }
+            }
             ReducerEvent::TextStart(index) => {
                 block_positions.insert(index, blocks.len());
                 blocks.push(serde_json::json!({"type":"text","text":""}))

--- a/src/providers/grok/translate/mod.rs
+++ b/src/providers/grok/translate/mod.rs
@@ -1,5 +1,6 @@
 pub mod accumulate;
 pub mod model_allowlist;
+pub mod reasoning_signature;
 pub mod reducer;
 pub mod request;
 pub mod stream;

--- a/src/providers/grok/translate/reasoning_signature.rs
+++ b/src/providers/grok/translate/reasoning_signature.rs
@@ -1,0 +1,137 @@
+use base64::Engine;
+use serde_json::Value;
+
+const PREFIX: &str = "ccp:grok:v1:";
+const MAX_ID_BYTES: usize = 4 * 1024;
+const MAX_ENCRYPTED_CONTENT_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReasoningReplay {
+    pub id: String,
+    pub encrypted_content: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PendingReasoning {
+    id: Option<String>,
+    encrypted_content: Option<String>,
+}
+
+impl PendingReasoning {
+    pub fn capture(&mut self, item: &Value) {
+        if let Some(id) = non_empty_string(item.get("id")) {
+            self.id = Some(id.to_string());
+        }
+        if let Some(encrypted_content) = non_empty_string(item.get("encrypted_content")) {
+            self.encrypted_content = Some(encrypted_content.to_string());
+        }
+    }
+
+    pub fn replay(&self) -> Option<ReasoningReplay> {
+        Some(ReasoningReplay {
+            id: self.id.clone()?,
+            encrypted_content: self.encrypted_content.clone()?,
+        })
+    }
+}
+
+pub fn encode_reasoning_signature(replay: &ReasoningReplay) -> Option<String> {
+    if replay.id.is_empty()
+        || replay.id.len() > MAX_ID_BYTES
+        || replay.encrypted_content.is_empty()
+        || replay.encrypted_content.len() > MAX_ENCRYPTED_CONTENT_BYTES
+    {
+        return None;
+    }
+    let encoded_id = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(replay.id.as_bytes());
+    Some(format!("{PREFIX}{encoded_id}:{}", replay.encrypted_content))
+}
+
+pub fn decode_reasoning_signature(signature: &str) -> Option<ReasoningReplay> {
+    let payload = signature.strip_prefix(PREFIX)?;
+    if payload.is_empty() || payload.len() > max_payload_len() {
+        return None;
+    }
+    let (encoded_id, encrypted_content) = payload.split_once(':')?;
+    if encoded_id.is_empty()
+        || encoded_id.len() > encoded_id_len_limit()
+        || encrypted_content.is_empty()
+        || encrypted_content.len() > MAX_ENCRYPTED_CONTENT_BYTES
+    {
+        return None;
+    }
+    let id = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded_id)
+        .ok()?;
+    if id.is_empty() || id.len() > MAX_ID_BYTES {
+        return None;
+    }
+    Some(ReasoningReplay {
+        id: String::from_utf8(id).ok()?,
+        encrypted_content: encrypted_content.to_string(),
+    })
+}
+
+fn encoded_id_len_limit() -> usize {
+    (MAX_ID_BYTES + 2) / 3 * 4
+}
+
+fn max_payload_len() -> usize {
+    encoded_id_len_limit() + 1 + MAX_ENCRYPTED_CONTENT_BYTES
+}
+
+fn non_empty_string(value: Option<&Value>) -> Option<&str> {
+    value?.as_str().filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn signature_round_trip_preserves_reasoning_identity() {
+        let replay = ReasoningReplay {
+            id: "rs_abc".to_string(),
+            encrypted_content: "gAAAAopaque".to_string(),
+        };
+        let signature = encode_reasoning_signature(&replay).unwrap();
+        assert!(signature.starts_with(PREFIX));
+        assert!(signature.ends_with(":gAAAAopaque"));
+        assert_eq!(decode_reasoning_signature(&signature), Some(replay));
+    }
+
+    #[test]
+    fn foreign_and_malformed_signatures_are_ignored() {
+        assert_eq!(decode_reasoning_signature("anthropic-signature"), None);
+        assert_eq!(decode_reasoning_signature("ccp:codex:v1:not-base64"), None);
+        assert_eq!(decode_reasoning_signature("ccp:grok:v1:"), None);
+    }
+
+    #[test]
+    fn pending_reasoning_keeps_early_metadata_when_done_omits_it() {
+        let mut pending = PendingReasoning::default();
+        pending.capture(&json!({
+            "id": "rs_1",
+            "encrypted_content": "early"
+        }));
+        pending.capture(&json!({ "id": "rs_1" }));
+        assert_eq!(
+            pending.replay(),
+            Some(ReasoningReplay {
+                id: "rs_1".to_string(),
+                encrypted_content: "early".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn oversized_signature_is_ignored_without_decoding() {
+        let signature = format!(
+            "{PREFIX}{}:{}",
+            "A".repeat(encoded_id_len_limit() + 1),
+            "x"
+        );
+        assert_eq!(decode_reasoning_signature(&signature), None);
+    }
+}

--- a/src/providers/grok/translate/reducer.rs
+++ b/src/providers/grok/translate/reducer.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
+use super::reasoning_signature::{
+    PendingReasoning, encode_reasoning_signature,
+};
 use super::stream::SseDecoder;
 
 const MAX_TOOL_ARGUMENT_BYTES: usize = 1024 * 1024;
@@ -11,6 +14,8 @@ const MAX_INCOMPLETE_TOOL_CALLS: usize = 128;
 pub enum ReducerEvent {
     ThinkingStart(usize),
     ThinkingDelta(usize, String),
+    /// Opaque signature so Claude can round-trip encrypted reasoning next turn.
+    ThinkingSignature(usize, String),
     ThinkingStop(usize),
     TextStart(usize),
     TextDelta(usize, String),
@@ -38,12 +43,15 @@ pub enum ReducerEvent {
 #[derive(Default)]
 pub struct Reducer {
     next_index: usize,
-    active: Option<(String, usize)>,
+    /// Active content channel: ("thinking"|"text", anthropic_index, optional output_index)
+    active: Option<(String, usize, Option<usize>)>,
     calls: HashMap<String, (usize, String)>,
     item_calls: HashMap<String, String>,
     tool_args: HashMap<String, String>,
     completed_arguments: HashMap<String, bool>,
     hosted_calls: HashMap<String, (String, String)>,
+    /// Pending reasoning items keyed by Responses output_index.
+    reasoning_by_output_index: HashMap<usize, PendingReasoning>,
     web_search_requests: u64,
     x_search_requests: u64,
     saw_tool: bool,
@@ -64,14 +72,17 @@ impl Reducer {
             "response.reasoning_summary_part.added"
             | "response.reasoning_summary_part.done"
             | "response.content_part.added" => Ok(vec![]),
-            "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => self
-                .delta(
+            "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+                let output_index = value.get("output_index").and_then(Value::as_u64).map(|v| v as usize);
+                self.delta(
                     "thinking",
                     value
                         .get("delta")
                         .and_then(Value::as_str)
                         .ok_or_else(|| anyhow::anyhow!("reasoning delta is invalid"))?,
-                ),
+                    output_index,
+                )
+            }
             "response.custom_tool_call_input.delta" => {
                 let id = value
                     .get("item_id")
@@ -96,7 +107,7 @@ impl Reducer {
             | "response.web_search_call.searching"
             | "response.web_search_call.completed" => Ok(vec![]),
             "response.output_text.annotation.added" => {
-                let Some((kind, index)) = self.active.as_ref() else {
+                let Some((kind, index, _)) = self.active.as_ref() else {
                     return Ok(vec![]);
                 };
                 let Some(annotation) = value.get("annotation") else {
@@ -116,12 +127,26 @@ impl Reducer {
                     .get("delta")
                     .and_then(Value::as_str)
                     .ok_or_else(|| anyhow::anyhow!("text delta is invalid"))?,
+                value.get("output_index").and_then(Value::as_u64).map(|v| v as usize),
             ),
             "response.output_item.added" => {
                 let item = value
                     .get("item")
                     .and_then(Value::as_object)
                     .ok_or_else(|| anyhow::anyhow!("output item is invalid"))?;
+                if item.get("type").and_then(Value::as_str) == Some("reasoning") {
+                    let output_index = value
+                        .get("output_index")
+                        .and_then(Value::as_u64)
+                        .map(|v| v as usize)
+                        .unwrap_or(0);
+                    let pending = self
+                        .reasoning_by_output_index
+                        .entry(output_index)
+                        .or_default();
+                    pending.capture(&Value::Object(item.clone()));
+                    return Ok(vec![]);
+                }
                 if item.get("type").and_then(Value::as_str) == Some("custom_tool_call") {
                     let id = item
                         .get("id")
@@ -239,9 +264,9 @@ impl Reducer {
                 Ok(output)
             }
             "response.output_text.done" => self.close_kind("text"),
-            "response.reasoning_summary_text.done" | "response.reasoning_text.done" => {
-                self.close_kind("thinking")
-            }
+            // Keep thinking open until `response.output_item.done` for the reasoning
+            // item so we can attach `encrypted_content` to the signature.
+            "response.reasoning_summary_text.done" | "response.reasoning_text.done" => Ok(vec![]),
             "response.content_part.done" => Ok(vec![]),
             "response.output_item.done" => {
                 let item = value
@@ -249,6 +274,52 @@ impl Reducer {
                     .and_then(Value::as_object)
                     .ok_or_else(|| anyhow::anyhow!("completed output item is invalid"))?;
                 match item.get("type").and_then(Value::as_str) {
+                    Some("reasoning") => {
+                        let output_index = value
+                            .get("output_index")
+                            .and_then(Value::as_u64)
+                            .map(|v| v as usize)
+                            .unwrap_or(0);
+                        let pending = self
+                            .reasoning_by_output_index
+                            .entry(output_index)
+                            .or_default();
+                        pending.capture(&Value::Object(item.clone()));
+                        // Close open thinking for this reasoning item (with signature),
+                        // or emit a signature-only block when no text deltas arrived.
+                        let thinking_open = self
+                            .active
+                            .as_ref()
+                            .is_some_and(|(kind, _, stored)| {
+                                kind == "thinking"
+                                    && (*stored == Some(output_index) || stored.is_none())
+                            });
+                        if thinking_open {
+                            // Ensure the active channel is linked to this output_index
+                            // so close_active finds the encrypted blob.
+                            if let Some((_, _, stored)) = self.active.as_mut() {
+                                *stored = Some(output_index);
+                            }
+                            return self.close_kind("thinking");
+                        }
+                        let Some(replay) = self
+                            .reasoning_by_output_index
+                            .remove(&output_index)
+                            .and_then(|pending| pending.replay())
+                        else {
+                            return Ok(vec![]);
+                        };
+                        let Some(signature) = encode_reasoning_signature(&replay) else {
+                            return Ok(vec![]);
+                        };
+                        let index = self.next_index;
+                        self.next_index += 1;
+                        Ok(vec![
+                            ReducerEvent::ThinkingStart(index),
+                            ReducerEvent::ThinkingSignature(index, signature),
+                            ReducerEvent::ThinkingStop(index),
+                        ])
+                    }
                     Some("web_search_call") => {
                         let id = item
                             .get("id")
@@ -366,22 +437,32 @@ impl Reducer {
             _ => anyhow::bail!("unsupported Grok stream event: {typ}"),
         }
     }
-    fn delta(&mut self, kind: &str, delta: &str) -> anyhow::Result<Vec<ReducerEvent>> {
+    fn delta(
+        &mut self,
+        kind: &str,
+        delta: &str,
+        output_index: Option<usize>,
+    ) -> anyhow::Result<Vec<ReducerEvent>> {
         let mut out = Vec::new();
         if self
             .active
             .as_ref()
-            .is_none_or(|(active, _)| active != kind)
+            .is_none_or(|(active, _, _)| active != kind)
         {
             out.extend(self.close_active()?);
             let index = self.next_index;
             self.next_index += 1;
-            self.active = Some((kind.into(), index));
+            self.active = Some((kind.into(), index, output_index));
             out.push(if kind == "thinking" {
                 ReducerEvent::ThinkingStart(index)
             } else {
                 ReducerEvent::TextStart(index)
             });
+        } else if let Some((_, _, stored)) = self.active.as_mut()
+            && stored.is_none()
+            && let Some(output_index) = output_index
+        {
+            *stored = Some(output_index);
         }
         let index = self.active.as_ref().unwrap().1;
         out.push(if kind == "thinking" {
@@ -393,8 +474,31 @@ impl Reducer {
     }
     fn close_active(&mut self) -> anyhow::Result<Vec<ReducerEvent>> {
         Ok(match self.active.take() {
-            Some((kind, index)) if kind == "thinking" => vec![ReducerEvent::ThinkingStop(index)],
-            Some((_, index)) => vec![ReducerEvent::TextStop(index)],
+            Some((kind, index, output_index)) if kind == "thinking" => {
+                let mut out = Vec::new();
+                let replay = output_index
+                    .and_then(|output_index| self.reasoning_by_output_index.remove(&output_index))
+                    .and_then(|pending| pending.replay())
+                    .or_else(|| {
+                        // Fallback when stream deltas omit output_index: take the only pending blob.
+                        if self.reasoning_by_output_index.len() == 1 {
+                            self.reasoning_by_output_index
+                                .drain()
+                                .next()
+                                .and_then(|(_, pending)| pending.replay())
+                        } else {
+                            None
+                        }
+                    });
+                if let Some(replay) = replay
+                    && let Some(signature) = encode_reasoning_signature(&replay)
+                {
+                    out.push(ReducerEvent::ThinkingSignature(index, signature));
+                }
+                out.push(ReducerEvent::ThinkingStop(index));
+                out
+            }
+            Some((_, index, _)) => vec![ReducerEvent::TextStop(index)],
             None => vec![],
         })
     }
@@ -402,7 +506,7 @@ impl Reducer {
         if self
             .active
             .as_ref()
-            .is_some_and(|(active, _)| active == kind)
+            .is_some_and(|(active, _, _)| active == kind)
         {
             self.close_active()
         } else {
@@ -464,6 +568,38 @@ mod tests {
             ReducerEvent::ThinkingDelta(0, delta) if delta == "think"
         ));
         assert!(matches!(events.last(), Some(ReducerEvent::Finish { .. })));
+    }
+
+    #[test]
+    fn grok_reducer_emits_reasoning_signature_for_round_trip() {
+        let input = concat!(
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_1"}}"#,
+            "\n\n",
+            r#"data: {"type":"response.reasoning_text.delta","output_index":0,"delta":"think"}"#,
+            "\n\n",
+            r#"data: {"type":"response.reasoning_text.done","output_index":0}"#,
+            "\n\n",
+            r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs_1","encrypted_content":"opaque"}}"#,
+            "\n\n",
+            r#"data: {"type":"response.output_text.delta","delta":"answer"}"#,
+            "\n\n",
+            r#"data: {"type":"response.output_text.done"}"#,
+            "\n\n",
+            r#"data: {"type":"response.completed","response":{"usage":{"input_tokens":4,"output_tokens":2}}}"#,
+            "\n\n",
+        );
+        let events = reduce_upstream_bytes(input.as_bytes()).unwrap();
+        let signature = events.iter().find_map(|event| match event {
+            ReducerEvent::ThinkingSignature(0, signature) => Some(signature.as_str()),
+            _ => None,
+        });
+        assert!(signature.is_some_and(|s| s.starts_with("ccp:grok:v1:")));
+        let decoded = super::super::reasoning_signature::decode_reasoning_signature(
+            signature.unwrap(),
+        )
+        .unwrap();
+        assert_eq!(decoded.id, "rs_1");
+        assert_eq!(decoded.encrypted_content, "opaque");
     }
 
     #[test]

--- a/src/providers/grok/translate/request.rs
+++ b/src/providers/grok/translate/request.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use serde::Serialize;
 use serde_json::Value;
 
+use super::reasoning_signature::decode_reasoning_signature;
 use crate::anthropic::schema::{Message, MessagesRequest};
 
 #[derive(Debug, Clone, Serialize)]
@@ -15,6 +16,8 @@ pub struct GrokResponsesRequest {
     pub tools: Option<Vec<GrokTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<GrokToolChoice>,
+    /// Omitted when false so the wire matches official CLI (store unset).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub store: bool,
     pub stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,6 +40,15 @@ pub enum GrokInputItem {
     },
     #[serde(rename = "function_call_output")]
     FunctionCallOutput { call_id: String, output: String },
+    /// Replay of a prior Responses reasoning item (encrypted blob + id).
+    /// Required for prefix/KV-cache hits on multi-turn reasoning models.
+    #[serde(rename = "reasoning")]
+    Reasoning {
+        id: String,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        summary: Vec<Value>,
+        encrypted_content: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -110,42 +122,12 @@ pub fn translate_request(
     model: String,
 ) -> anyhow::Result<GrokResponsesRequest> {
     reject_unknown_top_level(req)?;
-    let mut instructions = parse_system(req.extra.get("system"))?;
-    let mut tools = parse_tools(req.extra.get("tools"))?;
-    let hosted_web_search = tools
-        .as_ref()
-        .is_some_and(|tools| tools.iter().any(|tool| tool.kind == "web_search"));
-    let dedicated_x_search = tools
-        .as_ref()
-        .is_some_and(|tools| tools.iter().any(|tool| tool.kind == "x_search"));
-    let x_search_intent = requests_x_search(req);
-    let force_x_search = dedicated_x_search || x_search_intent;
-    let force_web_search = !force_x_search && hosted_web_search && requests_web_search(req);
-    if force_x_search {
-        tools = Some(vec![GrokTool::hosted("x_search")]);
-    } else if force_web_search {
-        tools = Some(vec![GrokTool::hosted("web_search")]);
-    } else {
-        let tools = tools.get_or_insert_default();
-        if !tools.iter().any(|tool| tool.kind == "x_search") {
-            tools.push(GrokTool::hosted("x_search"));
-        }
-    }
-    if hosted_web_search {
-        append_guidance(
-            &mut instructions,
-            "For general web searches, use the hosted web_search tool. Do not use shell commands, HTTP clients, or local tools to search the web.",
-        );
-    }
-    append_guidance(
-        &mut instructions,
-        "For requests to search X or Twitter, use the hosted x_search tool. XSearch accepts a query and supports allowed_x_handles, excluded_x_handles, from_date, and to_date filters. Do not use Bash, curl, HTTP clients, or general web_search for X searches.",
-    );
-    let tool_choice = if force_x_search || force_web_search {
-        Some(GrokToolChoice::Required("required".into()))
-    } else {
-        parse_tool_choice(req.extra.get("tool_choice"), tools.as_ref())?
-    };
+    let instructions = parse_system(req.extra.get("system"))?;
+    // Map tools 1:1. Do not rewrite the tool list or append guidance based on
+    // latest-user-text intent — that mutates the request prefix every turn and
+    // busts Grok's server-side KV / prefix cache.
+    let tools = parse_tools(req.extra.get("tools"))?;
+    let tool_choice = parse_tool_choice(req.extra.get("tool_choice"), tools.as_ref())?;
     let mut call_ids = HashSet::new();
     let mut input = Vec::new();
     for message in &req.messages {
@@ -161,67 +143,6 @@ pub fn translate_request(
         stream: true,
         max_output_tokens: req.max_tokens,
     })
-}
-
-fn append_guidance(instructions: &mut Option<String>, guidance: &str) {
-    *instructions = Some(match instructions.take() {
-        Some(existing) if !existing.is_empty() => format!("{existing}\n\n{guidance}"),
-        _ => guidance.into(),
-    });
-}
-
-fn latest_user_text(req: &MessagesRequest) -> Option<String> {
-    let message = req
-        .messages
-        .iter()
-        .rev()
-        .find(|message| message.role == "user")?;
-    match &message.content {
-        Value::String(text) => Some(text.to_ascii_lowercase()),
-        Value::Array(blocks) => Some(
-            blocks
-                .iter()
-                .filter_map(|block| block.get("text").and_then(Value::as_str))
-                .collect::<Vec<_>>()
-                .join(" ")
-                .to_ascii_lowercase(),
-        ),
-        _ => None,
-    }
-}
-
-fn requests_x_search(req: &MessagesRequest) -> bool {
-    let Some(text) = latest_user_text(req) else {
-        return false;
-    };
-    [
-        "search x for",
-        "search on x",
-        "search twitter",
-        "search tweets",
-        "x search",
-        "posts on x",
-        "posts from x",
-        "tweets about",
-        "twitter posts",
-    ]
-    .iter()
-    .any(|phrase| text.contains(phrase))
-}
-
-fn requests_web_search(req: &MessagesRequest) -> bool {
-    let Some(text) = latest_user_text(req) else {
-        return false;
-    };
-    [
-        "search online",
-        "search the web",
-        "web search",
-        "look up online",
-        "look up on the web",
-    ]
-    .iter()
-    .any(|phrase| text.contains(phrase))
 }
 
 fn reject_unknown_top_level(req: &MessagesRequest) -> anyhow::Result<()> {
@@ -350,10 +271,26 @@ fn parse_tool_choice(
                 .get("name")
                 .and_then(Value::as_str)
                 .ok_or_else(|| anyhow::anyhow!("tool_choice name is invalid"))?;
-            if !tools
-                .is_some_and(|items| items.iter().any(|tool| tool.name.as_deref() == Some(name)))
-            {
+            // Hosted tools have no `name` field; Claude "tool" choice for
+            // WebSearch/XSearch is not expressible as a function choice.
+            let is_function = tools
+                .is_some_and(|items| items.iter().any(|tool| tool.name.as_deref() == Some(name)));
+            let is_hosted = matches!(name, "WebSearch" | "web_search" | "XSearch" | "x_search")
+                && tools.is_some_and(|items| {
+                    items.iter().any(|tool| {
+                        matches!(
+                            (name, tool.kind.as_str()),
+                            ("WebSearch" | "web_search", "web_search")
+                                | ("XSearch" | "x_search", "x_search")
+                        )
+                    })
+                });
+            if !is_function && !is_hosted {
                 anyhow::bail!("tool_choice references an unknown tool");
+            }
+            if is_hosted {
+                // Responses API: force a tool to be used without naming a function.
+                return Ok(Some(GrokToolChoice::Required("required".into())));
             }
             Ok(Some(GrokToolChoice::Function {
                 r#type: "function".into(),
@@ -387,7 +324,22 @@ fn parse_message(
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow::anyhow!("content block type is invalid"))?;
         match (message.role.as_str(), typ) {
-            (_, "thinking") | (_, "redacted_thinking") => {}
+            (_, "thinking") | (_, "redacted_thinking") => {
+                // Replay encrypted reasoning when Claude returns our signature;
+                // otherwise drop (foreign signatures / empty).
+                let signature = object
+                    .get("signature")
+                    .and_then(Value::as_str)
+                    .or_else(|| object.get("data").and_then(Value::as_str));
+                if let Some(replay) = signature.and_then(decode_reasoning_signature) {
+                    flush_message(&message.role, &mut content, out);
+                    out.push(GrokInputItem::Reasoning {
+                        id: replay.id,
+                        summary: Vec::new(),
+                        encrypted_content: replay.encrypted_content,
+                    });
+                }
+            }
             (_, "text") => {
                 if object
                     .keys()
@@ -411,6 +363,8 @@ fn parse_message(
                 if !matches!(name, Some("web_search" | "x_search")) {
                     anyhow::bail!("unsupported server tool use");
                 }
+                // Hosted tool history is not yet re-emitted as Responses items;
+                // accept and drop so multi-turn sessions after search still work.
             }
             ("assistant", "web_search_tool_result" | "x_search_tool_result")
             | ("user", "web_search_tool_result" | "x_search_tool_result") => {}
@@ -535,6 +489,10 @@ fn flush_message(role: &str, content: &mut Vec<GrokContentPart>, out: &mut Vec<G
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::grok::translate::reasoning_signature::{
+        ReasoningReplay, encode_reasoning_signature,
+    };
+
     #[test]
     fn grok_translation_replays_hosted_search_history() {
         let request: MessagesRequest = serde_json::from_value(serde_json::json!({
@@ -572,13 +530,16 @@ mod tests {
         })).unwrap();
         let value =
             serde_json::to_value(translate_request(&request, "grok-4.5".into()).unwrap()).unwrap();
-        assert!(value["instructions"].as_str().unwrap().starts_with("rules"));
+        assert_eq!(value["instructions"], "rules");
         assert_eq!(value["input"][1]["type"], "function_call");
         assert_eq!(value["input"][2]["type"], "function_call_output");
         assert_eq!(value["tool_choice"]["type"], "function");
+        // store:false is omitted from the wire (skip_serializing_if Not::not)
+        assert!(value.get("store").is_none());
     }
+
     #[test]
-    fn grok_translation_maps_claude_web_search_to_hosted_web_search() {
+    fn grok_translation_maps_claude_web_search_to_hosted_web_search_without_mutation() {
         let request: MessagesRequest = serde_json::from_value(serde_json::json!({
             "model":"grok-4.5",
             "messages":[{"role":"user","content":"search online for the project"}],
@@ -595,17 +556,14 @@ mod tests {
             translated["tools"],
             serde_json::json!([{"type":"web_search"}])
         );
-        assert!(
-            translated["instructions"]
-                .as_str()
-                .unwrap()
-                .contains("use the hosted web_search tool")
-        );
-        assert_eq!(translated["tool_choice"], "required");
+        // No per-request guidance appended into instructions (prefix stability).
+        assert!(translated.get("instructions").is_none() || translated["instructions"].is_null());
+        // No forced tool_choice from user-text intent.
+        assert!(translated.get("tool_choice").is_none() || translated["tool_choice"].is_null());
     }
 
     #[test]
-    fn grok_translation_maps_x_intent_to_required_hosted_x_search() {
+    fn grok_translation_keeps_function_tools_when_user_mentions_x() {
         let request: MessagesRequest = serde_json::from_value(serde_json::json!({
             "model":"grok-4.5",
             "messages":[{"role":"user","content":"Search X for recent posts mentioning claude-code-proxy"}],
@@ -617,16 +575,18 @@ mod tests {
         .unwrap();
         let translated =
             serde_json::to_value(translate_request(&request, "grok-4.5".into()).unwrap()).unwrap();
-        assert_eq!(
-            translated["tools"],
-            serde_json::json!([{"type":"x_search"}])
-        );
-        assert_eq!(translated["tool_choice"], "required");
-        assert!(!translated.to_string().contains("\"name\":\"Bash\""));
+        let tools = translated["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["type"], "function");
+        assert_eq!(tools[0]["name"], "Bash");
+        assert_eq!(tools[1]["type"], "web_search");
+        // No auto-injected x_search and no forced required choice.
+        assert!(!translated.to_string().contains("\"type\":\"x_search\""));
+        assert!(translated.get("tool_choice").is_none() || translated["tool_choice"].is_null());
     }
 
     #[test]
-    fn grok_translation_maps_dedicated_xsearch_with_domain_schema() {
+    fn grok_translation_maps_dedicated_xsearch() {
         let request: MessagesRequest = serde_json::from_value(serde_json::json!({
             "model":"grok-4.5",
             "messages":[{"role":"user","content":"find relevant posts"}],
@@ -653,7 +613,53 @@ mod tests {
             translated["tools"],
             serde_json::json!([{"type":"x_search"}])
         );
-        assert_eq!(translated["tool_choice"], "required");
+    }
+
+    #[test]
+    fn grok_translation_replays_reasoning_from_signature() {
+        let signature = encode_reasoning_signature(&ReasoningReplay {
+            id: "rs_1".into(),
+            encrypted_content: "opaque-blob".into(),
+        })
+        .unwrap();
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[
+                {"role":"user","content":"hi"},
+                {"role":"assistant","content":[
+                    {"type":"thinking","thinking":"plan","signature":signature},
+                    {"type":"text","text":"hello"}
+                ]},
+                {"role":"user","content":"again"}
+            ]
+        }))
+        .unwrap();
+        let value =
+            serde_json::to_value(translate_request(&request, "grok-4.5".into()).unwrap()).unwrap();
+        assert_eq!(value["input"][1]["type"], "reasoning");
+        assert_eq!(value["input"][1]["id"], "rs_1");
+        assert_eq!(value["input"][1]["encrypted_content"], "opaque-blob");
+        assert_eq!(value["input"][2]["type"], "message");
+        assert_eq!(value["input"][2]["role"], "assistant");
+    }
+
+    #[test]
+    fn grok_translation_drops_thinking_without_grok_signature() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[
+                {"role":"assistant","content":[
+                    {"type":"thinking","thinking":"plan","signature":"foreign"},
+                    {"type":"text","text":"hello"}
+                ]}
+            ]
+        }))
+        .unwrap();
+        let value =
+            serde_json::to_value(translate_request(&request, "grok-4.5".into()).unwrap()).unwrap();
+        assert_eq!(value["input"].as_array().unwrap().len(), 1);
+        assert_eq!(value["input"][0]["type"], "message");
+        assert!(!value.to_string().contains("reasoning"));
     }
 
     #[test]

--- a/src/providers/grok/translate/stream.rs
+++ b/src/providers/grok/translate/stream.rs
@@ -150,6 +150,7 @@ impl StreamTranslator {
                 && matches!(
                     event,
                     ReducerEvent::ThinkingStart(_)
+                        | ReducerEvent::ThinkingSignature(_, _)
                         | ReducerEvent::TextStart(_)
                         | ReducerEvent::ToolStart(_, _, _)
                         | ReducerEvent::HostedSearch { .. }
@@ -213,6 +214,11 @@ fn render(out: &mut Vec<u8>, event: ReducerEvent) {
             out,
             "content_block_delta",
             serde_json::json!({"type":"content_block_delta","index":i,"delta":{"type":"thinking_delta","thinking":t}}),
+        ),
+        ReducerEvent::ThinkingSignature(i, signature) => emit(
+            out,
+            "content_block_delta",
+            serde_json::json!({"type":"content_block_delta","index":i,"delta":{"type":"signature_delta","signature":signature}}),
         ),
         ReducerEvent::ThinkingStop(i) | ReducerEvent::TextStop(i) | ReducerEvent::ToolStop(i) => {
             emit(


### PR DESCRIPTION
## Summary

Grok through this proxy was slower and less cache-friendly than the official Grok CLI because request shape and transport did not match how Grok actually reuses work. This PR fixes three concrete problems.

Grok does **not** use Anthropic-style `cache_control` markers. Caching is **server-side prefix / KV reuse** on a **byte-stable Responses `input` prefix**. Long streams also need an HTTP client that is not hard-capped at 120s.

---

## Issues fixed

### 1. Hard 120s request timeout killed long turns

**Problem:** `GrokClient` used `reqwest` with `.timeout(Duration::from_secs(120))` on the whole request, including streaming. Multi-turn / tool-heavy / reasoning generations that take longer than two minutes failed even when upstream was healthy.

**Fix:** Remove the whole-request timeout. Keep a connect timeout. Enable HTTP/2 keepalive, connection pooling, and `tcp_nodelay` (aligned with official Grok Build sampling client behavior).

**Where:** `src/providers/grok/client.rs`

---

### 2. Missing session / turn headers (weaker upstream affinity)

**Problem:** Official Grok clients send `x-grok-session-id`, `x-grok-conv-id`, `x-grok-req-id`, `x-grok-turn-idx`, and related headers. The proxy only sent auth + client version, so each call looked less like a continuous session for routing/affinity/diagnostics.

**Fix:** Pass `RequestContext` session fields into `GrokClient::post` as `GrokRequestMeta` and set those headers on every upstream attempt. Client identifier is now `claude-code-proxy`.

**Where:** `src/providers/grok/client.rs`, `src/providers/grok/mod.rs`

---

### 3. Per-request tool / instruction mutation busted the KV prefix

**Problem:** On every Claude request, Grok translation:
- rewrote tools from latest-user-text intent (force only `x_search` / only `web_search`, or auto-inject `x_search`)
- forced `tool_choice = required` from phrase matching
- appended search-guidance strings into `instructions`

That changes the **shared request prefix** across turns → prefix/KV miss even when conversation history was similar. The official client keeps tools and system-like content stable within a session epoch.

**Fix:** Map tools 1:1 (`WebSearch` → `web_search`, `XSearch` → `x_search`, else function). Do not rewrite the tool list from user intent. Do not append guidance into `instructions`. Omit `store: false` from the wire (same posture as leaving store unset).

**Where:** `src/providers/grok/translate/request.rs`

---

### 4. Reasoning history was dropped (guaranteed multi-turn prefix miss)

**Problem:** Streamed Grok reasoning was converted to Claude `thinking` with an **empty** `signature`. On the next request, `thinking` / `redacted_thinking` were **ignored**. Encrypted reasoning items never went back to Grok, so the Responses `input` no longer matched the prior turn’s wire shape.

**Fix:** Copy the Codex pattern:
- capture `id` + `encrypted_content` from reasoning output items
- emit Anthropic `signature_delta` with opaque `ccp:grok:v1:…` signatures
- on the next request, decode those signatures and replay Responses `type: "reasoning"` input items

**Where:**
- `src/providers/grok/translate/reasoning_signature.rs` (new)
- `src/providers/grok/translate/reducer.rs`
- `src/providers/grok/translate/stream.rs`
- `src/providers/grok/translate/accumulate.rs`
- `src/providers/grok/translate/request.rs`

---

## Out of scope (follow-ups)

- Re-emitting hosted search history (`web_search` / `x_search` calls) as Responses input items (currently still accepted and dropped)
- Sticky tool-schema session store against Claude Code’s tool-JSON churn
- Monitor TTFT / `cached_tokens` reporting for Grok

Claude Code will still rewrite large system prompts between turns; this PR stabilizes the **Grok wire shape** for tools, instructions mutation, reasoning, and transport—the parts the proxy fully controls.

## Test plan

- [x] `cargo test --lib` (495 tests)
- [x] Unit coverage for stable tools (no intent rewrite)
- [x] Unit coverage for reasoning signature encode/decode + stream round-trip
- [ ] Manual: multi-turn Grok chat past 120s without disconnect
- [ ] Manual: multi-turn with thinking enabled; second turn should include `reasoning` items with `encrypted_content` in captured upstream request
- [ ] Manual: confirm tools stay identical across turns when Claude sends the same tool set (no forced `x_search`-only rewrite)