### PR TITLE
server: implement GET /v1/models for gateway model discovery

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -11,7 +11,7 @@ use crate::{
 use axum::{
     Json, Router,
     body::Body,
-    extract::State,
+    extract::{Query, State},
     http::{Request, StatusCode},
     response::Response,
     routing::{get, post},
@@ -105,6 +105,7 @@ pub fn app_with_monitor(registry: Arc<Registry>, monitor: Option<MonitorHandle>)
         .route("/healthz", get(healthz))
         .route("/v1/messages", post(handler_messages))
         .route("/v1/messages/count_tokens", post(handler_count_tokens))
+        .route("/v1/models", get(handler_models))
         .fallback(fallback_handler)
         .with_state(state)
 }
@@ -117,6 +118,44 @@ struct AppState {
 
 async fn healthz() -> Json<serde_json::Value> {
     Json(json!({ "ok": true }))
+}
+
+#[derive(serde::Deserialize)]
+struct ModelsQuery {
+    limit: Option<usize>,
+}
+
+/// Anthropic-shaped model listing so Claude Code's gateway model discovery
+/// (`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`) finds the proxy's models.
+/// Claude Code only adds entries whose id starts with `claude` or `anthropic`,
+/// so the Anthropic-style aliases are what surface in its `/model` picker;
+/// raw provider ids are still listed for other Anthropic-compatible clients.
+async fn handler_models(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ModelsQuery>,
+) -> Json<serde_json::Value> {
+    let mut data: Vec<Value> = state
+        .registry
+        .all_supported_models()
+        .into_iter()
+        .map(|(model, provider)| {
+            json!({
+                "type": "model",
+                "id": model,
+                "display_name": format!("{model} ({provider})"),
+            })
+        })
+        .collect();
+    let has_more = query.limit.is_some_and(|limit| data.len() > limit);
+    if let Some(limit) = query.limit {
+        data.truncate(limit);
+    }
+    Json(json!({
+        "data": data,
+        "has_more": has_more,
+        "first_id": data.first().and_then(|entry| entry.get("id")).cloned(),
+        "last_id": data.last().and_then(|entry| entry.get("id")).cloned(),
+    }))
 }
 
 async fn handler_messages(State(state): State<Arc<AppState>>, req: Request<Body>) -> Response {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -358,3 +358,78 @@ async fn monitor_records_unknown_model_failure() {
     assert!(error.starts_with("Unknown model \"not-a-model\""));
     assert!(error.contains("Supported:"));
 }
+
+async fn get_models(app: axum::Router, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, value)
+}
+
+#[tokio::test]
+async fn models_endpoint_lists_supported_models() {
+    let app = app(Arc::new(Registry::with_default_alias()));
+    let (status, value) = get_models(app, "/v1/models").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let data = value["data"].as_array().unwrap();
+    assert!(!data.is_empty());
+    let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+    assert!(ids.contains(&"gpt-5.6-sol"));
+    for entry in data {
+        assert_eq!(entry["type"], "model");
+        assert!(entry["display_name"].as_str().is_some());
+    }
+    assert_eq!(value["has_more"], json!(false));
+    assert_eq!(value["first_id"], data[0]["id"]);
+    assert_eq!(value["last_id"], data[data.len() - 1]["id"]);
+}
+
+#[tokio::test]
+async fn models_endpoint_includes_claude_prefixed_aliases_for_discovery() {
+    // Claude Code's gateway model discovery ignores ids that don't start with
+    // "claude" or "anthropic", so the alias entries are what make
+    // CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 useful at all.
+    let app = app(Arc::new(Registry::with_default_alias()));
+    let (status, value) = get_models(app, "/v1/models?limit=1000").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let ids: Vec<&str> = value["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["id"].as_str().unwrap())
+        .collect();
+    assert!(ids.iter().any(|id| id.starts_with("claude-")));
+}
+
+#[tokio::test]
+async fn models_endpoint_respects_limit() {
+    let app = app(Arc::new(Registry::with_default_alias()));
+    let (status, value) = get_models(app, "/v1/models?limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let data = value["data"].as_array().unwrap();
+    assert_eq!(data.len(), 2);
+    assert_eq!(value["has_more"], json!(true));
+    assert_eq!(value["last_id"], data[1]["id"]);
+}
+
+#[tokio::test]
+async fn models_endpoint_tolerates_unknown_query_params() {
+    let app = app(Arc::new(Registry::with_default_alias()));
+    let (status, _) = get_models(app, "/v1/models?limit=1000&after_id=x").await;
+    assert_eq!(status, StatusCode::OK);
+}


### PR DESCRIPTION
Fixes #60.

## Problem

The README quickstart recommends `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, but there is no `/v1/models` route, so Claude Code's startup discovery request (`GET /v1/models?limit=1000`) falls through and the flag silently does nothing.

## Change

Single concern: add `GET /v1/models`, serving the registry's model list in the Anthropic models-list shape.

- `data[].id` + `data[].display_name` (`"<model> (<provider>)"`) + `type: "model"`
- `has_more`, `first_id`, `last_id`; `limit` honored, unknown query params tolerated
- The Anthropic-style aliases from the registry are included. Per the official gateway protocol (https://code.claude.com/docs/en/llm-gateway-protocol), Claude Code ignores discovered ids that don't start with `claude`/`anthropic`, so the aliases are what actually surface in the `/model` picker; raw provider ids remain listed for other Anthropic-compatible clients.
- No auth on the endpoint, matching the server's existing no-inbound-auth posture; response is static registry data (fits Claude Code's 3s discovery timeout, no redirects).

## Testing

- 4 new integration tests in `tests/server.rs` (list shape, claude-prefixed aliases present, limit + has_more, unknown query params tolerated)
- `cargo test`: 599 passed, 0 failed
- `cargo fmt --all --check` clean
- `cargo clippy --all-targets -- -D warnings`: identical pre-existing error count before/after (34), none in touched files
- Live check on a local build:

```
$ curl -s 'http://127.0.0.1:18799/v1/models?limit=1000' | jq '[.data[].id | select(startswith("claude-"))]'
["claude-fable-5","claude-haiku-4-5","claude-haiku-4-5-20251001","claude-opus-4-7","claude-opus-4-8","claude-sonnet-4-6","claude-sonnet-5"]
```