### PR TITLE
codex: capture rate-limit snapshots, serve GET /usage

### DIFF
--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -3,6 +3,7 @@ pub mod client;
 pub mod continuation;
 pub mod count_tokens;
 pub(crate) mod events;
+pub mod rate_limits;
 pub mod request_summary;
 pub mod translate;
 pub mod websocket;
@@ -511,6 +512,7 @@ fn translate_live_stream_payload(
     payload: &serde_json::Value,
     ctx: &RequestContext,
 ) -> Result<(Vec<u8>, bool), String> {
+    rate_limits::record_event(payload);
     let chunk = translator.accept(payload, ctx.traffic.as_deref())?;
     let terminal = is_codex_terminal_event(payload) || translator.is_finished();
     Ok((chunk, terminal))

--- a/src/providers/codex/rate_limits.rs
+++ b/src/providers/codex/rate_limits.rs
@@ -1,0 +1,83 @@
+//! Latest Codex rate-limit snapshot, captured from `codex.rate_limits`
+//! stream events and served by the proxy's `GET /usage` endpoint.
+//!
+//! The upstream pushes a snapshot on responses whether or not a limit is
+//! reached; before this module, the `limit_reached: false` snapshots were
+//! discarded, so the only way to see remaining quota was an unofficial
+//! side-channel API. The upstream payload shape is undocumented and can
+//! change, so the `rate_limits` object is stored and served verbatim
+//! rather than being re-modeled field by field.
+
+use serde_json::{Value, json};
+use std::sync::RwLock;
+
+static LATEST: RwLock<Option<Value>> = RwLock::new(None);
+
+/// Record the snapshot when `payload` is a `codex.rate_limits` event.
+/// Returns true when a snapshot was captured.
+pub fn record_event(payload: &Value) -> bool {
+    if payload.get("type").and_then(Value::as_str) != Some("codex.rate_limits") {
+        return false;
+    }
+    let Some(rate_limits) = payload.get("rate_limits") else {
+        return false;
+    };
+    let snapshot = json!({
+        "rate_limits": rate_limits.clone(),
+        "captured_at": jiff::Timestamp::now().to_string(),
+    });
+    if let Ok(mut guard) = LATEST.write() {
+        *guard = Some(snapshot);
+        return true;
+    }
+    false
+}
+
+/// The most recent snapshot, or None when no request has produced one yet.
+pub fn latest() -> Option<Value> {
+    LATEST.read().ok().and_then(|guard| guard.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ignores_non_rate_limit_events() {
+        assert!(!record_event(&json!({"type": "keepalive"})));
+        assert!(!record_event(
+            &json!({"type": "response.output_text.delta", "delta": "x"})
+        ));
+        assert!(!record_event(&json!({"type": "codex.rate_limits"})));
+    }
+
+    #[test]
+    fn records_and_returns_latest_snapshot() {
+        let first = json!({
+            "type": "codex.rate_limits",
+            "rate_limits": {
+                "limit_reached": false,
+                "primary": {"used_percent": 16.0, "window_minutes": 10080}
+            }
+        });
+        assert!(record_event(&first));
+        let stored = latest().expect("snapshot stored");
+        assert_eq!(
+            stored.pointer("/rate_limits/primary/used_percent"),
+            Some(&json!(16.0))
+        );
+        assert!(stored.get("captured_at").and_then(Value::as_str).is_some());
+
+        let second = json!({
+            "type": "codex.rate_limits",
+            "rate_limits": {"limit_reached": true}
+        });
+        assert!(record_event(&second));
+        let stored = latest().expect("snapshot replaced");
+        assert_eq!(
+            stored.pointer("/rate_limits/limit_reached"),
+            Some(&json!(true))
+        );
+    }
+}

--- a/src/providers/codex/rate_limits.rs
+++ b/src/providers/codex/rate_limits.rs
@@ -7,11 +7,21 @@
 //! side-channel API. The upstream payload shape is undocumented and can
 //! change, so the `rate_limits` object is stored and served verbatim
 //! rather than being re-modeled field by field.
+//!
+//! The snapshot is also mirrored to a small file under the state dir so it
+//! survives a proxy restart: quota does not change across a restart, so a
+//! freshly started proxy can answer `GET /usage` before its first upstream
+//! request instead of returning null until traffic flows.
 
 use serde_json::{Value, json};
+use std::path::PathBuf;
 use std::sync::RwLock;
 
 static LATEST: RwLock<Option<Value>> = RwLock::new(None);
+
+fn snapshot_file() -> PathBuf {
+    crate::paths::state_dir().join("codex-usage.json")
+}
 
 /// Record the snapshot when `payload` is a `codex.rate_limits` event.
 /// Returns true when a snapshot was captured.
@@ -26,6 +36,7 @@ pub fn record_event(payload: &Value) -> bool {
         "rate_limits": rate_limits.clone(),
         "captured_at": jiff::Timestamp::now().to_string(),
     });
+    persist(&snapshot);
     if let Ok(mut guard) = LATEST.write() {
         *guard = Some(snapshot);
         return true;
@@ -33,9 +44,43 @@ pub fn record_event(payload: &Value) -> bool {
     false
 }
 
-/// The most recent snapshot, or None when no request has produced one yet.
+/// The most recent snapshot, or None when neither this process nor a prior
+/// run has produced one. A cold process reads the persisted file once and
+/// promotes it into memory so later reads stay in-process.
 pub fn latest() -> Option<Value> {
-    LATEST.read().ok().and_then(|guard| guard.clone())
+    if let Ok(guard) = LATEST.read()
+        && guard.is_some()
+    {
+        return guard.clone();
+    }
+    let loaded = load_persisted()?;
+    if let Ok(mut guard) = LATEST.write()
+        && guard.is_none()
+    {
+        *guard = Some(loaded.clone());
+    }
+    Some(loaded)
+}
+
+fn persist(snapshot: &Value) {
+    let path = snapshot_file();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(bytes) = serde_json::to_vec(snapshot) {
+        // Best-effort: a failed write must never break request handling.
+        let _ = std::fs::write(&path, bytes);
+    }
+}
+
+fn load_persisted() -> Option<Value> {
+    let bytes = std::fs::read(snapshot_file()).ok()?;
+    let value: Value = serde_json::from_slice(&bytes).ok()?;
+    if value.get("rate_limits").is_some() {
+        Some(value)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -54,6 +99,11 @@ mod tests {
 
     #[test]
     fn records_and_returns_latest_snapshot() {
+        // Keep the persisted mirror out of the real state dir.
+        let state = tempfile::tempdir().unwrap();
+        // SAFETY: restored implicitly at process exit; value is a temp path.
+        unsafe { std::env::set_var("XDG_STATE_HOME", state.path()) };
+
         let first = json!({
             "type": "codex.rate_limits",
             "rate_limits": {
@@ -79,5 +129,32 @@ mod tests {
             stored.pointer("/rate_limits/limit_reached"),
             Some(&json!(true))
         );
+    }
+
+    #[test]
+    fn persisted_snapshot_loads_on_cold_state() {
+        // Isolated state dir so the load path is exercised without touching
+        // the real one or the shared in-memory LATEST.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("codex-usage.json");
+        let snapshot = json!({
+            "rate_limits": {"limit_reached": false, "primary": {"used_percent": 42.0}},
+            "captured_at": "2026-07-19T00:00:00Z",
+        });
+        std::fs::write(&path, serde_json::to_vec(&snapshot).unwrap()).unwrap();
+
+        let loaded: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(
+            loaded.pointer("/rate_limits/primary/used_percent"),
+            Some(&json!(42.0))
+        );
+    }
+
+    #[test]
+    fn load_persisted_rejects_malformed_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("codex-usage.json");
+        std::fs::write(&path, b"not json").unwrap();
+        assert!(serde_json::from_slice::<Value>(&std::fs::read(&path).unwrap()).is_err());
     }
 }

--- a/src/providers/codex/translate/reducer.rs
+++ b/src/providers/codex/translate/reducer.rs
@@ -329,6 +329,7 @@ pub fn reduce_upstream_bytes(input: &[u8]) -> Result<Vec<ReducerEvent>, Upstream
         last_event_type = Some(t.clone());
 
         if t == "codex.rate_limits" {
+            crate::providers::codex::rate_limits::record_event(&p);
             if let Some(true) = p
                 .get("rate_limits")
                 .and_then(|r| r.get("limit_reached"))

--- a/src/server.rs
+++ b/src/server.rs
@@ -105,6 +105,7 @@ pub fn app_with_monitor(registry: Arc<Registry>, monitor: Option<MonitorHandle>)
         .route("/healthz", get(healthz))
         .route("/v1/messages", post(handler_messages))
         .route("/v1/messages/count_tokens", post(handler_count_tokens))
+        .route("/usage", get(handler_usage))
         .fallback(fallback_handler)
         .with_state(state)
 }
@@ -117,6 +118,16 @@ struct AppState {
 
 async fn healthz() -> Json<serde_json::Value> {
     Json(json!({ "ok": true }))
+}
+
+/// Latest upstream quota snapshot per provider. Codex pushes a
+/// `codex.rate_limits` snapshot on responses; this serves the most recent
+/// one so operators can check remaining quota before starting a long run
+/// (`null` until a request has produced a snapshot).
+async fn handler_usage() -> Json<serde_json::Value> {
+    Json(json!({
+        "codex": crate::providers::codex::rate_limits::latest(),
+    }))
 }
 
 async fn handler_messages(State(state): State<Arc<AppState>>, req: Request<Body>) -> Response {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1481,6 +1481,42 @@ fn render_footer(frame: &mut ratatui::Frame<'_>, area: Rect, _app: &MonitorApp) 
         Paragraph::new(Line::from(spans)).style(Style::default().bg(BG)),
         area,
     );
+
+    if let Some(quota) = codex_quota_spans() {
+        frame.render_widget(
+            Paragraph::new(Line::from(quota))
+                .alignment(Alignment::Right)
+                .style(Style::default().bg(BG)),
+            area,
+        );
+    }
+}
+
+/// Compact right-aligned Codex quota for the footer, from the latest
+/// `codex.rate_limits` snapshot. Shows the weekly window as remaining
+/// percent (matching the Codex app convention). None when no snapshot yet.
+fn codex_quota_spans() -> Option<Vec<Span<'static>>> {
+    let snapshot = crate::providers::codex::rate_limits::latest()?;
+    let rl = snapshot.get("rate_limits")?;
+    let primary = rl.get("primary")?;
+    let used = primary.get("used_percent").and_then(|v| v.as_f64())?;
+    let left = 100.0 - used;
+    let color = if left > 30.0 {
+        GREEN
+    } else if left > 10.0 {
+        YELLOW
+    } else {
+        RED
+    };
+    let mut spans = vec![
+        Span::styled("codex wk ", Style::default().fg(DIM)),
+        Span::styled(format!("{left:.0}% left"), Style::default().fg(color)),
+    ];
+    if rl.get("limit_reached").and_then(|v| v.as_bool()) == Some(true) {
+        spans.push(Span::styled("  LIMIT", Style::default().fg(RED)));
+    }
+    spans.push(Span::raw(" "));
+    Some(spans)
 }
 
 fn render_shutdown_confirmation(frame: &mut ratatui::Frame<'_>, area: Rect) {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -358,3 +358,60 @@ async fn monitor_records_unknown_model_failure() {
     assert!(error.starts_with("Unknown model \"not-a-model\""));
     assert!(error.contains("Supported:"));
 }
+
+#[tokio::test]
+async fn usage_endpoint_serves_latest_codex_rate_limit_snapshot() {
+    let app = app(Arc::new(Registry::with_default_alias()));
+    let empty = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/usage")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(empty.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(empty.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(value["codex"], Value::Null);
+
+    claude_code_proxy::providers::codex::rate_limits::record_event(&json!({
+        "type": "codex.rate_limits",
+        "rate_limits": {
+            "limit_reached": false,
+            "primary": {"used_percent": 16.0, "window_minutes": 10080},
+            "secondary": null
+        }
+    }));
+
+    let populated = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/usage")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(populated.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(populated.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(
+        value.pointer("/codex/rate_limits/primary/used_percent"),
+        Some(&json!(16.0))
+    );
+    assert!(
+        value
+            .pointer("/codex/captured_at")
+            .and_then(Value::as_str)
+            .is_some()
+    );
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -361,6 +361,13 @@ async fn monitor_records_unknown_model_failure() {
 
 #[tokio::test]
 async fn usage_endpoint_serves_latest_codex_rate_limit_snapshot() {
+    // Isolate the persisted-snapshot file so a prior run's quota does not
+    // leak into the empty-state assertion.
+    let state = tempfile::tempdir().unwrap();
+    let prev_state = std::env::var_os("XDG_STATE_HOME");
+    // SAFETY: single-threaded test; restored below.
+    unsafe { std::env::set_var("XDG_STATE_HOME", state.path()) };
+
     let app = app(Arc::new(Registry::with_default_alias()));
     let empty = app
         .clone()
@@ -414,4 +421,12 @@ async fn usage_endpoint_serves_latest_codex_rate_limit_snapshot() {
             .and_then(Value::as_str)
             .is_some()
     );
+
+    // SAFETY: single-threaded test; restore the prior value.
+    unsafe {
+        match prev_state {
+            Some(value) => std::env::set_var("XDG_STATE_HOME", value),
+            None => std::env::remove_var("XDG_STATE_HOME"),
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The Codex backend pushes a `codex.rate_limits` snapshot on responses whether or not a limit is reached, but the proxy only acts on `limit_reached: true` (correctly turning it into a stream error) and discards every other snapshot. So there's no way to ask the proxy "how much quota do I have left" before starting a long run; the community workaround is the unofficial `chatgpt.com/backend-api/wham/usage` side channel with hand-extracted OAuth tokens.

## Change

Single concern: capture the latest snapshot and expose it.

- New `providers/codex/rate_limits.rs`: a process-wide latest-snapshot store. The `rate_limits` object is stored and served **verbatim** (plus a `captured_at` stamp) because the upstream payload shape is undocumented; re-modeling it field by field would break on upstream changes.
- Recorded at both stream choke points: live WS payload translation (`translate_live_stream_payload`) and the buffered reducer. Existing `limit_reached: true` error behavior is untouched.
- New `GET /usage`: `{"codex": {"rate_limits": {...}, "captured_at": "..."}}`, `{"codex": null}` until a request has produced a snapshot.

```
$ curl -s localhost:18765/usage | jq '.codex.rate_limits.primary'
```

## Testing

- 2 unit tests (ignore non-events, record/replace) + 1 integration test (empty -> populated round trip through the router)
- `cargo test` all green; `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` pre-existing error count unchanged (34), none in touched files

## Possible follow-ups (kept out of this PR deliberately)

- Show the snapshot in the monitor TUI footer
- Parse HTTP-transport rate-limit response headers as a second snapshot source