### PR TITLE
Route compaction requests to a dedicated model

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,10 @@ Windows, and at
 | `CCP_LOG_VERBOSE`                | `log.verbose`              | unset                                             | Preserve full string fields in `proxy.log`; any env value enables it                                                                                                              |
 | `CCP_TRAFFIC_LOG`                | —                          | unset                                             | Write full per-request traffic captures under `traffic/` for session debugging (`1`, `true`, or `yes`)                                                                            |
 | `CCP_ALIAS_PROVIDER`             | `aliasProvider`            | `codex`                                           | Route Anthropic-style aliases (`haiku`, `sonnet`, `opus`, `claude-*`) through `codex` or `kimi`                                                                                   |
+| `CCP_COMPACTION_MODEL`           | —                          | unset (disabled)                                  | One-shot target model for signaled Claude Code compaction requests                                                                                                                |
+| `CCP_COMPACTION_EFFORT`          | —                          | `medium`                                          | One-shot compaction effort (`low`, `medium`, `high`, `xhigh`, or `max`)                                                                                                           |
+| `CCP_COMPACTION_MARKER_DIR`      | —                          | unset                                             | Shared directory containing short-lived `<session-id>.json` compaction markers; required when routing is enabled                                                                 |
+| `CCP_COMPACTION_MARKER_TTL_SECONDS` | —                       | `60`                                              | Marker lifetime in seconds (1–86400)                                                                                                                                              |
 | `CCP_KIMI_OAUTH_HOST`            | `kimi.oauthHost`           | `https://auth.kimi.com`                           | Override Kimi's OAuth host (debugging only)                                                                                                                                       |
 | `CCP_KIMI_BASE_URL`              | `kimi.baseUrl`             | `https://api.kimi.com/coding/v1`                  | Override Kimi's API base URL                                                                                                                                                      |
 | `CCP_CODEX_MODEL`                | `codex.model`              | unset                                             | Force all Codex requests to this model (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`) |
@@ -764,6 +768,26 @@ proxy clears unsafe continuation state and sends the full request instead.
 Continuation reduces repeated request upload size, but it does not increase the
 upstream model context window. Multi-process or load-balanced deployments need
 sticky sessions or shared state before enabling continuation.
+
+### One-shot compaction routing
+
+Compaction routing is disabled unless both `CCP_COMPACTION_MODEL` and
+`CCP_COMPACTION_MARKER_DIR` are set. A cooperating Claude Code `PreCompact` hook
+writes `<marker-dir>/<session-id>.json` with this schema:
+
+```json
+{"version":1,"sessionId":"<session-id>","createdAtMs":1750000000000}
+```
+
+For `/v1/messages` only, the proxy requires the same validated
+`x-claude-code-session-id`, a fresh marker, and Claude Code's compaction prompt
+anchor. It atomically claims the marker, changes that request's model, and merges
+`output_config.effort`. `/count_tokens`, ordinary prompts, wrong sessions, and
+stale or malformed markers do not route. A marker can route at most one request;
+all marker errors fail open to the original request model. Logs contain only the
+request/session correlation and selected model/effort, never marker or prompt bodies.
+The prompt guard is intentionally conservative: if Claude Code changes its
+compaction prompt, routing stops rather than rerouting an ambiguous request.
 
 ### Files
 

--- a/src/compaction_route.rs
+++ b/src/compaction_route.rs
@@ -1,0 +1,469 @@
+use crate::{anthropic::schema::MessagesRequest, logging::create_logger};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+const COMPACTION_ANCHOR: &str = "Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.";
+const DEFAULT_EFFORT: &str = "medium";
+const DEFAULT_MARKER_TTL_SECONDS: u64 = 60;
+const MAX_MARKER_TTL_SECONDS: u64 = 86_400;
+const MAX_SESSION_ID_LEN: usize = 128;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactionRouteConfig {
+    model: String,
+    effort: String,
+    marker_dir: PathBuf,
+    marker_ttl_seconds: u64,
+}
+
+impl CompactionRouteConfig {
+    /// Loads the optional route configuration. An absent or blank model disables the feature.
+    pub fn from_env() -> anyhow::Result<Option<Self>> {
+        Self::from_values(
+            std::env::var("CCP_COMPACTION_MODEL").ok(),
+            std::env::var("CCP_COMPACTION_EFFORT").ok(),
+            std::env::var("CCP_COMPACTION_MARKER_DIR").ok(),
+            std::env::var("CCP_COMPACTION_MARKER_TTL_SECONDS").ok(),
+        )
+    }
+
+    pub fn from_values(
+        model: Option<String>,
+        effort: Option<String>,
+        marker_dir: Option<String>,
+        marker_ttl_seconds: Option<String>,
+    ) -> anyhow::Result<Option<Self>> {
+        let Some(model) = model.filter(|value| !value.trim().is_empty()) else {
+            return Ok(None);
+        };
+        let marker_dir = marker_dir
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "CCP_COMPACTION_MARKER_DIR is required when compaction routing is enabled"
+                )
+            })?;
+        let effort = effort.unwrap_or_else(|| DEFAULT_EFFORT.to_string());
+        if !matches!(effort.as_str(), "low" | "medium" | "high" | "xhigh" | "max") {
+            anyhow::bail!("CCP_COMPACTION_EFFORT must be one of low, medium, high, xhigh, or max");
+        }
+        let marker_ttl_seconds = match marker_ttl_seconds {
+            Some(value) => value.parse::<u64>().map_err(|_| {
+                anyhow::anyhow!(
+                    "CCP_COMPACTION_MARKER_TTL_SECONDS must be a positive integer no greater than {MAX_MARKER_TTL_SECONDS}"
+                )
+            })?,
+            None => DEFAULT_MARKER_TTL_SECONDS,
+        };
+        if !(1..=MAX_MARKER_TTL_SECONDS).contains(&marker_ttl_seconds) {
+            anyhow::bail!(
+                "CCP_COMPACTION_MARKER_TTL_SECONDS must be a positive integer no greater than {MAX_MARKER_TTL_SECONDS}"
+            );
+        }
+
+        Ok(Some(Self {
+            model: model.trim().to_string(),
+            effort,
+            marker_dir: PathBuf::from(marker_dir),
+            marker_ttl_seconds,
+        }))
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompactionRoute {
+    config: CompactionRouteConfig,
+}
+
+impl CompactionRoute {
+    pub fn new(config: CompactionRouteConfig) -> Self {
+        Self { config }
+    }
+
+    /// Attempts a one-shot compaction route. Every invalid or unavailable marker fails open.
+    pub fn try_route(
+        &self,
+        body: &mut MessagesRequest,
+        session_id: Option<&str>,
+        request_id: &str,
+        count_tokens: bool,
+        now_ms: u64,
+    ) -> bool {
+        if count_tokens || !has_compaction_anchor(body) {
+            return false;
+        }
+        let Some(session_id) = session_id.filter(|id| valid_session_id(id)) else {
+            return false;
+        };
+        let Some(output_config) = routed_output_config(body, &self.config.effort) else {
+            return false;
+        };
+        let marker_path = self.marker_path(session_id);
+        let Some(claim_path) = self.claim_path(session_id, request_id) else {
+            return false;
+        };
+        if fs::rename(&marker_path, &claim_path).is_err() {
+            return false;
+        }
+        let _claim = ClaimGuard {
+            path: claim_path.clone(),
+        };
+        if !valid_marker(
+            &claim_path,
+            session_id,
+            now_ms,
+            self.config.marker_ttl_seconds,
+        ) {
+            return false;
+        }
+
+        body.model = Some(self.config.model.clone());
+        body.extra
+            .insert("output_config".to_string(), Value::Object(output_config));
+        create_logger("compaction_route").info(
+            "compaction_routed",
+            Some(Map::from_iter([
+                ("reqId".to_string(), json!(request_id)),
+                ("sessionId".to_string(), json!(session_id)),
+                ("model".to_string(), json!(&self.config.model)),
+                ("effort".to_string(), json!(&self.config.effort)),
+            ])),
+        );
+        true
+    }
+
+    fn marker_path(&self, session_id: &str) -> PathBuf {
+        self.config.marker_dir.join(format!("{session_id}.json"))
+    }
+
+    fn claim_path(&self, session_id: &str, request_id: &str) -> Option<PathBuf> {
+        valid_request_id(request_id).then(|| {
+            self.config
+                .marker_dir
+                .join(format!("{session_id}.json.claim-{request_id}"))
+        })
+    }
+}
+
+struct ClaimGuard {
+    path: PathBuf,
+}
+
+impl Drop for ClaimGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Marker {
+    version: u8,
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    #[serde(rename = "createdAtMs")]
+    created_at_ms: u64,
+}
+
+fn valid_marker(path: &Path, session_id: &str, now_ms: u64, ttl_seconds: u64) -> bool {
+    let marker = match fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<Marker>(&bytes).ok())
+    {
+        Some(marker) => marker,
+        None => {
+            let _ = fs::remove_file(path);
+            return false;
+        }
+    };
+    if marker.version != 1
+        || marker.session_id != session_id
+        || !valid_session_id(&marker.session_id)
+    {
+        let _ = fs::remove_file(path);
+        return false;
+    }
+    if marker.created_at_ms > now_ms {
+        let _ = fs::remove_file(path);
+        return false;
+    }
+    let ttl_ms = ttl_seconds.saturating_mul(1_000);
+    if now_ms.saturating_sub(marker.created_at_ms) > ttl_ms {
+        let _ = fs::remove_file(path);
+        return false;
+    }
+    true
+}
+
+fn has_compaction_anchor(body: &MessagesRequest) -> bool {
+    body.messages.last().is_some_and(|message| {
+        message.role == "user" && content_has_compaction_anchor(&message.content)
+    })
+}
+
+fn content_has_compaction_anchor(content: &Value) -> bool {
+    match content {
+        Value::String(text) => text.contains(COMPACTION_ANCHOR),
+        Value::Array(blocks) => blocks.iter().any(|block| match block {
+            Value::String(text) => text.contains(COMPACTION_ANCHOR),
+            Value::Object(block) => {
+                block
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|kind| kind == "text")
+                    && block
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| text.contains(COMPACTION_ANCHOR))
+            }
+            _ => false,
+        }),
+        _ => false,
+    }
+}
+
+fn routed_output_config(body: &MessagesRequest, effort: &str) -> Option<Map<String, Value>> {
+    let mut config = match body.extra.get("output_config") {
+        Some(Value::Object(config)) => config.clone(),
+        Some(_) => return None,
+        None => Map::new(),
+    };
+    config.insert("effort".to_string(), Value::String(effort.to_string()));
+    Some(config)
+}
+
+fn valid_session_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_SESSION_ID_LEN
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+        })
+}
+
+fn valid_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_SESSION_ID_LEN
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{sync::Arc, thread};
+
+    fn route(dir: &Path) -> CompactionRoute {
+        CompactionRoute::new(
+            CompactionRouteConfig::from_values(
+                Some("gpt-5.4".to_string()),
+                Some("high".to_string()),
+                Some(dir.display().to_string()),
+                Some("60".to_string()),
+            )
+            .unwrap()
+            .unwrap(),
+        )
+    }
+
+    fn request() -> MessagesRequest {
+        serde_json::from_value(json!({
+            "model": "original-model",
+            "messages": [{
+                "role": "user",
+                "content": format!("CRITICAL: Respond with TEXT ONLY. {COMPACTION_ANCHOR} Continue with the detailed requirements.")
+            }]
+        }))
+        .unwrap()
+    }
+
+    fn write_marker(dir: &Path, session_id: &str, created_at_ms: u64) -> PathBuf {
+        let path = dir.join(format!("{session_id}.json"));
+        fs::write(
+            &path,
+            json!({
+                "version": 1,
+                "sessionId": session_id,
+                "createdAtMs": created_at_ms,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn disabled_without_model_and_no_marker_do_not_route() {
+        assert!(
+            CompactionRouteConfig::from_values(None, None, None, None)
+                .unwrap()
+                .is_none()
+        );
+        let defaulted = CompactionRouteConfig::from_values(
+            Some("gpt-5.4".to_string()),
+            None,
+            Some("markers".to_string()),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(defaulted.effort, "medium");
+        assert_eq!(defaulted.marker_ttl_seconds, 60);
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut body = request();
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "request", false, 1));
+        assert_eq!(body.model.as_deref(), Some("original-model"));
+    }
+
+    #[test]
+    fn count_tokens_retains_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "session", 1_000);
+        let mut body = request();
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "request", true, 1_000));
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn wrong_session_and_noncompaction_requests_retain_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let wrong_session = write_marker(dir.path(), "other", 1_000);
+        let mut body = request();
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "request", false, 1_000));
+        assert!(wrong_session.exists());
+
+        let marker = write_marker(dir.path(), "session", 1_000);
+        body.messages[0].content = json!("not a compaction request");
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "second", false, 1_000));
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn historical_anchor_and_noncanonical_session_do_not_route() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "session", 1_000);
+        let mut body = request();
+        body.messages.push(
+            serde_json::from_value(json!({
+                "role": "assistant",
+                "content": "previous response"
+            }))
+            .unwrap(),
+        );
+        body.messages.push(
+            serde_json::from_value(json!({
+                "role": "user",
+                "content": "ordinary terminal prompt"
+            }))
+            .unwrap(),
+        );
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "request", false, 1_000));
+        assert!(marker.exists());
+
+        let upper_marker = write_marker(dir.path(), "UPPER", 1_000);
+        let mut compact = request();
+        assert!(
+            !route(dir.path()).try_route(&mut compact, Some("UPPER"), "request", false, 1_000,)
+        );
+        assert!(upper_marker.exists());
+    }
+
+    #[test]
+    fn routes_once_then_leaves_second_request_normal() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "session", 1_000);
+        let router = route(dir.path());
+        let mut first = request();
+        assert!(router.try_route(&mut first, Some("session"), "first", false, 1_000));
+        assert_eq!(first.model.as_deref(), Some("gpt-5.4"));
+        assert!(!marker.exists());
+        assert!(!dir.path().join("session.json.claim-first").exists());
+
+        let mut second = request();
+        assert!(!router.try_route(&mut second, Some("session"), "second", false, 1_000));
+        assert_eq!(second.model.as_deref(), Some("original-model"));
+    }
+
+    #[test]
+    fn stale_malformed_and_future_markers_fail_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = write_marker(dir.path(), "session", 1);
+        let mut body = request();
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "request", false, 61_002));
+        assert!(!stale.exists());
+
+        let malformed = dir.path().join("session.json");
+        fs::write(&malformed, "not json").unwrap();
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "again", false, 1_000));
+        assert!(!malformed.exists());
+
+        let future = write_marker(dir.path(), "session", 1_001);
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "future", false, 1_000));
+        assert!(!future.exists());
+    }
+
+    #[test]
+    fn malformed_output_config_leaves_marker_unclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = write_marker(dir.path(), "session", 1_000);
+        let mut body = request();
+        body.extra.insert(
+            "output_config".to_string(),
+            Value::String("invalid".to_string()),
+        );
+        assert!(!route(dir.path()).try_route(&mut body, Some("session"), "request", false, 1_000));
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn routing_preserves_unknown_output_config_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        write_marker(dir.path(), "session", 1_000);
+        let mut body = request();
+        body.extra.insert(
+            "output_config".to_string(),
+            json!({"format": {"type": "json_schema"}, "effort": "low"}),
+        );
+        body.extra
+            .insert("future_feature".to_string(), json!({"preserved": true}));
+        assert!(route(dir.path()).try_route(&mut body, Some("session"), "request", false, 1_000));
+        assert_eq!(
+            body.extra["output_config"],
+            json!({"format": {"type": "json_schema"}, "effort": "high"}),
+        );
+        assert_eq!(body.extra["future_feature"], json!({"preserved": true}));
+    }
+
+    #[test]
+    fn concurrent_claims_route_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        write_marker(dir.path(), "session", 1_000);
+        let router = Arc::new(route(dir.path()));
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let mut joins = Vec::new();
+        for request_id in ["first", "second"] {
+            let router = Arc::clone(&router);
+            let barrier = Arc::clone(&barrier);
+            joins.push(thread::spawn(move || {
+                let mut body = request();
+                barrier.wait();
+                router.try_route(&mut body, Some("session"), request_id, false, 1_000)
+            }));
+        }
+        let routed = joins
+            .into_iter()
+            .map(|join| join.join().unwrap())
+            .filter(|routed| *routed)
+            .count();
+        assert_eq!(routed, 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod auth;
+pub mod compaction_route;
 pub mod config;
 pub mod logging;
 pub mod monitor;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use crate::{
     anthropic::json_error,
+    compaction_route::{CompactionRoute, CompactionRouteConfig},
     logging::{Logger, REDACT_KEYS, create_logger},
     monitor::{EndpointKind, MonitorHandle},
     project,
@@ -88,19 +89,91 @@ pub async fn serve_listener(
             ),
         ])),
     );
-    let app = app_with_monitor(Arc::new(Registry::with_default_alias()), monitor);
+    let registry = Arc::new(Registry::with_default_alias());
+    let compaction_route = load_compaction_route_config(&registry);
+    let app = app_with_monitor_and_compaction_route(registry, monitor, compaction_route);
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
         .await?;
     Ok(())
 }
 
+fn load_compaction_route_config(registry: &Registry) -> Option<CompactionRouteConfig> {
+    let config = match CompactionRouteConfig::from_env() {
+        Ok(config) => config?,
+        Err(error) => {
+            create_logger("compaction_route").warn(
+                "compaction_route_disabled_invalid_config",
+                Some(Map::from_iter([(
+                    "error".to_string(),
+                    json!(error.to_string()),
+                )])),
+            );
+            return None;
+        }
+    };
+
+    validate_compaction_route_config(registry, config)
+}
+
+fn validate_compaction_route_config(
+    registry: &Registry,
+    config: CompactionRouteConfig,
+) -> Option<CompactionRouteConfig> {
+    if registry.provider_for_model(config.model(), None).is_none() {
+        create_logger("compaction_route").warn(
+            "compaction_route_disabled_unknown_model",
+            Some(Map::from_iter([(
+                "model".to_string(),
+                json!(config.model()),
+            )])),
+        );
+        return None;
+    }
+
+    Some(config)
+}
+
+#[cfg(test)]
+mod compaction_route_config_tests {
+    use super::*;
+
+    #[test]
+    fn unknown_target_is_rejected_before_router_state_is_built() {
+        let registry = Registry::with_default_alias();
+        let config = CompactionRouteConfig::from_values(
+            Some("not-a-configured-model".to_string()),
+            Some("medium".to_string()),
+            Some("markers".to_string()),
+            Some("60".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(validate_compaction_route_config(&registry, config).is_none());
+    }
+}
+
 pub fn app(registry: Arc<Registry>) -> Router {
-    app_with_monitor(registry, None)
+    app_with_monitor_and_compaction_route(registry, None, None)
 }
 
 pub fn app_with_monitor(registry: Arc<Registry>, monitor: Option<MonitorHandle>) -> Router {
-    let state = Arc::new(AppState { registry, monitor });
+    app_with_monitor_and_compaction_route(registry, monitor, None)
+}
+
+pub fn app_with_monitor_and_compaction_route(
+    registry: Arc<Registry>,
+    monitor: Option<MonitorHandle>,
+    compaction_route: Option<CompactionRouteConfig>,
+) -> Router {
+    let compaction_route = compaction_route
+        .and_then(|config| validate_compaction_route_config(registry.as_ref(), config));
+    let state = Arc::new(AppState {
+        registry,
+        monitor,
+        compaction_route: compaction_route.map(CompactionRoute::new),
+    });
     Router::new()
         .route("/healthz", get(healthz))
         .route("/v1/messages", post(handler_messages))
@@ -113,6 +186,7 @@ pub fn app_with_monitor(registry: Arc<Registry>, monitor: Option<MonitorHandle>)
 struct AppState {
     registry: Arc<Registry>,
     monitor: Option<MonitorHandle>,
+    compaction_route: Option<CompactionRoute>,
 }
 
 async fn healthz() -> Json<serde_json::Value> {
@@ -163,7 +237,6 @@ async fn dispatch_request(
         monitor.request_started(&req_id, session_id.clone(), None, endpoint);
     }
     let request_guard = RequestMonitorGuard::new(state.monitor.clone(), req_id.clone());
-    let now = current_millis();
     let body_bytes = match axum::body::to_bytes(req.into_body(), usize::MAX).await {
         Ok(bytes) => bytes,
         Err(err) => {
@@ -247,6 +320,14 @@ async fn dispatch_request(
             return response;
         }
     };
+
+    let now = current_millis();
+    let compaction_routed = state
+        .compaction_route
+        .as_ref()
+        .is_some_and(|compaction_route| {
+            compaction_route.try_route(&mut body, session_id.as_deref(), &req_id, count_tokens, now)
+        });
 
     if let Some(project) = project::name_from_request(
         body.extra.get("system"),
@@ -382,6 +463,7 @@ async fn dispatch_request(
         provider.name(),
         &normalized_model,
         now,
+        !compaction_routed,
     );
     if let Some(monitor) = state.monitor.as_ref() {
         if let Some(current) = current.as_ref() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -52,17 +52,24 @@ pub fn record_session_request(
     provider_name: &str,
     model: &str,
     now: u64,
+    update_affinity: bool,
 ) -> Option<SessionState> {
     let id = session_id?;
     let mut store = SESSIONS.lock().expect("session lock");
-    let mut next = prior.cloned().unwrap_or(SessionState {
-        seq: 0,
-        affinity_provider: None,
-        last_seen: now,
-    });
+    let mut next = store
+        .map
+        .get(id)
+        .cloned()
+        .or_else(|| prior.cloned())
+        .unwrap_or(SessionState {
+            seq: 0,
+            affinity_provider: None,
+            last_seen: now,
+        });
     next.seq += 1;
     next.last_seen = now;
-    if is_alias_routable_provider(provider_name)
+    if update_affinity
+        && is_alias_routable_provider(provider_name)
         && !crate::registry::is_anthropic_alias(normalize_incoming_model(model).as_str())
     {
         next.affinity_provider = Some(match provider_name {
@@ -101,4 +108,48 @@ pub fn reset_sessions_for_test() {
 
 pub fn affinity_provider_from_session(session: &SessionState) -> Option<AliasProvider> {
     session.affinity_provider
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_can_advance_session_without_changing_latest_affinity() {
+        reset_sessions_for_test();
+        let first = record_session_request(
+            Some("compaction-affinity-test"),
+            None,
+            "codex",
+            "gpt-5.6-sol",
+            1_000,
+            true,
+        )
+        .unwrap();
+        assert_eq!(first.affinity_provider, Some(AliasProvider::Codex));
+
+        let ordinary = record_session_request(
+            Some("compaction-affinity-test"),
+            Some(&first),
+            "kimi",
+            "kimi-for-coding",
+            1_500,
+            true,
+        )
+        .unwrap();
+        assert_eq!(ordinary.affinity_provider, Some(AliasProvider::Kimi));
+
+        let compacted = record_session_request(
+            Some("compaction-affinity-test"),
+            Some(&first),
+            "codex",
+            "gpt-5.6-terra",
+            2_000,
+            false,
+        )
+        .unwrap();
+        assert_eq!(compacted.seq, 3);
+        assert_eq!(compacted.last_seen, 2_000);
+        assert_eq!(compacted.affinity_provider, Some(AliasProvider::Kimi));
+    }
 }


### PR DESCRIPTION
## Summary

- route signaled compaction requests to a configurable dedicated model
- preserve the session's normal provider and model affinity
- add one-shot marker claiming with validation and expiration
- document the compaction routing configuration

## Testing

- verified compaction requests route to the configured model
- verified ordinary requests remain on the normal route
- verified markers are consumed only by matching compaction requests