### PR TITLE
fix(codex): surface rate limits as a clean 429, not a 502 retry storm

### DIFF
--- a/src/providers/codex/websocket.rs
+++ b/src/providers/codex/websocket.rs
@@ -876,6 +876,22 @@ async fn collect_ws_events(
                     last_response_event_at = Instant::now();
                 }
 
+                // A rate limit is authoritative: return it as a terminal 429
+                // now, so quota exhaustion is a clean 429 + Retry-After rather
+                // than a socket close misread as a retryable transport drop.
+                if let Some(failure) = super::events::classify_event_failure(&parsed)
+                    && failure.kind == super::events::CodexFailureKind::RateLimit
+                {
+                    invalidate_pool_owner(pool_key, pool_entry);
+                    return Err(CodexError {
+                        status: 429,
+                        message: failure.message,
+                        detail: Some("rate_limit_reached".to_string()),
+                        retry_after: failure.retry_after,
+                        origin: CodexErrorOrigin::WebSocket,
+                    });
+                }
+
                 // Check for terminal events
                 if is_terminal_event(&parsed) {
                     terminal_event = Some(WsEvent {
@@ -1035,6 +1051,29 @@ async fn stream_ws_events(
                 if parsed.get("type").and_then(|v| v.as_str()) == Some("error") {
                     status = event_error_status(&parsed).unwrap_or(500);
                 }
+
+                // A rate limit signalled mid-stream is authoritative: surface
+                // it as a terminal 429 immediately. Otherwise it is forwarded
+                // as an ordinary event that does not close the retry window,
+                // and the socket close that follows quota exhaustion is then
+                // misread as a retryable transport drop and re-driven into a
+                // 502 storm instead of a clean 429 + Retry-After.
+                if let Some(failure) = super::events::classify_event_failure(&parsed)
+                    && failure.kind == super::events::CodexFailureKind::RateLimit
+                {
+                    invalidate_pool_owner(pool_key, pool_entry);
+                    let _ = tx
+                        .send(Err(CodexError {
+                            status: 429,
+                            message: failure.message,
+                            detail: Some("rate_limit_reached".to_string()),
+                            retry_after: failure.retry_after,
+                            origin: CodexErrorOrigin::WebSocket,
+                        }))
+                        .await;
+                    break;
+                }
+
                 let terminal = is_terminal_event(&parsed);
                 if terminal && is_previous_response_missing(&parsed) {
                     invalidate_pool_owner(pool_key, pool_entry);

--- a/tests/smoke_cutover.rs
+++ b/tests/smoke_cutover.rs
@@ -1550,3 +1550,115 @@ async fn fault_disconnect_after_output_does_not_replay_request() {
         "after semantic output the request must not be replayed"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Fault injection: more transport faults (overload, malformed, no-reset)
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fault_overload_at_stream_start_maps_to_overloaded_error() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let upstream = spawn_websocket_fault_upstream(connections.clone(), |_| {
+        vec![
+            json!({
+                "type": "error",
+                "status": 529,
+                "error": {"type": "overloaded_error", "message": "overloaded"}
+            })
+            .to_string(),
+        ]
+    })
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "websocket");
+
+    let response = call_messages("gpt-5.5").await;
+    // 529 is retryable, so after the retry budget it surfaces as an
+    // overloaded_error, never a silent hang or a misclassified 500.
+    let status = response.status();
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(status, StatusCode::from_u16(529).unwrap());
+    assert_eq!(value["error"]["type"], "overloaded_error");
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fault_malformed_frame_does_not_crash_the_stream() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // A garbage frame, then a normal completion: the proxy must tolerate the
+    // unparseable frame and still deliver the real response.
+    let upstream = spawn_websocket_fault_upstream(connections.clone(), |_| {
+        vec![
+            "this is not json".to_string(),
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_up"}}"#.to_string(),
+            r#"{"type":"response.output_text.delta","output_index":0,"delta":"survived garbage"}"#.to_string(),
+            r#"{"type":"response.output_item.done","output_index":0,"item":{"type":"message"}}"#.to_string(),
+            r#"{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":5,"output_tokens":2}}}"#.to_string(),
+        ]
+    })
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "websocket");
+
+    let response = call_messages("gpt-5.5").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["content"][0]["text"], "survived garbage");
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fault_rate_limit_without_reset_still_returns_429() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // limit_reached with no primary/reset_after_seconds: still a clean 429,
+    // just without a precise Retry-After.
+    let upstream = spawn_websocket_fault_upstream(connections.clone(), |_| {
+        vec![
+            json!({"type": "codex.rate_limits", "rate_limits": {"limit_reached": true}})
+                .to_string(),
+        ]
+    })
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "websocket");
+
+    let response = call_messages("gpt-5.5").await;
+    let status = response.status();
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(value["error"]["type"], "rate_limit_error");
+}

--- a/tests/smoke_cutover.rs
+++ b/tests/smoke_cutover.rs
@@ -1355,16 +1355,6 @@ fn rate_limit_reached_event() -> String {
     .to_string()
 }
 
-// KNOWN BUG (upstream PR #30 territory): a rate limit at stream start is
-// classified as a generic upstream failure and returned as 502, so Claude
-// Code treats quota exhaustion as a server error and re-drives it. It should
-// be a clean 429 + Retry-After. Un-ignore once the classification is fixed.
-// Root cause (traced 2026-07-19): the codex.rate_limits{limit_reached} signal
-// is lost to the race with the subsequent WebSocket close, so the proxy sees a
-// generic connection reset (status 0) and maps it to 502 api_error instead of a
-// clean 429 rate_limit_error. Un-ignore once the rate-limit signal is
-// prioritized over the transport close.
-#[ignore = "known bug: quota exhaustion at stream start returns 502, not 429"]
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn fault_rate_limit_at_stream_start_returns_429_fast_without_retry_storm() {

--- a/tests/smoke_cutover.rs
+++ b/tests/smoke_cutover.rs
@@ -1298,3 +1298,265 @@ async fn smoke_codex_websocket_traffic_capture_writes_upstream_artifacts() {
     traffic_file(&files, "032-upstream-response-body.sse");
     traffic_file(&files, "040-upstream-event.json");
 }
+
+// ---------------------------------------------------------------------------
+// Fault injection: rate limits and retry boundaries
+// ---------------------------------------------------------------------------
+
+/// WebSocket upstream that serves each connection with `script(nth)`, counting
+/// how many connections the proxy opened (its retry behavior made visible).
+async fn spawn_websocket_fault_upstream(
+    connections: Arc<std::sync::atomic::AtomicUsize>,
+    script: fn(u32) -> Vec<String>,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let addr_str = format!("http://{addr}");
+
+    tokio::spawn(async move {
+        let mut nth: u32 = 0;
+        while let Ok((stream, _)) = listener.accept().await {
+            connections.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let events = script(nth);
+            nth += 1;
+            tokio::spawn(async move {
+                if let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await {
+                    let _ = ws.next().await;
+                    for event in events {
+                        let _ = ws.send(Message::Text(event)).await;
+                    }
+                }
+            });
+        }
+    });
+
+    addr_str
+}
+
+fn conn_count(c: &Arc<std::sync::atomic::AtomicUsize>) -> usize {
+    c.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Count logical Anthropic messages by the SSE event line, not the substring
+/// (which also appears in the data payload's "type" field).
+fn message_start_events(body: &str) -> usize {
+    body.matches("event: message_start").count()
+}
+
+fn rate_limit_reached_event() -> String {
+    json!({
+        "type": "codex.rate_limits",
+        "rate_limits": {
+            "limit_reached": true,
+            "allowed": false,
+            "primary": {"used_percent": 100, "window_minutes": 10080, "reset_after_seconds": 518773}
+        }
+    })
+    .to_string()
+}
+
+// KNOWN BUG (upstream PR #30 territory): a rate limit at stream start is
+// classified as a generic upstream failure and returned as 502, so Claude
+// Code treats quota exhaustion as a server error and re-drives it. It should
+// be a clean 429 + Retry-After. Un-ignore once the classification is fixed.
+// Root cause (traced 2026-07-19): the codex.rate_limits{limit_reached} signal
+// is lost to the race with the subsequent WebSocket close, so the proxy sees a
+// generic connection reset (status 0) and maps it to 502 api_error instead of a
+// clean 429 rate_limit_error. Un-ignore once the rate-limit signal is
+// prioritized over the transport close.
+#[ignore = "known bug: quota exhaustion at stream start returns 502, not 429"]
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fault_rate_limit_at_stream_start_returns_429_fast_without_retry_storm() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let upstream =
+        spawn_websocket_fault_upstream(connections.clone(), |_| vec![rate_limit_reached_event()])
+            .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "websocket");
+
+    let started = std::time::Instant::now();
+    let response = call_messages("gpt-5.5").await;
+    let elapsed = started.elapsed();
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    let retry_after = response
+        .headers()
+        .get(http::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(retry_after, "518773", "Retry-After must carry the reset");
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["error"]["type"], "rate_limit_error");
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "quota exhaustion must fail fast, took {elapsed:?}"
+    );
+    assert_eq!(
+        conn_count(&connections),
+        1,
+        "an exhausted quota must not be retried against the upstream"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fault_rate_limit_mid_stream_surfaces_error_without_replaying_request() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let upstream = spawn_websocket_fault_upstream(connections.clone(), |_| {
+        vec![
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_up"}}"#.to_string(),
+            r#"{"type":"response.output_text.delta","output_index":0,"delta":"partial text"}"#.to_string(),
+            rate_limit_reached_event(),
+        ]
+    })
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "websocket");
+
+    let response = call_messages_body(json!({
+        "model": "gpt-5.5",
+        "max_tokens": 64,
+        "stream": true,
+        "messages": [{"role":"user","content":"hello"}]
+    }))
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap();
+
+    assert!(body.contains("partial text"), "streamed text must be kept");
+    assert!(
+        body.contains("event: error"),
+        "mid-stream rate limit must surface as an SSE error event, body: {body}"
+    );
+    assert_eq!(
+        message_start_events(&body),
+        1,
+        "no silent replay: exactly one logical message"
+    );
+    assert_eq!(
+        conn_count(&connections),
+        1,
+        "after semantic output the request must not be replayed"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fault_disconnect_before_output_retries_transparently() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let upstream = spawn_websocket_fault_upstream(connections.clone(), |nth| {
+        if nth == 0 {
+            vec![] // close before any event: retryable
+        } else {
+            vec![
+                r#"{"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_up"}}"#.to_string(),
+                r#"{"type":"response.output_text.delta","output_index":0,"delta":"recovered ok"}"#.to_string(),
+                r#"{"type":"response.output_item.done","output_index":0,"item":{"type":"message"}}"#.to_string(),
+                r#"{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":5,"output_tokens":2}}}"#.to_string(),
+            ]
+        }
+    })
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "websocket");
+
+    let response = call_messages("gpt-5.5").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let value: Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(value["content"][0]["text"], "recovered ok");
+    assert!(
+        conn_count(&connections) >= 2,
+        "pre-output disconnect must be retried"
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fault_disconnect_after_output_does_not_replay_request() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let connections = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let upstream = spawn_websocket_fault_upstream(connections.clone(), |_| {
+        vec![
+            r#"{"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_up"}}"#.to_string(),
+            r#"{"type":"response.output_text.delta","output_index":0,"delta":"partial before drop"}"#.to_string(),
+            // close without a terminal event
+        ]
+    })
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "websocket");
+
+    let response = call_messages_body(json!({
+        "model": "gpt-5.5",
+        "max_tokens": 64,
+        "stream": true,
+        "messages": [{"role":"user","content":"hello"}]
+    }))
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap();
+
+    assert!(body.contains("partial before drop"));
+    assert!(
+        body.contains("event: error"),
+        "post-output disconnect must surface an error event"
+    );
+    assert_eq!(
+        message_start_events(&body),
+        1,
+        "no duplicated message after post-output disconnect"
+    );
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        conn_count(&connections),
+        1,
+        "after semantic output the request must not be replayed"
+    );
+}


### PR DESCRIPTION
Closes #65.

## Problem

A `codex.rate_limits` event with `limit_reached` does not close the live retry window (`event_closes_live_retry_window` excludes it). So when the upstream signals quota exhaustion and then closes the socket, the close is misread as a retryable transport drop, re-driven up to the retry cap, and finally mapped to **502 `api_error`**. Claude Code treats a hit quota window as a server error and re-drives the whole request: a 502 storm on an already-exhausted account.

## Fix

Both WebSocket readers (buffered and live) now treat a `limit_reached` rate-limit event as **authoritative**: they return a terminal **429** carrying `Retry-After` from `reset_after_seconds`, via the existing `classify_event_failure` helper. With a real reset far in the future the backoff budget is exceeded and the 429 is returned immediately, so quota exhaustion fails fast instead of storming.

## Tests

This PR also adds a small fault-injection harness (`spawn_websocket_fault_upstream`, which counts proxy connection attempts so retry behavior is observable) with four scenarios:

| scenario | asserts |
|---|---|
| rate limit at stream start | fast 429 + `Retry-After`, **one** upstream connection (no storm) |
| rate limit mid-stream after output | error event, request not replayed |
| disconnect before output | retried transparently |
| disconnect after output | error event, exactly one message, not replayed |

The first was written failing (it reproduced the 502) and passes with the fix. Before: 502 after ~12s of retries. After: 429 in <2s, one connection.

`cargo test` green, `cargo fmt --check` clean, clippy unchanged. Verified against `upstream/main`; independent of the /usage PR (#62).