### PR TITLE
feat(codex): allow disabling reasoning signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Codex encrypted reasoning continuation signatures can now be disabled with
+  `codex.reasoningSignatures` / `CCP_CODEX_REASONING_SIGNATURES`, reducing
+  transcript growth in tool-heavy Claude Code sessions.
+
 ## v0.1.22 (2026-07-20)
 
 - Grok accepts request metadata and tool-result references sent by current Claude

--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ Windows, and at
     "model": "gpt-5.4",
     "effort": "medium",
     "reasoningSummary": "auto",
+    "reasoningSignatures": "on",
     "serviceTier": "fast",
     "baseUrl": "https://chatgpt.com/backend-api/codex/responses",
     "transport": "websocket",
@@ -730,6 +731,7 @@ Windows, and at
 | `CCP_CODEX_MODEL`                | `codex.model`              | unset                                             | Force all Codex requests to this model (`gpt-5.2`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`) |
 | `CCP_CODEX_EFFORT`               | `codex.effort`             | unset                                             | Force all Codex requests to this reasoning effort (`none`, `low`, `medium`, `high`, `xhigh`, `max`)                                                                               |
 | `CCP_CODEX_REASONING_SUMMARY`    | `codex.reasoningSummary`   | unset                                             | Request Codex reasoning summaries when reasoning effort is enabled; `off` and `none` suppress summaries                                                                           |
+| `CCP_CODEX_REASONING_SIGNATURES` | `codex.reasoningSignatures` | `on`                                              | Preserve Codex encrypted reasoning continuation in Anthropic thinking signatures; `off`, `none`, `false`, and `0` suppress signature storage                                      |
 | `CCP_CODEX_SERVICE_TIER`         | `codex.serviceTier`        | unset                                             | Force all Codex requests to this service tier (`fast`/`priority`, `flex`; `fast` is sent upstream as `priority`)                                                                  |
 | `CCP_CODEX_BASE_URL`             | `codex.baseUrl`            | `https://chatgpt.com/backend-api/codex/responses` | Override the Codex Responses endpoint                                                                                                                                             |
 | `CCP_CODEX_TRANSPORT`            | `codex.transport`          | `websocket`                                       | Codex transport: `websocket`, `http`, or `auto`                                                                                                                                   |
@@ -1031,6 +1033,8 @@ supported shape.
   (Kimi accepts them in `role:"tool"` content).
 - **Codex — reasoning blocks:** not forwarded to Claude Code (dropped), even if
   the upstream model produced them.
+  Encrypted continuation signatures are preserved by default and can be disabled
+  with `codex.reasoningSignatures` / `CCP_CODEX_REASONING_SIGNATURES`.
 - **Kimi — reasoning blocks:** forwarded as Anthropic `thinking` content blocks
   and rendered by Claude Code. Disable by setting
   `thinking: {"type":"disabled"}` in your Anthropic request.

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,8 @@ struct CodexConfig {
     pub service_tier: Option<String>,
     #[serde(rename = "reasoningSummary")]
     pub reasoning_summary: Option<String>,
+    #[serde(rename = "reasoningSignatures")]
+    pub reasoning_signatures: Option<String>,
     #[serde(rename = "effort")]
     pub effort: Option<String>,
     #[serde(rename = "model")]
@@ -244,6 +246,12 @@ pub fn config_override_summary_lines(cfg: &LoadedConfig) -> Vec<String> {
     {
         out.push("CCP_CODEX_REASONING_SUMMARY (env)".to_string());
     }
+    if env
+        .get("CCP_CODEX_REASONING_SIGNATURES")
+        .is_some_and(|raw| !raw.is_empty())
+    {
+        out.push("CCP_CODEX_REASONING_SIGNATURES (env)".to_string());
+    }
     if let Some(file_cfg) = file {
         if let Some(bind_address) = file_cfg.bind_address {
             out.push(format!("bindAddress: {bind_address}"));
@@ -262,11 +270,17 @@ pub fn config_override_summary_lines(cfg: &LoadedConfig) -> Vec<String> {
                 out.push(format!("log.stderr: {v}"));
             }
         }
-        if let Some(codex) = file_cfg.codex
-            && let Some(summary) = codex.reasoning_summary
-            && !summary.is_empty()
-        {
-            out.push("codex.reasoningSummary (config)".to_string());
+        if let Some(codex) = file_cfg.codex {
+            if let Some(summary) = codex.reasoning_summary
+                && !summary.is_empty()
+            {
+                out.push("codex.reasoningSummary (config)".to_string());
+            }
+            if let Some(signatures) = codex.reasoning_signatures
+                && !signatures.is_empty()
+            {
+                out.push("codex.reasoningSignatures (config)".to_string());
+            }
         }
     }
     out
@@ -466,6 +480,28 @@ pub fn codex_reasoning_summary() -> Option<String> {
     None
 }
 
+pub fn codex_reasoning_signatures_enabled() -> bool {
+    let env: HashMap<_, _> = std::env::vars().collect();
+    if let Some(raw) = env
+        .get("CCP_CODEX_REASONING_SIGNATURES")
+        .filter(|raw| !raw.is_empty())
+    {
+        return reasoning_signatures_enabled(raw);
+    }
+    let config_dir = paths::config_dir();
+    if let Some(file) = read_file_config(&config_dir)
+        && let Some(codex) = file.codex
+        && let Some(signatures) = codex.reasoning_signatures.filter(|raw| !raw.is_empty())
+    {
+        return reasoning_signatures_enabled(&signatures);
+    }
+    true
+}
+
+fn reasoning_signatures_enabled(raw: &str) -> bool {
+    !matches!(raw, "off" | "none" | "false" | "0")
+}
+
 pub fn codex_model() -> Option<String> {
     let env: HashMap<_, _> = std::env::vars().collect();
     if let Some(raw) = env.get("CCP_CODEX_MODEL") {
@@ -592,6 +628,7 @@ mod tests {
             std::env::remove_var("CCP_LOG_VERBOSE");
             std::env::remove_var("CCP_LOG_STDERR");
             std::env::remove_var("CCP_CODEX_REASONING_SUMMARY");
+            std::env::remove_var("CCP_CODEX_REASONING_SIGNATURES");
         }
     }
 
@@ -781,5 +818,44 @@ mod tests {
             let _summary_env = EnvGuard::set("CCP_CODEX_REASONING_SUMMARY", "");
             assert_eq!(codex_reasoning_summary().as_deref(), Some("off"));
         }
+    }
+
+    #[test]
+    fn codex_reasoning_signatures_default_to_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_env();
+
+        assert!(codex_reasoning_signatures_enabled());
+    }
+
+    #[test]
+    fn codex_reasoning_signatures_reads_config() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_env();
+        let config = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            config.path().join("config.json"),
+            r#"{"codex":{"reasoningSignatures":"off"}}"#,
+        )
+        .unwrap();
+        let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+
+        assert!(!codex_reasoning_signatures_enabled());
+    }
+
+    #[test]
+    fn codex_reasoning_signatures_env_overrides_config() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_env();
+        let config = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            config.path().join("config.json"),
+            r#"{"codex":{"reasoningSignatures":"off"}}"#,
+        )
+        .unwrap();
+        let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+        let _signature_env = EnvGuard::set("CCP_CODEX_REASONING_SIGNATURES", "on");
+
+        assert!(codex_reasoning_signatures_enabled());
     }
 }

--- a/src/providers/codex/translate/live_stream.rs
+++ b/src/providers/codex/translate/live_stream.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::anthropic::sse::encode_sse_event;
+use crate::config;
 use crate::providers::codex::events::is_terminal_rate_limit_event;
 use crate::traffic::TrafficCapture;
 
@@ -936,6 +937,9 @@ impl LiveStreamTranslator {
         traffic: Option<&TrafficCapture>,
         out: &mut Vec<u8>,
     ) {
+        if !config::codex_reasoning_signatures_enabled() {
+            return;
+        }
         let Some(replay) = self
             .reasoning_by_output_index
             .remove(&output_index)
@@ -984,22 +988,26 @@ impl LiveStreamTranslator {
         let Some(thinking) = self.thinking.take() else {
             return;
         };
-        if let Some(signature) = self
+        let replay = self
             .reasoning_by_output_index
             .remove(&thinking.output_index)
-            .and_then(|pending| pending.replay())
-            .and_then(|replay| encode_reasoning_signature(&replay))
-        {
-            self.emit(
-                traffic,
-                out,
-                "content_block_delta",
-                &serde_json::json!({
-                    "type": "content_block_delta",
-                    "index": thinking.anthropic_index,
-                    "delta": {"type": "signature_delta", "signature": signature}
-                }),
-            );
+            .and_then(|pending| pending.replay());
+        if config::codex_reasoning_signatures_enabled() {
+            if let Some(signature) = replay
+                .as_ref()
+                .and_then(|replay| encode_reasoning_signature(replay))
+            {
+                self.emit(
+                    traffic,
+                    out,
+                    "content_block_delta",
+                    &serde_json::json!({
+                        "type": "content_block_delta",
+                        "index": thinking.anthropic_index,
+                        "delta": {"type": "signature_delta", "signature": signature}
+                    }),
+                );
+            }
         }
         self.emit(
             traffic,

--- a/src/providers/codex/translate/reducer.rs
+++ b/src/providers/codex/translate/reducer.rs
@@ -1,4 +1,5 @@
 use crate::anthropic::sse::parse_sse_events;
+use crate::config;
 use crate::providers::codex::events::is_terminal_rate_limit_event;
 
 use super::read_rewrite::sanitize_read_args;
@@ -169,16 +170,19 @@ fn finalize_active_thinking(
     reasoning_by_output_index: &mut std::collections::HashMap<usize, PendingReasoning>,
     output_items_by_index: &mut std::collections::BTreeMap<usize, ResponsesInputItem>,
 ) {
-    if let Some(replay) = reasoning_by_output_index
+    let replay = reasoning_by_output_index
         .remove(&active.output_index)
-        .and_then(|pending| pending.replay())
-        && let Some(signature) = encode_reasoning_signature(&replay)
-    {
-        out.push(ReducerEvent::ThinkingSignature {
-            index: active.anthropic_index,
-            signature,
-        });
-        output_items_by_index.insert(active.output_index, reasoning_input_item(replay));
+        .and_then(|pending| pending.replay());
+    if config::codex_reasoning_signatures_enabled() {
+        if let Some(replay) = replay
+            && let Some(signature) = encode_reasoning_signature(&replay)
+        {
+            out.push(ReducerEvent::ThinkingSignature {
+                index: active.anthropic_index,
+                signature,
+            });
+            output_items_by_index.insert(active.output_index, reasoning_input_item(replay));
+        }
     }
     out.push(ReducerEvent::ThinkingStop {
         index: active.anthropic_index,
@@ -208,6 +212,10 @@ fn emit_signature_only_reasoning(
     reasoning_by_output_index: &mut std::collections::HashMap<usize, PendingReasoning>,
     output_items_by_index: &mut std::collections::BTreeMap<usize, ResponsesInputItem>,
 ) {
+    if !config::codex_reasoning_signatures_enabled() {
+        reasoning_by_output_index.remove(&output_index);
+        return;
+    }
     let Some(replay) = reasoning_by_output_index
         .remove(&output_index)
         .and_then(|pending| pending.replay())

--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -510,7 +510,7 @@ pub fn translate_request(
             context: opts.use_responses_lite.then_some("all_turns".to_string()),
         });
     }
-    if resolved_effort.is_some() {
+    if resolved_effort.is_some() && config::codex_reasoning_signatures_enabled() {
         out.include = Some(vec!["reasoning.encrypted_content".to_string()]);
     }
 


### PR DESCRIPTION
## Problem

The proxy preserves Codex encrypted reasoning continuation by storing it in Anthropic thinking signatures. That keeps multi-turn Codex reasoning replay available, but it can also add large signature-only `thinking` blocks to Claude Code transcripts.

For tool-heavy Claude Code sessions, those opaque signatures increase transcript size and context pressure even when visible reasoning summaries are disabled.

## Change

- Add `codex.reasoningSignatures` / `CCP_CODEX_REASONING_SIGNATURES`.
- Keep signatures enabled by default to preserve the existing continuation behavior.
- Treat `off`, `none`, `false`, and `0` as disabled values.
- When disabled, skip `reasoning.encrypted_content` includes and suppress downstream reasoning signature emission in live and reducer paths.
- Document the new option in README and changelog.

## Verification

- `cargo fmt --check`
- `cargo test`
