### PR TITLE
fix(codex): preserve tool choice semantics

### DIFF
--- a/src/providers/codex/translate/request.rs
+++ b/src/providers/codex/translate/request.rs
@@ -49,11 +49,17 @@ pub enum ServiceTier {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ResponsesToolChoice {
+#[serde(rename_all = "snake_case")]
+pub enum ResponsesToolChoiceMode {
     Auto,
     None,
     Required,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ResponsesToolChoice {
+    Mode(ResponsesToolChoiceMode),
     Function {
         r#type: String,
         name: String,
@@ -427,6 +433,7 @@ pub fn translate_request(
     let input = build_input(req);
     let tools = read_tools(req)?;
     let tool_choice = map_tool_choice(req)?;
+    let parallel_tool_calls = !disable_parallel_tool_use(req);
 
     let mut text = ResponsesText {
         verbosity: Some("low".to_string()),
@@ -443,7 +450,7 @@ pub fn translate_request(
         input,
         store: false,
         stream: true,
-        parallel_tool_calls: true,
+        parallel_tool_calls,
         tool_choice,
         text,
         tools: None,
@@ -504,7 +511,7 @@ pub fn translate_request(
                 .any(|tool| matches!(tool, ResponsesTool::WebSearch(_)))
         });
         if !has_web_search {
-            out.tool_choice = Some(ResponsesToolChoice::Auto);
+            out.tool_choice = Some(ResponsesToolChoice::Mode(ResponsesToolChoiceMode::Auto));
         }
     }
 
@@ -698,10 +705,10 @@ fn map_tool_choice(req: &MessagesRequest) -> Result<Option<ResponsesToolChoice>,
         Some(Value::Object(m)) => m,
         Some(Value::String(s)) => {
             return Ok(Some(match s.as_str() {
-                "auto" => ResponsesToolChoice::Auto,
-                "none" => ResponsesToolChoice::None,
-                "any" | "required" => ResponsesToolChoice::Required,
-                _ => ResponsesToolChoice::Auto,
+                "auto" => ResponsesToolChoice::Mode(ResponsesToolChoiceMode::Auto),
+                "none" => ResponsesToolChoice::Mode(ResponsesToolChoiceMode::None),
+                "any" | "required" => ResponsesToolChoice::Mode(ResponsesToolChoiceMode::Required),
+                _ => ResponsesToolChoice::Mode(ResponsesToolChoiceMode::Auto),
             }));
         }
         _ => return Ok(None),
@@ -712,9 +719,15 @@ fn map_tool_choice(req: &MessagesRequest) -> Result<Option<ResponsesToolChoice>,
         .and_then(|v| v.as_str())
         .unwrap_or("auto");
     match choice_type {
-        "auto" => Ok(Some(ResponsesToolChoice::Auto)),
-        "none" => Ok(Some(ResponsesToolChoice::None)),
-        "any" | "required" => Ok(Some(ResponsesToolChoice::Required)),
+        "auto" => Ok(Some(ResponsesToolChoice::Mode(
+            ResponsesToolChoiceMode::Auto,
+        ))),
+        "none" => Ok(Some(ResponsesToolChoice::Mode(
+            ResponsesToolChoiceMode::None,
+        ))),
+        "any" | "required" => Ok(Some(ResponsesToolChoice::Mode(
+            ResponsesToolChoiceMode::Required,
+        ))),
         "tool" => {
             let name = choice.get("name").and_then(|v| v.as_str()).unwrap_or("");
             let tools = req.extra.get("tools").and_then(|v| v.as_array());
@@ -739,6 +752,15 @@ fn map_tool_choice(req: &MessagesRequest) -> Result<Option<ResponsesToolChoice>,
         }
         _ => Ok(None),
     }
+}
+
+fn disable_parallel_tool_use(req: &MessagesRequest) -> bool {
+    req.extra
+        .get("tool_choice")
+        .and_then(Value::as_object)
+        .and_then(|choice| choice.get("disable_parallel_tool_use"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn build_input(req: &MessagesRequest) -> Vec<ResponsesInputItem> {
@@ -1100,6 +1122,95 @@ mod tests {
     }
 
     #[test]
+    fn responses_tool_choice_modes_serialize_as_openai_strings() {
+        for (mode, expected) in [
+            (ResponsesToolChoiceMode::Auto, json!("auto")),
+            (ResponsesToolChoiceMode::None, json!("none")),
+            (ResponsesToolChoiceMode::Required, json!("required")),
+        ] {
+            assert_eq!(
+                serde_json::to_value(ResponsesToolChoice::Mode(mode)).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn translate_tool_choice_preserves_wire_and_parallel_semantics() {
+        for (tool_choice, expected_choice, expected_parallel) in [
+            (json!({"type":"auto"}), json!("auto"), true),
+            (
+                json!({"type":"auto","disable_parallel_tool_use":false}),
+                json!("auto"),
+                true,
+            ),
+            (json!({"type":"none"}), json!("none"), true),
+            (json!({"type":"any"}), json!("required"), true),
+            (
+                json!({"type":"any","disable_parallel_tool_use":true}),
+                json!("required"),
+                false,
+            ),
+            (
+                json!({
+                    "type":"tool",
+                    "name":"test",
+                    "disable_parallel_tool_use":true
+                }),
+                json!({"type":"function","name":"test"}),
+                false,
+            ),
+        ] {
+            let req: MessagesRequest = serde_json::from_value(json!({
+                "model": "gpt-5.5",
+                "messages": [{"role":"user", "content":"use the tool"}],
+                "tools": [{
+                    "name":"test",
+                    "input_schema":{"type":"object","properties":{}}
+                }],
+                "tool_choice": tool_choice
+            }))
+            .unwrap();
+            let wire = serde_json::to_value(translate_request(&req, opts()).unwrap()).unwrap();
+
+            assert_eq!(wire["tool_choice"], expected_choice);
+            assert_eq!(wire["parallel_tool_calls"], expected_parallel);
+        }
+    }
+
+    #[test]
+    fn responses_lite_keeps_parallel_tool_calls_disabled() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "gpt-5.6-luna",
+            "messages": [{"role":"user", "content":"use the tool"}],
+            "tools": [{
+                "name":"test",
+                "input_schema":{"type":"object","properties":{}}
+            }],
+            "tool_choice": {
+                "type":"any",
+                "disable_parallel_tool_use":false
+            }
+        }))
+        .unwrap();
+        let wire = serde_json::to_value(
+            translate_request(
+                &req,
+                TranslateOptions {
+                    model: "gpt-5.6-luna".to_string(),
+                    use_responses_lite: true,
+                    ..opts()
+                },
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(wire["tool_choice"], json!("required"));
+        assert_eq!(wire["parallel_tool_calls"], false);
+    }
+
+    #[test]
     fn translate_web_search_tool_to_codex_tool() {
         let req: MessagesRequest = serde_json::from_value(json!({
             "model": "gpt-5.5",
@@ -1278,7 +1389,14 @@ mod tests {
         )
         .unwrap();
         assert!(out.tools.is_none());
-        assert!(matches!(out.tool_choice, Some(ResponsesToolChoice::Auto)));
+        assert!(matches!(
+            out.tool_choice,
+            Some(ResponsesToolChoice::Mode(ResponsesToolChoiceMode::Auto))
+        ));
+        assert_eq!(
+            serde_json::to_value(&out).unwrap()["tool_choice"],
+            json!("auto")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- serialize Codex Responses tool-choice modes as the OpenAI wire strings
  `"auto"`, `"none"`, and `"required"` instead of JSON `null`
- translate Anthropic's nested `disable_parallel_tool_use` flag into the
  top-level OpenAI `parallel_tool_calls` field
- keep Responses Lite parallel tool calls disabled
- add wire-level regression coverage for automatic, disabled, required, and
  forced-function tool choices

## Why

Anthropic and OpenAI expose the same controls using different request shapes:

- Anthropic places `disable_parallel_tool_use` inside `tool_choice`.
  With `auto`, it permits at most one tool call; with `any` or a named tool, it
  requires exactly one.
- OpenAI Responses represents `auto`, `none`, and `required` as JSON strings,
  forced functions as `{"type":"function","name":"..."}`, and parallelism as
  the separate top-level `parallel_tool_calls` boolean.

CCP previously represented the three string modes as unit variants inside a
Serde `untagged` enum. Serde serializes those variants as JSON `null`, so
`none` and `any` lost their meaning on the wire. The full Responses lane also
always sent `parallel_tool_calls: true`, ignoring Claude Code's explicit
single-tool constraint.

References:

- [Anthropic: parallel tool use and `disable_parallel_tool_use`](https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use)
- [Anthropic SDK tool-choice types](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/messages/messages.ts#L1853-L1912)
- [OpenAI: tool choice](https://developers.openai.com/api/docs/guides/function-calling#tool-choice)
- [OpenAI: parallel function calling](https://developers.openai.com/api/docs/guides/function-calling#parallel-function-calling)
- [OpenAI Responses request types](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_create_params.py#L1347-L1349)
- [Codex Responses request shape](https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/common.rs#L1450-L1469)

## Validation

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- formatter and `git diff --check`
- live Codex verification:
  - `tool_choice: none` returned text without a tool call
  - `tool_choice: any` with parallel use disabled returned exactly one tool call
  - a forced named tool called the requested function
  - captured upstream requests contained `"none"`, `"required"`, or the
    function object and the expected `parallel_tool_calls` value
