### PR TITLE
fix(codex): restore o200k token estimates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +365,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "tiktoken-rs",
  "time",
  "tokio",
  "tokio-rustls",
@@ -584,6 +600,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2139,6 +2166,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ flate2 = "1.0"
 ratatui = "0.29"
 crossterm = "0.28"
 jiff = { version = "0.2", default-features = false, features = ["std", "tz-system", "tzdb-zoneinfo"] }
+tiktoken-rs = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -43,6 +43,6 @@ Claude Code sends `x-claude-code-session-id`. The proxy uses it for monitor grou
 
 ## Count tokens
 
-`POST /v1/messages/count_tokens` performs a local estimate with `gpt-tokenizer` and the `o200k_base` encoding. It supports Claude Code's compaction decisions without an upstream request.
+`POST /v1/messages/count_tokens` stays local and does not make an upstream request. Codex uses `o200k_base` for text plus estimates for images, encrypted reasoning, and protocol framing. Other providers use their own local estimators. The result supports Claude Code's compaction decisions but is not a provider billing count.
 
 See [HTTP API](/reference/http-api/) for route contracts and [Compatibility and limitations](/reference/compatibility-and-limitations/) for translation boundaries.

--- a/docs/src/content/docs/reference/http-api.md
+++ b/docs/src/content/docs/reference/http-api.md
@@ -37,7 +37,7 @@ Accepts the same basic Anthropic request shape and returns:
 {"input_tokens":1234}
 ```
 
-Codex, Kimi, and Grok use a local `gpt-tokenizer` estimate with `o200k_base`. Cursor estimates the rendered prompt from its character length. Counts support Claude Code compaction behavior and are estimates rather than provider billing values.
+Codex tokenizes text locally with `o200k_base` and adds estimates for images, encrypted reasoning, and protocol framing. Kimi and Grok use local text heuristics, while Cursor estimates the rendered prompt from its character length. Counts support Claude Code compaction behavior and are estimates rather than provider billing values.
 
 ## `GET /v1/models`
 

--- a/src/providers/codex/count_tokens.rs
+++ b/src/providers/codex/count_tokens.rs
@@ -2,10 +2,12 @@ use super::translate::request::{
     ResponsesContentPart, ResponsesFunctionCallOutput, ResponsesFunctionCallOutputContentPart,
     ResponsesInputItem, ResponsesRequest, ResponsesTool,
 };
+use tiktoken_rs::o200k_base_singleton;
 
 /// Approximate token counter for Codex translated requests.
-/// Uses a simple monotonic estimator that satisfies Claude Code's
-/// compaction logic (needs approximate, not exact counts).
+/// Text uses the OpenAI `o200k_base` tokenizer. Images, encrypted reasoning,
+/// and protocol framing still use local estimates, so the result is not a
+/// provider billing count.
 pub fn count_translated_tokens(translated: &ResponsesRequest) -> u64 {
     let mut total = 0u64;
 
@@ -117,27 +119,30 @@ fn count_tool_tokens(tools: &[ResponsesTool]) -> u64 {
 }
 
 pub(crate) fn approx_token_count(text: &str) -> u64 {
-    if text.is_empty() {
-        return 0;
-    }
-    let mut count = 0u64;
-    let mut in_word = false;
+    u64::try_from(o200k_base_singleton().count_ordinary(text)).unwrap_or(u64::MAX)
+}
 
-    for ch in text.chars() {
-        if ch.is_alphanumeric() || ch == '-' || ch == '_' {
-            if !in_word {
-                count += 1;
-                in_word = true;
-            }
-        } else {
-            in_word = false;
-            if !ch.is_whitespace() {
-                count += 1;
-            }
+pub(crate) fn truncate_to_token_budget(text: &str, max_tokens: u64) -> String {
+    let max_tokens = usize::try_from(max_tokens).unwrap_or(usize::MAX);
+    if max_tokens == 0 {
+        return String::new();
+    }
+
+    let tokenizer = o200k_base_singleton();
+    let tokens = tokenizer.encode_ordinary(text);
+    if tokens.len() <= max_tokens {
+        return text.to_string();
+    }
+
+    // A token boundary may split a multi-byte UTF-8 scalar. Back up until the
+    // decoded prefix is valid rather than replacing bytes or splitting text.
+    for end in (1..=max_tokens).rev() {
+        if let Ok(prefix) = tokenizer.decode(&tokens[..end]) {
+            return prefix;
         }
     }
 
-    count.max(1)
+    String::new()
 }
 
 #[cfg(test)]
@@ -197,6 +202,34 @@ mod tests {
         }))
         .unwrap();
         assert!(count_translated_tokens(&long) >= count_translated_tokens(&short));
+    }
+
+    #[test]
+    fn o200k_counts_unbroken_text_instead_of_collapsing_it() {
+        assert_eq!(approx_token_count(&"a".repeat(4096)), 512);
+        assert_eq!(approx_token_count(&"汉字测试上下文压缩".repeat(384)), 2688);
+        assert_eq!(
+            approx_token_count(&"QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo".repeat(112)),
+            2240
+        );
+        assert_eq!(
+            approx_token_count(&"function f(a){return a===0?1:a*f(a-1)};".repeat(96)),
+            1632
+        );
+    }
+
+    #[test]
+    fn truncation_respects_o200k_budget_and_utf8_boundaries() {
+        for text in [
+            "a".repeat(4096),
+            "汉字测试上下文压缩".repeat(384),
+            "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo".repeat(112),
+        ] {
+            let truncated = truncate_to_token_budget(&text, 100);
+            assert!(text.starts_with(&truncated));
+            assert!(approx_token_count(&truncated) <= 100);
+            assert!(!truncated.is_empty());
+        }
     }
 
     #[test]

--- a/src/providers/codex/search.rs
+++ b/src/providers/codex/search.rs
@@ -7,7 +7,7 @@ use crate::anthropic::schema::MessagesRequest;
 use crate::anthropic::sse::encode_sse_event;
 use crate::traffic::TrafficCapture;
 
-use super::count_tokens::approx_token_count;
+use super::count_tokens::{approx_token_count, truncate_to_token_budget};
 
 const SEARCH_OUTPUT_TOKEN_BUDGET: u64 = 2_500;
 const SEARCH_ASSISTANT_CONTEXT_TOKEN_BUDGET: u64 = 1_000;
@@ -364,7 +364,7 @@ fn search_input(req: &MessagesRequest) -> Option<Value> {
                 if assistant_budget == 0 {
                     return None;
                 }
-                let text = truncate_to_approx_tokens(&text, assistant_budget);
+                let text = truncate_to_token_budget(&text, assistant_budget);
                 assistant_budget = assistant_budget.saturating_sub(approx_token_count(&text));
                 ("output_text", text)
             } else {
@@ -380,33 +380,6 @@ fn search_input(req: &MessagesRequest) -> Option<Value> {
         })
         .collect();
     (!items.is_empty()).then_some(Value::Array(items))
-}
-
-fn truncate_to_approx_tokens(text: &str, max_tokens: u64) -> String {
-    if approx_token_count(text) <= max_tokens {
-        return text.to_string();
-    }
-
-    let mut tokens = 0_u64;
-    let mut in_word = false;
-    let mut end = 0;
-    for (index, ch) in text.char_indices() {
-        let word_char = ch.is_alphanumeric() || ch == '-' || ch == '_';
-        let starts_token = if word_char {
-            !in_word
-        } else {
-            !ch.is_whitespace()
-        };
-        if starts_token {
-            if tokens == max_tokens {
-                break;
-            }
-            tokens += 1;
-        }
-        in_word = word_char;
-        end = index + ch.len_utf8();
-    }
-    text[..end].to_string()
 }
 
 fn content_text(content: &Value) -> String {


### PR DESCRIPTION
## Summary

- restore `o200k_base` text tokenization for Codex `/v1/messages/count_tokens`
- keep image, encrypted-reasoning, and protocol-framing costs as explicit local estimates
- use the same tokenizer for standalone-search truncation so its token budget remains valid
- document which provider counters are tokenizer-backed and which remain heuristic

## Problem

The Rust implementation currently treats each uninterrupted run of letters, digits, `_`, or `-` as one token. Long identifiers, CJK text without whitespace, and base64-like text can therefore collapse to a single estimated token. The endpoint then severely under-reports request size.

This is also a regression from the proxy's original TypeScript implementation, which encoded text with `gpt-tokenizer/model/gpt-4o`. The current documentation continued to describe the Codex path as `o200k_base`-backed even though the Rust implementation had become a word-run heuristic.

Measured end to end against Codex terminal `usage` for the same translated requests:

| Fixture | Previous `/count_tokens` | Actual input tokens | Error |
| --- | ---: | ---: | ---: |
| English prose | 976 | 978 | -0.2% |
| Long identifier | 17 | 531 | -96.8% (31.2x undercount) |
| Minified code | 2,224 | 1,649 | +34.9% |
| CJK text | 17 | 2,705 | -99.4% (159.1x undercount) |
| Base64-like text | 17 | 2,257 | -99.2% (132.8x undercount) |

With this change:

| Fixture | New `/count_tokens` | Actual input tokens | Error |
| --- | ---: | ---: | ---: |
| English prose | 984 | 978 | +0.6% |
| Long identifier | 537 | 531 | +1.1% |
| Minified code | 1,655 | 1,649 | +0.4% |
| CJK text | 2,711 | 2,705 | +0.2% |
| Base64-like text | 2,263 | 2,257 | +0.3% |

The remaining six-token offset is the proxy's protocol-framing estimate. `/count_tokens` remains a local preflight estimate, not an upstream billing total.

## Implementation

- add `tiktoken-rs` with default features disabled
- count ordinary Codex text with the shared `o200k_base` tokenizer
- preserve the existing explicit estimates for images, encrypted reasoning, and request framing
- truncate standalone-search content by encoded-token prefixes while backing up to a valid UTF-8 boundary
- add regression coverage for long identifiers, CJK, base64-like text, minified code, and UTF-8-safe token-budget truncation
- correct the HTTP API and architecture documentation

## Why this is a bug

- [The current Rust counter](https://github.com/raine/claude-code-proxy/blob/5ca5596e54955f5ed1a8b7e9153f3c9230a9b851/src/providers/codex/count_tokens.rs#L119-L140) collapses whole alphanumeric runs into one token.
- [The original proxy implementation](https://github.com/raine/claude-code-proxy/blob/8c000902264dcf4472daa11a4cd115574984cbef/src/count-tokens.ts) used the GPT-4o tokenizer instead of this heuristic.
- [The existing HTTP API documentation](https://github.com/raine/claude-code-proxy/blob/5ca5596e54955f5ed1a8b7e9153f3c9230a9b851/docs/src/content/docs/reference/http-api.md#L32-L40) already promises an `o200k_base` estimate for the Codex path.
- Anthropic defines [`POST /v1/messages/count_tokens`](https://platform.claude.com/docs/en/api/messages/count_tokens) as a preflight estimate over the message input, including structured content such as tools and images, and notes that the estimate can differ slightly from final usage in its [token-counting guide](https://platform.claude.com/docs/en/build-with-claude/token-counting).
- OpenAI's tokenizer mapping assigns the [`gpt-5` family to `o200k_base`](https://github.com/openai/tiktoken/blob/main/tiktoken/model.py#L6-L33). The [OpenAI Cookbook token-counting example](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) also lists `tiktoken-rs` among Rust implementations.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- live `/count_tokens` calls and matching terminal Codex requests across all fixtures above
- verified that `/count_tokens` remains local and does not make an upstream request
