### PR TITLE
fix(kimi): tag content parts so serde emits the type discriminant

### DIFF
--- a/src/providers/kimi/translate/request.rs
+++ b/src/providers/kimi/translate/request.rs
@@ -488,7 +488,7 @@ fn push_user_messages(out: &mut Vec<KimiMessage>, blocks: &[ContentBlock]) {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
+#[serde(tag = "type", rename_all = "snake_case")]
 enum KimiUserContentPart {
     Text { text: String },
     ImageUrl { image_url: KimiImageUrl },
@@ -552,7 +552,7 @@ fn tool_result_content(content: &Value, is_error: Option<bool>) -> Value {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
+#[serde(tag = "type", rename_all = "snake_case")]
 enum KimiToolResultPart {
     Text { text: String },
     ImageUrl { image_url: KimiImageUrl },
@@ -838,6 +838,64 @@ mod tests {
                 assert!(parts[1].get("image_url").is_some());
             }
             _ => panic!("expected User message"),
+        }
+    }
+
+    #[test]
+    fn user_content_parts_carry_a_type_discriminant() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "kimi-for-coding",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "xyz"}}
+                ]
+            }]
+        }))
+        .unwrap();
+        let translated = translate_request(&req, TranslateOptions { session_id: None }).unwrap();
+        match &translated.messages[0] {
+            KimiMessage::User { content, .. } => {
+                let parts = content.as_array().unwrap();
+                assert_eq!(parts[0].get("type").and_then(|v| v.as_str()), Some("text"));
+                assert_eq!(
+                    parts[1].get("type").and_then(|v| v.as_str()),
+                    Some("image_url")
+                );
+            }
+            _ => panic!("expected User message"),
+        }
+    }
+
+    #[test]
+    fn tool_result_parts_carry_a_type_discriminant() {
+        let req: MessagesRequest = serde_json::from_value(json!({
+            "model": "kimi-for-coding",
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": [
+                        {"type": "text", "text": "caption"},
+                        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc"}}
+                    ]
+                }]
+            }]
+        }))
+        .unwrap();
+        let translated = translate_request(&req, TranslateOptions { session_id: None }).unwrap();
+        match &translated.messages[0] {
+            KimiMessage::Tool { content, .. } => {
+                let parts = content.as_array().unwrap();
+                assert_eq!(parts[0].get("type").and_then(|v| v.as_str()), Some("text"));
+                assert_eq!(
+                    parts[1].get("type").and_then(|v| v.as_str()),
+                    Some("image_url")
+                );
+            }
+            _ => panic!("expected Tool message"),
         }
     }
 


### PR DESCRIPTION
Addresses #98.

## Problem

`KimiUserContentPart` and `KimiToolResultPart` are declared `#[serde(untagged)]`, so they serialize without a discriminant:

```json
{"text": "..."}
{"image_url": {"url": "..."}}
```

Kimi expects the OpenAI multimodal shape and rejects the payload:

```
the message at position 0 with role 'user' contains an invalid part type:
the message at position 2 with role 'tool' contains an invalid part type:
```

The value after the colon is empty because the discriminant is missing.

The practical impact is that **subagents do not work through the proxy**. Claude Code's `Task` tool returns a multi-block `tool_result`, which always takes this path. Single-output tools such as Bash and Read are unaffected, because `tool_result_content` collapses a lone text part back into a plain string before serializing.

## Change

Tag both enums:

```rust
#[serde(tag = "type", rename_all = "snake_case")]
```

Output becomes `{"type":"text","text":"..."}` and `{"type":"image_url","image_url":{...}}`.

## Tests

Two regression tests added, one per enum, asserting the discriminant is present:

- `user_content_parts_carry_a_type_discriminant`
- `tool_result_parts_carry_a_type_discriminant`

The existing `translate_tool_result_with_image`, `translate_tool_result_with_unsupported_blocks` and `translate_user_text_and_image_collapse_correctly` assert only on the `text` and `image_url` keys, so they are unaffected.

## Verification

Built and tested against a live Kimi account on macOS arm64. Before the change, a multimodal user message and any subagent invocation both returned `invalid part type`. After the change, both succeed.