### PR TITLE
Preserve Codex statusless transport errors

### DIFF
--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -1480,13 +1480,11 @@ fn is_context_window_overflow(message: &str) -> bool {
 }
 
 fn codex_error_message(err: &client::CodexError) -> &str {
-    err.detail.as_deref().unwrap_or({
-        if err.status == 0 {
-            err.message.as_str()
-        } else {
-            "Upstream error"
-        }
-    })
+    if err.status == 0 {
+        err.message.as_str()
+    } else {
+        err.detail.as_deref().unwrap_or("Upstream error")
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/smoke_cutover.rs
+++ b/tests/smoke_cutover.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
 use tower::util::ServiceExt;
@@ -194,6 +195,28 @@ where
     });
 
     addr_str
+}
+
+async fn spawn_truncated_http_upstream(body: &'static [u8]) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        let mut request = [0_u8; 8192];
+        let _ = stream.read(&mut request).await;
+        let headers = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len() + 4096
+        );
+        let _ = stream.write_all(headers.as_bytes()).await;
+        let _ = stream.write_all(body).await;
+        let _ = stream.shutdown().await;
+    });
+
+    format!("http://{addr}")
 }
 
 #[allow(clippy::await_holding_lock)]
@@ -1905,6 +1928,56 @@ async fn smoke_codex_http_cancels_retry_backoff_when_request_drops() {
 
     tokio::time::sleep(Duration::from_millis(300)).await;
     assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn smoke_codex_http_body_error_after_semantic_output_preserves_message() {
+    let _guard = env_lock();
+    clear_all_continuations_for_tests();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+
+    let upstream = spawn_truncated_http_upstream(concat!(
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_partial\"}}\n\n",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_partial\"}}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"delta\":\"partial before body error\"}\n\n"
+    ).as_bytes())
+    .await;
+
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let _transport_env = EnvGuard::set("CCP_CODEX_TRANSPORT", "http");
+    let response = call_messages_body(json!({
+        "model": "gpt-5.5",
+        "max_tokens": 64,
+        "stream": true,
+        "messages": [{"role":"user","content":"hello"}]
+    }))
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = tokio::time::timeout(
+        Duration::from_secs(2),
+        axum::body::to_bytes(response.into_body(), usize::MAX),
+    )
+    .await
+    .expect("failed semantic stream must terminate")
+    .unwrap();
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("partial before body error"),
+        "stream body: {text}"
+    );
+    assert!(text.contains("event: error"), "stream body: {text}");
+    assert!(
+        text.contains("Transport error reading Codex response body"),
+        "stream body: {text}"
+    );
+    assert!(
+        !text.contains("\"message\":\"http_response_body\""),
+        "stream body: {text}"
+    );
 }
 
 #[allow(clippy::await_holding_lock)]


### PR DESCRIPTION
## Summary

- preserve the descriptive source message for statusless Codex transport errors
- keep structured `detail` values for statusful upstream responses
- cover an HTTP response-body failure after semantic output has already been streamed

## Problem

Codex HTTP body failures use status `0`, a descriptive `message`, and an internal `detail` discriminator such as `http_response_body`. The shared error mapper preferred `detail` whenever it was present, so Claude Code received:

```text
API Error: http_response_body
```

instead of the actionable transport message. This is especially confusing after partial output, where replay is intentionally disabled to avoid duplicating text or tool side effects.

## Fix

For statusless errors, always surface `CodexError.message`. Preserve the existing `detail`-first behavior for statusful upstream errors.

The regression test serves a deliberately truncated HTTP response after a valid text delta and verifies that:

- partial semantic output is preserved
- the stream terminates with `event: error`
- the descriptive response-body transport error is returned
- the internal `http_response_body` discriminator is not exposed as the user-facing message

This follows the same post-commit boundary used by CLIProxyAPI: retry is allowed only before the first deliverable payload; after partial output, the stream is terminated with an error rather than replayed ([bootstrap handler](https://github.com/router-for-me/CLIProxyAPI/blob/41fc5e134631789e98137245f576680c7fb9b322/sdk/api/handlers/handlers_stream.go#L390-L490), [post-payload regression test](https://github.com/router-for-me/CLIProxyAPI/blob/41fc5e134631789e98137245f576680c7fb9b322/sdk/api/handlers/handlers_stream_bootstrap_test.go#L780-L847)). Codex itself also treats a stream ending before `response.completed` as an incomplete attempt ([Codex regression test](https://github.com/openai/codex/blob/main/codex-rs/core/tests/suite/stream_no_completed.rs)).

## Verification

- `cargo fmt --check`
- `cargo test --offline --all-targets`
- `cargo clippy --offline --all-targets -- -D warnings`

All checks pass on the current `main` base (`v0.1.32`).
