### PR TITLE
opencode: register four additional Go catalog models

### DIFF
--- a/docs/src/content/docs/providers/opencode-go.md
+++ b/docs/src/content/docs/providers/opencode-go.md
@@ -5,10 +5,9 @@ description: Configure an OpenCode Go API key, model routing, streaming, tools, 
 
 OpenCode Go uses the API at `https://opencode.ai/zen/go/v1`. Its catalog spans
 OpenAI-compatible chat completions, Anthropic-compatible messages, and OpenAI
-Responses; the proxy selects the wire protocol for each registered model. The
-registered mapping follows the [official OpenCode Go endpoint table](https://opencode.ai/docs/go/#endpoints).
-The catalog additionally registers `glm-5`, `kimi-k2.5`, and `qwen3.5-plus`
-based on live protocol verification because the current table omits those IDs.
+Responses; the proxy selects the wire protocol for each registered model. Each
+mapping comes from the [official OpenCode Go endpoint table](https://opencode.ai/docs/go/#endpoints)
+or direct protocol verification against the API.
 
 ## Account and authentication
 
@@ -25,10 +24,9 @@ implement an OpenCode login flow.
 
 ## Models
 
-Run `claude-code-proxy models` for the statically registered catalog based on
-OpenCode's documented endpoint table. Every registered model has a
-provider-qualified form. Bare IDs are also accepted when they do not belong to
-another provider:
+Run `claude-code-proxy models` for the statically registered catalog. Every
+registered model has a provider-qualified form. Bare IDs are also accepted when
+they do not belong to another provider:
 
 ```sh
 ANTHROPIC_MODEL=opencode-go/glm-5.2 \

--- a/docs/src/content/docs/providers/opencode-go.md
+++ b/docs/src/content/docs/providers/opencode-go.md
@@ -7,6 +7,8 @@ OpenCode Go uses the API at `https://opencode.ai/zen/go/v1`. Its catalog spans
 OpenAI-compatible chat completions, Anthropic-compatible messages, and OpenAI
 Responses; the proxy selects the wire protocol for each registered model. The
 registered mapping follows the [official OpenCode Go endpoint table](https://opencode.ai/docs/go/#endpoints).
+The catalog additionally registers `glm-5`, `kimi-k2.5`, and `qwen3.5-plus`
+based on live protocol verification because the current table omits those IDs.
 
 ## Account and authentication
 
@@ -57,6 +59,6 @@ OpenCode Go.
 - `CCP_OPENCODE_BASE_URL` or `opencode.baseUrl` changes the API base URL.
 
 OpenCode Go may expose additional model IDs through `/models`, but the proxy
-registers only models whose wire protocol is documented. Unknown IDs are
-rejected locally. Access or usage-limit errors for registered models are
-surfaced from OpenCode.
+registers only models whose wire protocol is documented or has been verified
+against the live API. Unknown IDs are rejected locally. Access or usage-limit
+errors for registered models are surfaced from OpenCode.

--- a/src/providers/opencode/model.rs
+++ b/src/providers/opencode/model.rs
@@ -31,6 +31,10 @@ pub const MODELS: &[ModelSpec] = &[
         endpoint: EndpointKind::ChatCompletions,
     },
     ModelSpec {
+        id: "glm-5",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
         id: "kimi-k3",
         endpoint: EndpointKind::ChatCompletions,
     },
@@ -40,6 +44,10 @@ pub const MODELS: &[ModelSpec] = &[
     },
     ModelSpec {
         id: "kimi-k2.6",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "kimi-k2.5",
         endpoint: EndpointKind::ChatCompletions,
     },
     ModelSpec {
@@ -71,6 +79,10 @@ pub const MODELS: &[ModelSpec] = &[
         endpoint: EndpointKind::Messages,
     },
     ModelSpec {
+        id: "qwen3.8-max",
+        endpoint: EndpointKind::Messages,
+    },
+    ModelSpec {
         id: "qwen3.7-max",
         endpoint: EndpointKind::Messages,
     },
@@ -80,6 +92,10 @@ pub const MODELS: &[ModelSpec] = &[
     },
     ModelSpec {
         id: "qwen3.6-plus",
+        endpoint: EndpointKind::Messages,
+    },
+    ModelSpec {
+        id: "qwen3.5-plus",
         endpoint: EndpointKind::Messages,
     },
     ModelSpec {
@@ -126,9 +142,34 @@ mod tests {
             .iter()
             .filter(|model| model.endpoint == EndpointKind::Responses)
             .count();
-        assert_eq!(chat, 11);
-        assert_eq!(messages, 6);
+        assert_eq!(chat, 13);
+        assert_eq!(messages, 8);
         assert_eq!(responses, 1);
+    }
+
+    #[test]
+    fn refreshed_models_resolve_and_are_advertised() {
+        let advertised = advertised_models();
+        for (id, endpoint) in [
+            ("glm-5", EndpointKind::ChatCompletions),
+            ("kimi-k2.5", EndpointKind::ChatCompletions),
+            ("qwen3.8-max", EndpointKind::Messages),
+            ("qwen3.5-plus", EndpointKind::Messages),
+        ] {
+            let qualified = format!("{MODEL_PREFIX}{id}");
+            assert_eq!(
+                resolve(id).expect("registered bare model").endpoint,
+                endpoint
+            );
+            assert_eq!(
+                resolve(&qualified)
+                    .expect("registered provider-qualified model")
+                    .endpoint,
+                endpoint
+            );
+            assert!(advertised.iter().any(|model| model == id));
+            assert!(advertised.contains(&qualified));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Register four additional OpenCode Go catalog IDs:
  - `glm-5` and `kimi-k2.5` through Chat Completions
  - `qwen3.8-max` and `qwen3.5-plus` through Anthropic Messages
- Advertise both bare and `opencode-go/...` forms for each model.
- Add table-driven regression coverage for model resolution, advertisement, and
  endpoint selection.
- Document that a catalog model can be registered after direct protocol
  verification even when the current Go endpoint table omits it.

## Motivation

OpenCode Go's public [`/models`](https://opencode.ai/zen/go/v1/models) endpoint
currently returns all four IDs.

`qwen3.8-max` is also listed in OpenCode's current
[Go endpoint table](https://github.com/anomalyco/opencode/blob/fe82a1b6ca4f535beb973b0867017e3f639f85ed/packages/web/src/content/docs/go.mdx#L194-L218)
as a `/messages` model. It was added upstream in
[anomalyco/opencode#40228](https://github.com/anomalyco/opencode/pull/40228)
after [CCP's original OpenCode Go provider PR](https://github.com/raine/claude-code-proxy/pull/54)
was merged.

The current Go endpoint table omits the other three IDs, so their transports are
not inferred from `/models`. Their endpoint assignments were verified directly
against the live Go API:

- `glm-5` -> `/chat/completions`
- `kimi-k2.5` -> `/chat/completions`
- `qwen3.5-plus` -> `/messages`

Those assignments also match OpenCode's current
[Zen endpoint table](https://github.com/anomalyco/opencode/blob/fe82a1b6ca4f535beb973b0867017e3f639f85ed/packages/web/src/content/docs/zen.mdx#L100-L114).
OpenCode previously published `glm-5` and `kimi-k2.5` in its
[Go documentation](https://github.com/anomalyco/opencode/commit/744c38cc7cfd4741227b9a1951ccba57668e2184),
and `qwen3.5-plus` in a later
[Go catalog update](https://github.com/anomalyco/opencode/commit/1bea2a95a8a3ebebc638fe4ab9d374101cb4f4f5).

The proxy catalog remains static: an ID returned by `/models` is still rejected
unless its generation endpoint has been documented or verified.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --offline --all-targets`: 956 passed, 0 failed
- release Docker build
- public Go `/models` contains all four IDs
- live proxy generation:
  - `glm-5`: buffered, HTTP 200, `end_turn`
  - `kimi-k2.5`: streaming, HTTP 200, `message_stop`
  - `qwen3.8-max`: buffered, HTTP 200, `end_turn`
  - `qwen3.5-plus`: streaming, HTTP 200, `message_stop`
