### PR TITLE
fix Grok web search: 400s on Claude Code's tool declarations, unrenderable hosted-search blocks, and seized tools

### DIFF
--- a/docs/src/content/docs/providers/grok.md
+++ b/docs/src/content/docs/providers/grok.md
@@ -38,20 +38,20 @@ The proxy translates Claude messages, function tools, tool results, thinking con
 
 Search reaches Grok-native tools when the caller asks for it:
 
-- A caller that declares Anthropic's hosted `web_search` tool gets Grok hosted
-  web search.
-- A caller that runs its own search tool keeps it. The proxy does not replace a
-  client-side search tool with a hosted one.
+- Anthropic's `web_search_20250305` declaration maps to Grok hosted web search.
+  The Grok CLI endpoint accepts the minimal declaration without domain or
+  location constraints.
+- A caller-managed search tool remains a function tool for the caller to run.
 - An X or Twitter query is additionally offered hosted `x_search`, which the
-  model can use or ignore. It never replaces the caller's other tools.
+  model can use or ignore alongside the caller's tools.
 - Citations and search usage return in Anthropic-compatible usage fields.
-- `CCP_GROK_HOSTED_SEARCH=1` restores the previous behaviour, in which hosted
-  tools replace the caller's search tools and an explicit search turn is forced.
+- `CCP_GROK_HOSTED_SEARCH=1` enables a policy where hosted tools replace caller
+  search tools and explicit search turns require a tool call.
 
-A hosted search is reported as a text block naming the query, which every
-Anthropic client can draw. `CCP_GROK_SEARCH_BLOCKS=native` reports it as
-`server_tool_use` plus `web_search_tool_result` or `x_search_tool_result`
-instead, for a client that renders those block types.
+A hosted search is reported as a text block naming the query.
+`CCP_GROK_SEARCH_BLOCKS=native` preserves `server_tool_use` plus
+`web_search_tool_result` or `x_search_tool_result` for clients that consume
+hosted-tool blocks.
 
 ## OpenAI-compatible APIs
 
@@ -81,11 +81,16 @@ Traffic captures redact Anthropic image data and upstream image data URLs.
 - `CCP_GROK_BASE_URL` or `grok.baseUrl` changes the API base URL.
 - `CCP_GROK_CLIENT_VERSION` or `grok.clientVersion` changes the client version header.
 - `CCP_GROK_TOOL_IMAGE` selects `omit`, `reattach`, `inline`, or `reject`.
-- `CCP_GROK_HOSTED_SEARCH` restores hosted search tools replacing the caller's own.
+- `CCP_GROK_HOSTED_SEARCH` enables hosted search replacement and forcing.
 - `CCP_GROK_SEARCH_BLOCKS` selects `text` or `native` hosted-search reporting.
 
 See [Configuration](/reference/configuration/) for defaults.
 
 ## Limitations and troubleshooting
+
+The Grok CLI hosted web-search endpoint has no equivalent for Anthropic's
+`max_uses`, domain filters, or user location. The proxy accepts and omits a
+valid `max_uses` value, while non-null domain and location constraints return a
+request error rather than weakening the requested search scope.
 
 A successful login does not guarantee every model is enabled for the account or region. Model rejection and upstream errors are surfaced to Claude Code. Use `grok auth status` for token state, inspect the failed request in the monitor, and use the structured log or error capture for the full redacted response.

--- a/docs/src/content/docs/providers/grok.md
+++ b/docs/src/content/docs/providers/grok.md
@@ -36,11 +36,22 @@ ANTHROPIC_SMALL_FAST_MODEL=grok-4.6 \
 
 The proxy translates Claude messages, function tools, tool results, thinking controls, token usage, and streaming events. Grok reasoning text appears as Claude Code thinking blocks.
 
-Claude Code hosted search tools map to Grok-native tools:
+Search reaches Grok-native tools when the caller asks for it:
 
-- General web queries use hosted web search.
-- X queries use hosted `x_search`.
-- Citations and search usage return in Anthropic-compatible content and usage fields.
+- A caller that declares Anthropic's hosted `web_search` tool gets Grok hosted
+  web search.
+- A caller that runs its own search tool keeps it. The proxy does not replace a
+  client-side search tool with a hosted one.
+- An X or Twitter query is additionally offered hosted `x_search`, which the
+  model can use or ignore. It never replaces the caller's other tools.
+- Citations and search usage return in Anthropic-compatible usage fields.
+- `CCP_GROK_HOSTED_SEARCH=1` restores the previous behaviour, in which hosted
+  tools replace the caller's search tools and an explicit search turn is forced.
+
+A hosted search is reported as a text block naming the query, which every
+Anthropic client can draw. `CCP_GROK_SEARCH_BLOCKS=native` reports it as
+`server_tool_use` plus `web_search_tool_result` or `x_search_tool_result`
+instead, for a client that renders those block types.
 
 ## OpenAI-compatible APIs
 
@@ -70,6 +81,8 @@ Traffic captures redact Anthropic image data and upstream image data URLs.
 - `CCP_GROK_BASE_URL` or `grok.baseUrl` changes the API base URL.
 - `CCP_GROK_CLIENT_VERSION` or `grok.clientVersion` changes the client version header.
 - `CCP_GROK_TOOL_IMAGE` selects `omit`, `reattach`, `inline`, or `reject`.
+- `CCP_GROK_HOSTED_SEARCH` restores hosted search tools replacing the caller's own.
+- `CCP_GROK_SEARCH_BLOCKS` selects `text` or `native` hosted-search reporting.
 
 See [Configuration](/reference/configuration/) for defaults.
 

--- a/docs/src/content/docs/reference/compatibility-and-limitations.md
+++ b/docs/src/content/docs/reference/compatibility-and-limitations.md
@@ -68,6 +68,9 @@ claude-code-proxy targets Claude Code's practical Anthropic API usage rather tha
 
 - Model availability varies by account and region.
 - Hosted general web search and X search are translated with citations and usage.
+- Hosted web search omits `max_uses` because the Grok CLI endpoint exposes no
+  equivalent cap. Non-null domain filters and user location are rejected because
+  dropping them would weaken the caller's requested search scope.
 - The implemented multimodal path does not claim general image or video compatibility.
 
 ## Cursor Agent

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -133,6 +133,8 @@ Proxy URLs may use `http`, `https`, `socks4`, `socks4a`, `socks5`, or `socks5h`.
 | `CCP_GROK_BASE_URL` | `grok.baseUrl` | `https://cli-chat-proxy.grok.com/v1` | Changes the Responses API base URL. |
 | `CCP_GROK_CLIENT_VERSION` | `grok.clientVersion` | `0.2.93` | Changes the Grok client version header. |
 | `CCP_GROK_TOOL_IMAGE` | none | `omit` | Selects `omit`, `reattach`, `inline`, or `reject` image handling. |
+| `CCP_GROK_HOSTED_SEARCH` | none | off | Set to `1`, `on`, or `true` to let hosted search tools replace the caller's own search tools and force them on an explicit search turn. |
+| `CCP_GROK_SEARCH_BLOCKS` | none | `text` | Selects how a hosted search is reported: `text` for a text block, `native` for `server_tool_use` plus a `*_tool_result` block. |
 
 ## OpenCode Go
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -458,20 +458,18 @@ pub fn warn_grok_tool_image_mode_once(log: &crate::logging::Logger) {
 // Grok hosted-search policy (CCP_GROK_HOSTED_SEARCH)
 // ---------------------------------------------------------------------------
 
-/// Whether the Grok translator replaces the caller's own search tools with
-/// xAI's hosted search, and forces their use.
+/// Whether the Grok translator replaces caller search tools with xAI-hosted
+/// search and requires hosted tool use on explicit search turns.
 ///
-/// Off is the default. The caller keeps every tool it declared, including its
-/// client-side `WebSearch`, and the system prompt is left alone. xAI's
-/// `x_search` is still offered on an X turn, because Claude Code has no X tool
-/// of its own and the index is unreachable otherwise -- offered, never forced.
+/// The disabled policy preserves caller tools, instructions, and tool choice.
+/// It adds `x_search` only to X-specific turns because the caller has no
+/// equivalent access to xAI's X index.
 ///
-/// On restores the original behaviour: hosted tools replace the caller's search
-/// tools, two directives are appended to the system prompt, and an explicit
-/// search turn pins `tool_choice: required`. Useful when xAI's own search and
-/// citations are wanted more than the caller's control of its tool set.
+/// The enabled policy favors xAI-hosted search and citations. Hosted tools
+/// replace caller search implementations, matching turns receive search
+/// guidance, and explicit search turns use `tool_choice: required`.
 ///
-/// Set `CCP_GROK_HOSTED_SEARCH` to `1`, `on`, or `true` to turn it on.
+/// Set `CCP_GROK_HOSTED_SEARCH` to `1`, `on`, or `true` to enable this policy.
 pub fn parse_grok_hosted_search(raw: Option<&str>) -> bool {
     matches!(raw.map(str::trim), Some("1" | "on" | "true"))
 }
@@ -484,17 +482,13 @@ pub fn grok_hosted_search() -> bool {
 // Grok hosted-search block shape (CCP_GROK_SEARCH_BLOCKS)
 // ---------------------------------------------------------------------------
 
-/// How a hosted search that xAI ran is reported back to the client.
+/// How a hosted search that xAI ran is reported to the client.
 ///
-/// `Text` is the default: one short `text` block naming the query. Every
-/// Anthropic client can draw a text block.
+/// `Text` projects the search query into a standard `text` block.
 ///
-/// `Native` emits the Anthropic server-tool shape, `server_tool_use` followed
-/// by `web_search_tool_result` or `x_search_tool_result`. It is the more
-/// faithful translation, and the Claude Code CLI accepts it, but the Claude
-/// Code VS Code webview has no renderer for either type and prints
-/// "Unsupported content type" once per block. Choose it only for a client
-/// known to draw them.
+/// `Native` preserves the Anthropic server-tool shape: `server_tool_use`
+/// followed by `web_search_tool_result` or `x_search_tool_result`. Select this
+/// shape for clients that consume hosted-tool blocks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GrokSearchBlocks {
     Text,
@@ -504,7 +498,7 @@ pub enum GrokSearchBlocks {
 pub fn parse_grok_search_blocks(raw: Option<&str>) -> GrokSearchBlocks {
     match raw.map(str::trim) {
         Some("native") => GrokSearchBlocks::Native,
-        // Any unknown or empty value degrades to the shape everything renders.
+        // Text is the compatibility-safe fallback for empty or unknown values.
         _ => GrokSearchBlocks::Text,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -454,6 +454,65 @@ pub fn warn_grok_tool_image_mode_once(log: &crate::logging::Logger) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Grok hosted-search policy (CCP_GROK_HOSTED_SEARCH)
+// ---------------------------------------------------------------------------
+
+/// Whether the Grok translator replaces the caller's own search tools with
+/// xAI's hosted search, and forces their use.
+///
+/// Off is the default. The caller keeps every tool it declared, including its
+/// client-side `WebSearch`, and the system prompt is left alone. xAI's
+/// `x_search` is still offered on an X turn, because Claude Code has no X tool
+/// of its own and the index is unreachable otherwise -- offered, never forced.
+///
+/// On restores the original behaviour: hosted tools replace the caller's search
+/// tools, two directives are appended to the system prompt, and an explicit
+/// search turn pins `tool_choice: required`. Useful when xAI's own search and
+/// citations are wanted more than the caller's control of its tool set.
+///
+/// Set `CCP_GROK_HOSTED_SEARCH` to `1`, `on`, or `true` to turn it on.
+pub fn parse_grok_hosted_search(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1" | "on" | "true"))
+}
+
+pub fn grok_hosted_search() -> bool {
+    parse_grok_hosted_search(std::env::var("CCP_GROK_HOSTED_SEARCH").ok().as_deref())
+}
+
+// ---------------------------------------------------------------------------
+// Grok hosted-search block shape (CCP_GROK_SEARCH_BLOCKS)
+// ---------------------------------------------------------------------------
+
+/// How a hosted search that xAI ran is reported back to the client.
+///
+/// `Text` is the default: one short `text` block naming the query. Every
+/// Anthropic client can draw a text block.
+///
+/// `Native` emits the Anthropic server-tool shape, `server_tool_use` followed
+/// by `web_search_tool_result` or `x_search_tool_result`. It is the more
+/// faithful translation, and the Claude Code CLI accepts it, but the Claude
+/// Code VS Code webview has no renderer for either type and prints
+/// "Unsupported content type" once per block. Choose it only for a client
+/// known to draw them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GrokSearchBlocks {
+    Text,
+    Native,
+}
+
+pub fn parse_grok_search_blocks(raw: Option<&str>) -> GrokSearchBlocks {
+    match raw.map(str::trim) {
+        Some("native") => GrokSearchBlocks::Native,
+        // Any unknown or empty value degrades to the shape everything renders.
+        _ => GrokSearchBlocks::Text,
+    }
+}
+
+pub fn grok_search_blocks() -> GrokSearchBlocks {
+    parse_grok_search_blocks(std::env::var("CCP_GROK_SEARCH_BLOCKS").ok().as_deref())
+}
+
 struct ResolvedOpenCodeConfig {
     api_key: Option<String>,
     api_key_source: Option<&'static str>,

--- a/src/providers/grok/translate/accumulate.rs
+++ b/src/providers/grok/translate/accumulate.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use super::reducer::{ReducerEvent, reduce_upstream_bytes};
+use super::search_text::search_line;
+use crate::config::GrokSearchBlocks;
 use crate::traffic::TrafficCapture;
 use serde_json::Value;
 
@@ -17,6 +19,24 @@ pub fn accumulate_response_with_traffic(
     message_id: &str,
     model: &str,
     traffic: Option<&TrafficCapture>,
+) -> anyhow::Result<Value> {
+    accumulate_response_with_options(
+        upstream,
+        message_id,
+        model,
+        traffic,
+        crate::config::grok_search_blocks(),
+    )
+}
+
+/// Tests choose the hosted-search block shape directly rather than through the
+/// environment.
+pub fn accumulate_response_with_options(
+    upstream: &[u8],
+    message_id: &str,
+    model: &str,
+    traffic: Option<&TrafficCapture>,
+    search_blocks: GrokSearchBlocks,
 ) -> anyhow::Result<Value> {
     let mut capture = traffic.map(TrafficCapture::stream_capture);
     let mut decoder = super::stream::SseDecoder::default();
@@ -136,6 +156,17 @@ pub fn accumulate_response_with_traffic(
                 name,
                 query,
             } => {
+                if search_blocks == GrokSearchBlocks::Text {
+                    // One text block, not two. Blocks are collected into an
+                    // array here and addressed through `block_positions`, so
+                    // leaving `result_index` unmapped costs nothing. The
+                    // streaming path emits an empty second block instead,
+                    // because there the index goes on the wire.
+                    block_positions.insert(index, blocks.len());
+                    blocks
+                        .push(serde_json::json!({"type":"text","text":search_line(&name,&query)}));
+                    continue;
+                }
                 block_positions.insert(index, blocks.len());
                 blocks.push(serde_json::json!({"type":"server_tool_use","id":id,"name":name,"input":{"query":query}}));
                 block_positions.insert(result_index, blocks.len());
@@ -200,6 +231,56 @@ fn finish_capture(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const HOSTED_WEB_SEARCH: &[u8] = b"data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\"}}\n\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"action\":{\"query\":\"rust news\"}}}\n\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Result\"}\n\ndata: {\"type\":\"response.output_text.done\"}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n\n";
+
+    #[test]
+    fn accumulated_hosted_search_renders_as_text_by_default() {
+        let response = accumulate_response_with_options(
+            HOSTED_WEB_SEARCH,
+            "message",
+            "grok-4.5",
+            None,
+            GrokSearchBlocks::Text,
+        )
+        .unwrap();
+        let types: Vec<&str> = response["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|block| block["type"].as_str().unwrap())
+            .collect();
+        // One text block for the search, one for the answer. No block type the
+        // VS Code webview would fail to draw.
+        assert_eq!(types, vec!["text", "text"]);
+        assert_eq!(response["content"][0]["text"], "[web search: rust news]\n");
+        assert_eq!(
+            response["usage"]["server_tool_use"]["web_search_requests"],
+            1
+        );
+    }
+
+    #[test]
+    fn accumulated_hosted_search_keeps_the_native_shape_on_request() {
+        let response = accumulate_response_with_options(
+            HOSTED_WEB_SEARCH,
+            "message",
+            "grok-4.5",
+            None,
+            GrokSearchBlocks::Native,
+        )
+        .unwrap();
+        let types: Vec<&str> = response["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|block| block["type"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            types,
+            vec!["server_tool_use", "web_search_tool_result", "text"]
+        );
+    }
 
     #[test]
     fn accumulate_response_tracks_two_interleaved_tool_calls() {

--- a/src/providers/grok/translate/accumulate.rs
+++ b/src/providers/grok/translate/accumulate.rs
@@ -250,8 +250,7 @@ mod tests {
             .iter()
             .map(|block| block["type"].as_str().unwrap())
             .collect();
-        // One text block for the search, one for the answer. No block type the
-        // VS Code webview would fail to draw.
+        // One text block represents the search and one contains the answer.
         assert_eq!(types, vec!["text", "text"]);
         assert_eq!(response["content"][0]["text"], "[web search: rust news]\n");
         assert_eq!(

--- a/src/providers/grok/translate/mod.rs
+++ b/src/providers/grok/translate/mod.rs
@@ -2,4 +2,5 @@ pub mod accumulate;
 pub mod model_allowlist;
 pub mod reducer;
 pub mod request;
+pub mod search_text;
 pub mod stream;

--- a/src/providers/grok/translate/request.rs
+++ b/src/providers/grok/translate/request.rs
@@ -85,10 +85,20 @@ pub struct GrokTool {
     pub from_date: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to_date: Option<String>,
+    #[serde(skip)]
+    choice_name: Option<String>,
 }
 
 impl GrokTool {
     fn hosted(kind: &str) -> Self {
+        Self::hosted_for_choice(kind, None)
+    }
+
+    fn hosted_named(kind: &str, name: &str) -> Self {
+        Self::hosted_for_choice(kind, Some(name))
+    }
+
+    fn hosted_for_choice(kind: &str, choice_name: Option<&str>) -> Self {
         Self {
             kind: kind.into(),
             name: None,
@@ -98,6 +108,7 @@ impl GrokTool {
             excluded_x_handles: None,
             from_date: None,
             to_date: None,
+            choice_name: choice_name.map(str::to_string),
         }
     }
 
@@ -111,6 +122,7 @@ impl GrokTool {
             excluded_x_handles: None,
             from_date: None,
             to_date: None,
+            choice_name: Some(name.into()),
         }
     }
 }
@@ -139,11 +151,11 @@ pub fn translate_request_with_mode(
     translate_request_with_options(req, model, image_mode, crate::config::grok_hosted_search())
 }
 
-/// `hosted_search` selects how xAI's hosted search tools reach the model. Off,
-/// the default, offers `x_search` on an X turn and changes nothing else. On,
-/// the hosted tools replace the caller's search tools and an explicit search
-/// turn is forced. See `crate::config::grok_hosted_search`. Tests pass the flag
-/// directly so neither path depends on the environment.
+/// `hosted_search` selects how xAI's hosted search tools reach the model. When
+/// disabled, the translator offers `x_search` only for X-specific turns and
+/// preserves every caller tool. When enabled, hosted tools replace caller
+/// search tools and explicit search turns require a tool call. Tests pass the
+/// policy directly so their behavior is independent of process configuration.
 pub fn translate_request_with_options(
     req: &MessagesRequest,
     model: String,
@@ -161,10 +173,9 @@ pub fn translate_request_with_options(
         .is_some_and(|tools| tools.iter().any(|tool| tool.kind == "x_search"));
     let mut forced_hosted_tool = false;
     if hosted_search {
-        // Opt-in path. xAI's hosted tools replace the caller's search tools,
-        // the model is told to prefer them, and an explicit search turn pins
-        // tool_choice. Kept for callers who want xAI's own search and
-        // citations, and who run a client that draws hosted-search blocks.
+        // The enabled policy favors xAI-hosted search and citations over the
+        // caller's search implementation. Explicit search turns expose only
+        // the selected hosted tool and require a tool call.
         let force_x_search = dedicated_x_search || requests_x_search(req);
         let force_web_search = !force_x_search && hosted_web_search && requests_web_search(req);
         if force_x_search {
@@ -191,11 +202,8 @@ pub fn translate_request_with_options(
         }
         forced_hosted_tool = force_x_search || force_web_search;
     } else if requests_x_search(req) {
-        // Default path. Claude Code has no X tool of its own, so xAI's index is
-        // only reachable if the proxy attaches it. Offer it as one more tool
-        // beside the caller's own, and stop there: no tool is removed, the
-        // system prompt is not written to, and tool_choice stays whatever the
-        // caller sent. The model decides whether the turn wants X.
+        // The disabled policy adds access to xAI's X index without changing
+        // caller tools, instructions, or tool choice.
         let tools = tools.get_or_insert_default();
         if !tools.iter().any(|tool| tool.kind == "x_search") {
             tools.push(GrokTool::hosted("x_search"));
@@ -204,7 +212,7 @@ pub fn translate_request_with_options(
     let tool_choice = if forced_hosted_tool {
         Some(GrokToolChoice::Required("required".into()))
     } else {
-        parse_tool_choice(req.extra.get("tool_choice"), tools.as_ref())?
+        parse_tool_choice(req.extra.get("tool_choice"), &mut tools)?
     };
     let mut call_ids = HashSet::new();
     let mut input = Vec::new();
@@ -332,6 +340,21 @@ fn latest_user_text(req: &MessagesRequest) -> Option<String> {
     }
 }
 
+fn contains_phrase(text: &str, phrase: &str) -> bool {
+    text.match_indices(phrase).any(|(start, _)| {
+        let end = start + phrase.len();
+        let starts_at_boundary = text[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|ch| !ch.is_ascii_alphanumeric() && ch != '_');
+        let ends_at_boundary = text[end..]
+            .chars()
+            .next()
+            .is_none_or(|ch| !ch.is_ascii_alphanumeric() && ch != '_');
+        starts_at_boundary && ends_at_boundary
+    })
+}
+
 fn requests_x_search(req: &MessagesRequest) -> bool {
     let Some(text) = latest_user_text(req) else {
         return false;
@@ -348,7 +371,7 @@ fn requests_x_search(req: &MessagesRequest) -> bool {
         "twitter posts",
     ]
     .iter()
-    .any(|phrase| text.contains(phrase))
+    .any(|phrase| contains_phrase(&text, phrase))
 }
 
 fn requests_web_search(req: &MessagesRequest) -> bool {
@@ -363,7 +386,7 @@ fn requests_web_search(req: &MessagesRequest) -> bool {
         "look up on the web",
     ]
     .iter()
-    .any(|phrase| text.contains(phrase))
+    .any(|phrase| contains_phrase(&text, phrase))
 }
 
 fn reject_unknown_top_level(req: &MessagesRequest) -> anyhow::Result<()> {
@@ -459,15 +482,11 @@ fn parse_tools(
                 "input_schema",
                 "cache_control",
                 "eager_input_streaming",
-                // Claude Code caps its own WebSearch with `max_uses`. The cap
-                // is enforced by the caller that declared it, so the field is
-                // accepted and dropped rather than forwarded. Rejecting it
-                // failed the whole request with a 400 and left the turn with
-                // no search at all.
                 "max_uses",
-                // Anthropic's server-tool declarations carry a versioned
-                // `type` instead of an input schema. Handled below.
                 "type",
+                "allowed_domains",
+                "blocked_domains",
+                "user_location",
             ]
             .contains(&key.as_str())
             {
@@ -491,34 +510,43 @@ fn parse_tools(
         if !names.insert(name.to_string()) {
             anyhow::bail!("duplicate tool name");
         }
-        // Anthropic's server-tool declaration. Claude Code sends
-        // {"type":"web_search_20250305","name":"web_search","max_uses":8} the
-        // moment the model actually searches, and the tool carries no
-        // input_schema, so it cannot take the function path below. This is the
-        // caller explicitly asking for server-side search, so honour it with
-        // xAI's hosted tool whatever `hosted_search` says -- that setting
-        // governs whether the proxy seizes search on its own initiative, not
-        // whether it obeys a caller that asked. Rejecting the declaration
-        // failed the turn with "unsupported tool field: type".
-        if let Some(kind) = obj.get("type").and_then(Value::as_str) {
-            // Match the declaration exactly, name included. A prefix match
-            // would map any future `web_search_*` version, and any tool that
-            // merely carried such a type, onto xAI's hosted search.
-            if kind == "web_search_20250305" && name == "web_search" {
-                out.push(GrokTool::hosted("web_search"));
-                continue;
-            }
-            anyhow::bail!("unsupported tool type: {kind}");
+        let kind = match obj.get("type") {
+            None => None,
+            Some(Value::String(kind)) if !kind.is_empty() => Some(kind.as_str()),
+            Some(_) => anyhow::bail!("tool type is invalid"),
+        };
+        if let Some(max_uses) = obj.get("max_uses")
+            && !max_uses.is_null()
+            && max_uses.as_u64().is_none_or(|value| value == 0)
+        {
+            anyhow::bail!("tool max_uses must be a positive integer or null");
         }
-        // Only claim the caller's own search tools when hosted search is on.
-        // With hosted search off they fall through to the generic branch below
-        // and stay ordinary function tools, so the caller executes them itself.
+        if let Some(kind) = kind {
+            if kind != "web_search_20250305" || name != "web_search" {
+                anyhow::bail!("unsupported tool type: {kind}");
+            }
+            for field in ["allowed_domains", "blocked_domains", "user_location"] {
+                if obj.get(field).is_some_and(|value| !value.is_null()) {
+                    anyhow::bail!("Grok hosted web search does not support {field}");
+                }
+            }
+            out.push(GrokTool::hosted_named("web_search", name));
+            continue;
+        }
+        for field in ["allowed_domains", "blocked_domains", "user_location"] {
+            if obj.contains_key(field) {
+                anyhow::bail!("unsupported tool field: {field}");
+            }
+        }
+        if obj.contains_key("max_uses") && name != "WebSearch" {
+            anyhow::bail!("unsupported tool field: max_uses");
+        }
         if hosted_search && name == "WebSearch" {
-            out.push(GrokTool::hosted("web_search"));
+            out.push(GrokTool::hosted_named("web_search", name));
             continue;
         }
         if hosted_search && name == "XSearch" {
-            out.push(GrokTool::hosted("x_search"));
+            out.push(GrokTool::hosted_named("x_search", name));
             continue;
         }
         let parameters = obj
@@ -539,7 +567,7 @@ fn parse_tools(
 
 fn parse_tool_choice(
     value: Option<&Value>,
-    tools: Option<&Vec<GrokTool>>,
+    tools: &mut Option<Vec<GrokTool>>,
 ) -> anyhow::Result<Option<GrokToolChoice>> {
     let Some(value) = value else { return Ok(None) };
     let obj = value
@@ -576,15 +604,23 @@ fn parse_tool_choice(
                 .get("name")
                 .and_then(Value::as_str)
                 .ok_or_else(|| anyhow::anyhow!("tool_choice name is invalid"))?;
-            if !tools
-                .is_some_and(|items| items.iter().any(|tool| tool.name.as_deref() == Some(name)))
-            {
-                anyhow::bail!("tool_choice references an unknown tool");
+            let selected = tools
+                .as_ref()
+                .and_then(|items| {
+                    items
+                        .iter()
+                        .find(|tool| tool.choice_name.as_deref() == Some(name))
+                })
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("tool_choice references an unknown tool"))?;
+            if selected.kind == "function" {
+                return Ok(Some(GrokToolChoice::Function {
+                    r#type: "function".into(),
+                    name: name.into(),
+                }));
             }
-            Ok(Some(GrokToolChoice::Function {
-                r#type: "function".into(),
-                name: name.into(),
-            }))
+            *tools = Some(vec![selected]);
+            Ok(Some(GrokToolChoice::Required("required".into())))
         }
         _ => anyhow::bail!("unsupported tool_choice"),
     }
@@ -1299,10 +1335,7 @@ mod tests {
         }))
         .unwrap();
         let translated = translate_client_search(&request, "grok-4.5");
-        // The caller's own tool survives as a plain function, so the search
-        // comes back as tool_use / tool_result. Hosted search would instead
-        // return server_tool_use and web_search_tool_result, which the VS Code
-        // webview cannot draw.
+        // Caller-managed search remains a function tool.
         assert_eq!(translated["tools"][0]["type"], "function");
         assert_eq!(translated["tools"][0]["name"], "WebSearch");
         assert_eq!(translated["tools"].as_array().unwrap().len(), 1);
@@ -1342,9 +1375,7 @@ mod tests {
         }))
         .unwrap();
         let translated = translate_client_search(&request, "grok-4.5");
-        // xAI's X index has no client-side equivalent, so the turn gets it as
-        // one more tool. Everything the caller declared is still there, the
-        // system prompt is untouched, and nothing is pinned: the model picks.
+        // X-specific turns receive one additional hosted capability.
         let tools = translated["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 3);
         assert!(tools.iter().any(|t| t["name"] == "Bash"));
@@ -1363,9 +1394,23 @@ mod tests {
         }))
         .unwrap();
         let translated = translate_client_search(&request, "grok-4.5");
-        // A turn that never mentions X pays nothing for the capability.
         assert_eq!(translated["tools"].as_array().unwrap().len(), 1);
         assert!(!translated.to_string().contains("x_search"));
+    }
+
+    #[test]
+    fn grok_translation_requires_phrase_boundaries_for_x_search() {
+        for text in ["use unix search for files", "run a linux search command"] {
+            let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+                "model":"grok-4.5",
+                "messages":[{"role":"user","content":text}],
+                "tools":[{"name":"Bash","description":"Run a command","input_schema":{"type":"object"}}]
+            }))
+            .unwrap();
+            let translated = translate_client_search(&request, "grok-4.5");
+            assert_eq!(translated["tools"].as_array().unwrap().len(), 1);
+            assert!(!translated.to_string().contains("x_search"));
+        }
     }
 
     #[test]
@@ -1407,11 +1452,7 @@ mod tests {
         }))
         .unwrap();
         let translated = translate_hosted(&request, "grok-4.5");
-        // A greeting must reach the model with the caller's system prompt intact:
-        // no appended tool directive, so nothing sits in the highest-recency slot
-        // telling the model to go search.
         assert_eq!(translated["instructions"], "rules");
-        // The tool stays available; only the standing instruction to use it is gone.
         assert_eq!(
             translated["tools"],
             serde_json::json!([{"type":"x_search"}])
@@ -1428,8 +1469,6 @@ mod tests {
         }))
         .unwrap();
         let translated = translate_client_search(&request, "grok-4.5");
-        // No standing x_search tool, so a greeting gives the model nothing to
-        // search with and the reply carries no hosted-search blocks.
         assert_eq!(translated["instructions"], "rules");
         assert!(translated["tools"].as_array().is_none_or(|t| t.is_empty()));
         assert!(translated["tool_choice"].is_null());
@@ -1645,18 +1684,13 @@ mod tests {
             }]
         }))
         .unwrap();
-        // Claude Code sends this field on its own WebSearch. Rejecting it
-        // failed the request with a 400 and the turn got no search at all.
         let translated = translate_client_search(&request, "grok-4.5");
         assert_eq!(translated["tools"][0]["name"], "WebSearch");
-        // The cap belongs to the caller that declared it, so it is not relayed.
         assert!(!translated.to_string().contains("max_uses"));
     }
 
     #[test]
     fn grok_translation_maps_the_anthropic_server_web_search_declaration() {
-        // The exact shape captured from Claude Code 2.1.220 when the model
-        // searches: no input_schema, a versioned type, and a use cap.
         let request: MessagesRequest = serde_json::from_value(serde_json::json!({
             "model":"grok-4.5",
             "messages":[{"role":"user","content":"find it"}],
@@ -1668,13 +1702,83 @@ mod tests {
         .unwrap();
         let translated = translate_client_search(&request, "grok-4.5");
         let tools = translated["tools"].as_array().unwrap();
-        // The caller asked for server-side search, so it gets xAI's hosted
-        // tool. Its other tools are untouched.
         assert_eq!(tools.len(), 2);
         assert!(tools.iter().any(|t| t["name"] == "Bash"));
         assert!(tools.iter().any(|t| t["type"] == "web_search"));
         assert!(!translated.to_string().contains("web_search_20250305"));
         assert!(!translated.to_string().contains("max_uses"));
+    }
+
+    #[test]
+    fn grok_translation_forces_a_named_hosted_web_search() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"find it"}],
+            "tools":[
+                {"name":"Bash","description":"Run a command","input_schema":{"type":"object"}},
+                {"type":"web_search_20250305","name":"web_search","max_uses":8}
+            ],
+            "tool_choice":{"type":"tool","name":"web_search"}
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        assert_eq!(
+            translated["tools"],
+            serde_json::json!([{"type":"web_search"}])
+        );
+        assert_eq!(translated["tool_choice"], "required");
+    }
+
+    #[test]
+    fn grok_translation_rejects_unsupported_hosted_web_search_options() {
+        for (field, value) in [
+            ("allowed_domains", serde_json::json!(["example.com"])),
+            ("blocked_domains", serde_json::json!(["example.com"])),
+            (
+                "user_location",
+                serde_json::json!({"type":"approximate","country":"GB"}),
+            ),
+        ] {
+            let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+                "model":"grok-4.5",
+                "messages":[{"role":"user","content":"find it"}],
+                "tools":[{"type":"web_search_20250305","name":"web_search",(field):value}]
+            }))
+            .unwrap();
+            let error = translate_request_with_options(
+                &request,
+                "grok-4.5".into(),
+                crate::config::GrokToolImageMode::Omit,
+                false,
+            )
+            .unwrap_err()
+            .to_string();
+            assert_eq!(
+                error,
+                format!("Grok hosted web search does not support {field}")
+            );
+        }
+    }
+
+    #[test]
+    fn grok_translation_accepts_null_hosted_web_search_options() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"find it"}],
+            "tools":[{
+                "type":"web_search_20250305",
+                "name":"web_search",
+                "allowed_domains":null,
+                "blocked_domains":null,
+                "user_location":null
+            }]
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        assert_eq!(
+            translated["tools"],
+            serde_json::json!([{"type":"web_search"}])
+        );
     }
 
     #[test]
@@ -1698,9 +1802,7 @@ mod tests {
 
     #[test]
     fn grok_translation_rejects_a_server_tool_type_it_does_not_know_exactly() {
-        // A future version, and the right version under someone else's name,
-        // both stay rejected. Only the declaration Anthropic documents maps to
-        // xAI's hosted search.
+        // The mapping requires both the supported version and canonical name.
         for (kind, name) in [
             ("web_search_20991231", "web_search"),
             ("web_search_20250305", "MyOwnSearch"),
@@ -1740,6 +1842,34 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert_eq!(error, "unsupported tool field: invented");
+    }
+
+    #[test]
+    fn grok_translation_rejects_invalid_or_misplaced_search_fields() {
+        let invalid = [
+            serde_json::json!({"type":null,"name":"Bash","input_schema":{"type":"object"}}),
+            serde_json::json!({"type":1,"name":"Bash","input_schema":{"type":"object"}}),
+            serde_json::json!({"name":"WebSearch","max_uses":0,"input_schema":{"type":"object"}}),
+            serde_json::json!({"name":"WebSearch","max_uses":"many","input_schema":{"type":"object"}}),
+            serde_json::json!({"name":"Bash","max_uses":2,"input_schema":{"type":"object"}}),
+        ];
+        for tool in invalid {
+            let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+                "model":"grok-4.5",
+                "messages":[{"role":"user","content":"run it"}],
+                "tools":[tool]
+            }))
+            .unwrap();
+            assert!(
+                translate_request_with_options(
+                    &request,
+                    "grok-4.5".into(),
+                    crate::config::GrokToolImageMode::Omit,
+                    false,
+                )
+                .is_err()
+            );
+        }
     }
 
     #[test]

--- a/src/providers/grok/translate/request.rs
+++ b/src/providers/grok/translate/request.rs
@@ -136,39 +136,72 @@ pub fn translate_request_with_mode(
     model: String,
     image_mode: GrokToolImageMode,
 ) -> anyhow::Result<GrokResponsesRequest> {
+    translate_request_with_options(req, model, image_mode, crate::config::grok_hosted_search())
+}
+
+/// `hosted_search` selects how xAI's hosted search tools reach the model. Off,
+/// the default, offers `x_search` on an X turn and changes nothing else. On,
+/// the hosted tools replace the caller's search tools and an explicit search
+/// turn is forced. See `crate::config::grok_hosted_search`. Tests pass the flag
+/// directly so neither path depends on the environment.
+pub fn translate_request_with_options(
+    req: &MessagesRequest,
+    model: String,
+    image_mode: GrokToolImageMode,
+    hosted_search: bool,
+) -> anyhow::Result<GrokResponsesRequest> {
     reject_unknown_top_level(req)?;
     let mut instructions = parse_system(req.extra.get("system"))?;
-    let mut tools = parse_tools(req.extra.get("tools"))?;
+    let mut tools = parse_tools(req.extra.get("tools"), hosted_search)?;
     let hosted_web_search = tools
         .as_ref()
         .is_some_and(|tools| tools.iter().any(|tool| tool.kind == "web_search"));
     let dedicated_x_search = tools
         .as_ref()
         .is_some_and(|tools| tools.iter().any(|tool| tool.kind == "x_search"));
-    let x_search_intent = requests_x_search(req);
-    let force_x_search = dedicated_x_search || x_search_intent;
-    let force_web_search = !force_x_search && hosted_web_search && requests_web_search(req);
-    if force_x_search {
-        tools = Some(vec![GrokTool::hosted("x_search")]);
-    } else if force_web_search {
-        tools = Some(vec![GrokTool::hosted("web_search")]);
-    } else {
+    let mut forced_hosted_tool = false;
+    if hosted_search {
+        // Opt-in path. xAI's hosted tools replace the caller's search tools,
+        // the model is told to prefer them, and an explicit search turn pins
+        // tool_choice. Kept for callers who want xAI's own search and
+        // citations, and who run a client that draws hosted-search blocks.
+        let force_x_search = dedicated_x_search || requests_x_search(req);
+        let force_web_search = !force_x_search && hosted_web_search && requests_web_search(req);
+        if force_x_search {
+            tools = Some(vec![GrokTool::hosted("x_search")]);
+        } else if force_web_search {
+            tools = Some(vec![GrokTool::hosted("web_search")]);
+        } else {
+            let tools = tools.get_or_insert_default();
+            if !tools.iter().any(|tool| tool.kind == "x_search") {
+                tools.push(GrokTool::hosted("x_search"));
+            }
+        }
+        if hosted_web_search {
+            append_guidance(
+                &mut instructions,
+                "For general web searches, use the hosted web_search tool. Do not use shell commands, HTTP clients, or local tools to search the web.",
+            );
+        }
+        if force_x_search {
+            append_guidance(
+                &mut instructions,
+                "For requests to search X or Twitter, use the hosted x_search tool. XSearch accepts a query and supports allowed_x_handles, excluded_x_handles, from_date, and to_date filters. Do not use Bash, curl, HTTP clients, or general web_search for X searches.",
+            );
+        }
+        forced_hosted_tool = force_x_search || force_web_search;
+    } else if requests_x_search(req) {
+        // Default path. Claude Code has no X tool of its own, so xAI's index is
+        // only reachable if the proxy attaches it. Offer it as one more tool
+        // beside the caller's own, and stop there: no tool is removed, the
+        // system prompt is not written to, and tool_choice stays whatever the
+        // caller sent. The model decides whether the turn wants X.
         let tools = tools.get_or_insert_default();
         if !tools.iter().any(|tool| tool.kind == "x_search") {
             tools.push(GrokTool::hosted("x_search"));
         }
     }
-    if hosted_web_search {
-        append_guidance(
-            &mut instructions,
-            "For general web searches, use the hosted web_search tool. Do not use shell commands, HTTP clients, or local tools to search the web.",
-        );
-    }
-    append_guidance(
-        &mut instructions,
-        "For requests to search X or Twitter, use the hosted x_search tool. XSearch accepts a query and supports allowed_x_handles, excluded_x_handles, from_date, and to_date filters. Do not use Bash, curl, HTTP clients, or general web_search for X searches.",
-    );
-    let tool_choice = if force_x_search || force_web_search {
+    let tool_choice = if forced_hosted_tool {
         Some(GrokToolChoice::Required("required".into()))
     } else {
         parse_tool_choice(req.extra.get("tool_choice"), tools.as_ref())?
@@ -405,7 +438,10 @@ fn parse_system(value: Option<&Value>) -> anyhow::Result<Option<String>> {
     }
 }
 
-fn parse_tools(value: Option<&Value>) -> anyhow::Result<Option<Vec<GrokTool>>> {
+fn parse_tools(
+    value: Option<&Value>,
+    hosted_search: bool,
+) -> anyhow::Result<Option<Vec<GrokTool>>> {
     let Some(value) = value else { return Ok(None) };
     let tools = value
         .as_array()
@@ -423,6 +459,15 @@ fn parse_tools(value: Option<&Value>) -> anyhow::Result<Option<Vec<GrokTool>>> {
                 "input_schema",
                 "cache_control",
                 "eager_input_streaming",
+                // Claude Code caps its own WebSearch with `max_uses`. The cap
+                // is enforced by the caller that declared it, so the field is
+                // accepted and dropped rather than forwarded. Rejecting it
+                // failed the whole request with a 400 and left the turn with
+                // no search at all.
+                "max_uses",
+                // Anthropic's server-tool declarations carry a versioned
+                // `type` instead of an input schema. Handled below.
+                "type",
             ]
             .contains(&key.as_str())
             {
@@ -446,11 +491,33 @@ fn parse_tools(value: Option<&Value>) -> anyhow::Result<Option<Vec<GrokTool>>> {
         if !names.insert(name.to_string()) {
             anyhow::bail!("duplicate tool name");
         }
-        if name == "WebSearch" {
+        // Anthropic's server-tool declaration. Claude Code sends
+        // {"type":"web_search_20250305","name":"web_search","max_uses":8} the
+        // moment the model actually searches, and the tool carries no
+        // input_schema, so it cannot take the function path below. This is the
+        // caller explicitly asking for server-side search, so honour it with
+        // xAI's hosted tool whatever `hosted_search` says -- that setting
+        // governs whether the proxy seizes search on its own initiative, not
+        // whether it obeys a caller that asked. Rejecting the declaration
+        // failed the turn with "unsupported tool field: type".
+        if let Some(kind) = obj.get("type").and_then(Value::as_str) {
+            // Match the declaration exactly, name included. A prefix match
+            // would map any future `web_search_*` version, and any tool that
+            // merely carried such a type, onto xAI's hosted search.
+            if kind == "web_search_20250305" && name == "web_search" {
+                out.push(GrokTool::hosted("web_search"));
+                continue;
+            }
+            anyhow::bail!("unsupported tool type: {kind}");
+        }
+        // Only claim the caller's own search tools when hosted search is on.
+        // With hosted search off they fall through to the generic branch below
+        // and stay ordinary function tools, so the caller executes them itself.
+        if hosted_search && name == "WebSearch" {
             out.push(GrokTool::hosted("web_search"));
             continue;
         }
-        if name == "XSearch" {
+        if hosted_search && name == "XSearch" {
             out.push(GrokTool::hosted("x_search"));
             continue;
         }
@@ -1122,6 +1189,35 @@ fn flush_message(role: &str, content: &mut Vec<GrokContentPart>, out: &mut Vec<G
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Translate with an explicit hosted-search setting. Reading
+    /// `CCP_GROK_HOSTED_SEARCH` from the environment would make these tests
+    /// depend on the shell that ran them, so they pass the flag directly.
+    fn translate_search(
+        req: &MessagesRequest,
+        model: &str,
+        hosted_search: bool,
+    ) -> serde_json::Value {
+        serde_json::to_value(
+            translate_request_with_options(
+                req,
+                model.into(),
+                crate::config::GrokToolImageMode::Omit,
+                hosted_search,
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn translate_hosted(req: &MessagesRequest, model: &str) -> serde_json::Value {
+        translate_search(req, model, true)
+    }
+
+    fn translate_client_search(req: &MessagesRequest, model: &str) -> serde_json::Value {
+        translate_search(req, model, false)
+    }
+
     #[test]
     fn grok_translation_replays_hosted_search_history() {
         let request: MessagesRequest = serde_json::from_value(serde_json::json!({
@@ -1176,8 +1272,7 @@ mod tests {
             }]
         }))
         .unwrap();
-        let translated =
-            serde_json::to_value(translate_request(&request, "grok-4.5".into()).unwrap()).unwrap();
+        let translated = translate_hosted(&request, "grok-4.5");
         assert_eq!(
             translated["tools"],
             serde_json::json!([{"type":"web_search"}])
@@ -1192,6 +1287,30 @@ mod tests {
     }
 
     #[test]
+    fn grok_translation_keeps_client_web_search_tool_by_default() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"search online for the project"}],
+            "tools":[{
+                "name":"WebSearch",
+                "description":"Search the web",
+                "input_schema":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
+            }]
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        // The caller's own tool survives as a plain function, so the search
+        // comes back as tool_use / tool_result. Hosted search would instead
+        // return server_tool_use and web_search_tool_result, which the VS Code
+        // webview cannot draw.
+        assert_eq!(translated["tools"][0]["type"], "function");
+        assert_eq!(translated["tools"][0]["name"], "WebSearch");
+        assert_eq!(translated["tools"].as_array().unwrap().len(), 1);
+        assert!(!translated.to_string().contains("\"web_search\""));
+        assert!(!translated.to_string().contains("\"x_search\""));
+    }
+
+    #[test]
     fn grok_translation_maps_x_intent_to_required_hosted_x_search() {
         let request: MessagesRequest = serde_json::from_value(serde_json::json!({
             "model":"grok-4.5",
@@ -1202,14 +1321,51 @@ mod tests {
             ]
         }))
         .unwrap();
-        let translated =
-            serde_json::to_value(translate_request(&request, "grok-4.5".into()).unwrap()).unwrap();
+        let translated = translate_hosted(&request, "grok-4.5");
         assert_eq!(
             translated["tools"],
             serde_json::json!([{"type":"x_search"}])
         );
         assert_eq!(translated["tool_choice"], "required");
         assert!(!translated.to_string().contains("\"name\":\"Bash\""));
+    }
+
+    #[test]
+    fn grok_translation_offers_x_search_without_forcing_it() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"Search X for recent posts mentioning claude-code-proxy"}],
+            "tools":[
+                {"name":"Bash","description":"Run a command","input_schema":{"type":"object"}},
+                {"name":"WebSearch","description":"Search the web","input_schema":{"type":"object","properties":{"query":{"type":"string"}}}}
+            ]
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        // xAI's X index has no client-side equivalent, so the turn gets it as
+        // one more tool. Everything the caller declared is still there, the
+        // system prompt is untouched, and nothing is pinned: the model picks.
+        let tools = translated["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 3);
+        assert!(tools.iter().any(|t| t["name"] == "Bash"));
+        assert!(tools.iter().any(|t| t["name"] == "WebSearch"));
+        assert!(tools.iter().any(|t| t["type"] == "x_search"));
+        assert!(translated["tool_choice"].is_null());
+        assert!(!translated.to_string().contains("use the hosted x_search"));
+    }
+
+    #[test]
+    fn grok_translation_offers_no_x_search_without_x_intent() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"read the config file"}],
+            "tools":[{"name":"Bash","description":"Run a command","input_schema":{"type":"object"}}]
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        // A turn that never mentions X pays nothing for the capability.
+        assert_eq!(translated["tools"].as_array().unwrap().len(), 1);
+        assert!(!translated.to_string().contains("x_search"));
     }
 
     #[test]
@@ -1234,13 +1390,104 @@ mod tests {
             }]
         }))
         .unwrap();
-        let translated =
-            serde_json::to_value(translate_request(&request, "grok-4.5".into()).unwrap()).unwrap();
+        let translated = translate_hosted(&request, "grok-4.5");
         assert_eq!(
             translated["tools"],
             serde_json::json!([{"type":"x_search"}])
         );
         assert_eq!(translated["tool_choice"], "required");
+    }
+
+    #[test]
+    fn grok_translation_omits_x_search_guidance_without_x_intent() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "system":"rules",
+            "messages":[{"role":"user","content":"hi"}]
+        }))
+        .unwrap();
+        let translated = translate_hosted(&request, "grok-4.5");
+        // A greeting must reach the model with the caller's system prompt intact:
+        // no appended tool directive, so nothing sits in the highest-recency slot
+        // telling the model to go search.
+        assert_eq!(translated["instructions"], "rules");
+        // The tool stays available; only the standing instruction to use it is gone.
+        assert_eq!(
+            translated["tools"],
+            serde_json::json!([{"type":"x_search"}])
+        );
+        assert!(translated["tool_choice"].is_null());
+    }
+
+    #[test]
+    fn grok_translation_attaches_no_search_tool_to_a_greeting_by_default() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "system":"rules",
+            "messages":[{"role":"user","content":"hi"}]
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        // No standing x_search tool, so a greeting gives the model nothing to
+        // search with and the reply carries no hosted-search blocks.
+        assert_eq!(translated["instructions"], "rules");
+        assert!(translated["tools"].as_array().is_none_or(|t| t.is_empty()));
+        assert!(translated["tool_choice"].is_null());
+    }
+
+    #[test]
+    fn grok_translation_appends_x_search_guidance_on_x_intent() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "system":"rules",
+            "messages":[{"role":"user","content":"search twitter for the outage"}]
+        }))
+        .unwrap();
+        let translated = translate_hosted(&request, "grok-4.5");
+        let instructions = translated["instructions"].as_str().unwrap();
+        assert!(instructions.starts_with("rules"));
+        assert!(instructions.contains("use the hosted x_search tool"));
+    }
+
+    #[test]
+    fn grok_translation_appends_x_search_guidance_for_dedicated_x_tool() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "system":"rules",
+            "messages":[{"role":"user","content":"hi"}],
+            "tools":[{
+                "name":"XSearch",
+                "description":"Search X posts",
+                "input_schema":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
+            }]
+        }))
+        .unwrap();
+        let translated = translate_hosted(&request, "grok-4.5");
+        assert!(
+            translated["instructions"]
+                .as_str()
+                .unwrap()
+                .contains("use the hosted x_search tool")
+        );
+    }
+
+    #[test]
+    fn grok_translation_keeps_dedicated_xsearch_as_a_function_by_default() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "system":"rules",
+            "messages":[{"role":"user","content":"hi"}],
+            "tools":[{
+                "name":"XSearch",
+                "description":"Search X posts",
+                "input_schema":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
+            }]
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        assert_eq!(translated["tools"][0]["type"], "function");
+        assert_eq!(translated["tools"][0]["name"], "XSearch");
+        assert_eq!(translated["instructions"], "rules");
     }
 
     #[test]
@@ -1383,6 +1630,116 @@ mod tests {
             ]));
             assert!(translate_request(&request, "grok-4.5".into()).is_err());
         }
+    }
+
+    #[test]
+    fn grok_translation_accepts_web_search_max_uses_without_forwarding_it() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"find it"}],
+            "tools":[{
+                "name":"WebSearch",
+                "description":"Search the web",
+                "max_uses":6,
+                "input_schema":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
+            }]
+        }))
+        .unwrap();
+        // Claude Code sends this field on its own WebSearch. Rejecting it
+        // failed the request with a 400 and the turn got no search at all.
+        let translated = translate_client_search(&request, "grok-4.5");
+        assert_eq!(translated["tools"][0]["name"], "WebSearch");
+        // The cap belongs to the caller that declared it, so it is not relayed.
+        assert!(!translated.to_string().contains("max_uses"));
+    }
+
+    #[test]
+    fn grok_translation_maps_the_anthropic_server_web_search_declaration() {
+        // The exact shape captured from Claude Code 2.1.220 when the model
+        // searches: no input_schema, a versioned type, and a use cap.
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"find it"}],
+            "tools":[
+                {"name":"Bash","description":"Run a command","input_schema":{"type":"object"}},
+                {"type":"web_search_20250305","name":"web_search","max_uses":8}
+            ]
+        }))
+        .unwrap();
+        let translated = translate_client_search(&request, "grok-4.5");
+        let tools = translated["tools"].as_array().unwrap();
+        // The caller asked for server-side search, so it gets xAI's hosted
+        // tool. Its other tools are untouched.
+        assert_eq!(tools.len(), 2);
+        assert!(tools.iter().any(|t| t["name"] == "Bash"));
+        assert!(tools.iter().any(|t| t["type"] == "web_search"));
+        assert!(!translated.to_string().contains("web_search_20250305"));
+        assert!(!translated.to_string().contains("max_uses"));
+    }
+
+    #[test]
+    fn grok_translation_rejects_an_unknown_server_tool_type() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"run it"}],
+            "tools":[{"type":"code_execution_20260120","name":"code_execution"}]
+        }))
+        .unwrap();
+        let error = translate_request_with_options(
+            &request,
+            "grok-4.5".into(),
+            crate::config::GrokToolImageMode::Omit,
+            false,
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(error, "unsupported tool type: code_execution_20260120");
+    }
+
+    #[test]
+    fn grok_translation_rejects_a_server_tool_type_it_does_not_know_exactly() {
+        // A future version, and the right version under someone else's name,
+        // both stay rejected. Only the declaration Anthropic documents maps to
+        // xAI's hosted search.
+        for (kind, name) in [
+            ("web_search_20991231", "web_search"),
+            ("web_search_20250305", "MyOwnSearch"),
+        ] {
+            let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+                "model":"grok-4.5",
+                "messages":[{"role":"user","content":"find it"}],
+                "tools":[{"type":kind,"name":name}]
+            }))
+            .unwrap();
+            let error = translate_request_with_options(
+                &request,
+                "grok-4.5".into(),
+                crate::config::GrokToolImageMode::Omit,
+                false,
+            )
+            .unwrap_err()
+            .to_string();
+            assert_eq!(error, format!("unsupported tool type: {kind}"));
+        }
+    }
+
+    #[test]
+    fn grok_translation_still_rejects_an_unknown_tool_field() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model":"grok-4.5",
+            "messages":[{"role":"user","content":"find it"}],
+            "tools":[{"name":"WebSearch","input_schema":{"type":"object"},"invented":1}]
+        }))
+        .unwrap();
+        let error = translate_request_with_options(
+            &request,
+            "grok-4.5".into(),
+            crate::config::GrokToolImageMode::Omit,
+            false,
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(error, "unsupported tool field: invented");
     }
 
     #[test]

--- a/src/providers/grok/translate/search_text.rs
+++ b/src/providers/grok/translate/search_text.rs
@@ -1,19 +1,11 @@
-//! Text rendering of a hosted search that xAI already ran.
+//! Text projection for hosted searches completed by xAI.
 //!
-//! The faithful translation of hosted search is `server_tool_use` followed by
-//! `web_search_tool_result` or `x_search_tool_result`. Those two block types
-//! are unrenderable in some Anthropic clients -- notably the Claude Code VS
-//! Code webview, whose content-block renderer knows `text`, `thinking`,
-//! `redacted_thinking`, `tool_use`, `tool_result`, `image`, `document`, and
-//! `fallback`, and prints "Unsupported content type" for anything else.
-//!
-//! A `text` block says the same thing and draws everywhere, so it is the
-//! default shape. `CCP_GROK_SEARCH_BLOCKS=native` selects the block types
-//! above instead.
+//! Hosted-tool block support varies across Anthropic clients. The text shape
+//! preserves the search name and query using the baseline content type, while
+//! citations and usage remain attached to the translated response.
 
-/// One line naming a search the model already ran. The result payload is not
-/// included: xAI returns the findings as URL citations on the answer text, not
-/// as a separate result set, so the result block was always empty.
+/// One line naming a completed search. xAI returns findings as citations on the
+/// answer text, so the search event itself has no result payload to include.
 pub fn search_line(name: &str, query: &str) -> String {
     let label = match name {
         "x_search" => "X search",

--- a/src/providers/grok/translate/search_text.rs
+++ b/src/providers/grok/translate/search_text.rs
@@ -1,0 +1,54 @@
+//! Text rendering of a hosted search that xAI already ran.
+//!
+//! The faithful translation of hosted search is `server_tool_use` followed by
+//! `web_search_tool_result` or `x_search_tool_result`. Those two block types
+//! are unrenderable in some Anthropic clients -- notably the Claude Code VS
+//! Code webview, whose content-block renderer knows `text`, `thinking`,
+//! `redacted_thinking`, `tool_use`, `tool_result`, `image`, `document`, and
+//! `fallback`, and prints "Unsupported content type" for anything else.
+//!
+//! A `text` block says the same thing and draws everywhere, so it is the
+//! default shape. `CCP_GROK_SEARCH_BLOCKS=native` selects the block types
+//! above instead.
+
+/// One line naming a search the model already ran. The result payload is not
+/// included: xAI returns the findings as URL citations on the answer text, not
+/// as a separate result set, so the result block was always empty.
+pub fn search_line(name: &str, query: &str) -> String {
+    let label = match name {
+        "x_search" => "X search",
+        "web_search" => "web search",
+        other => other,
+    };
+    let query = query.trim();
+    if query.is_empty() {
+        format!("[{label}]\n")
+    } else {
+        format!("[{label}: {query}]\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_map_to_readable_labels() {
+        assert_eq!(search_line("web_search", "cars"), "[web search: cars]\n");
+        assert_eq!(search_line("x_search", "outage"), "[X search: outage]\n");
+    }
+
+    #[test]
+    fn an_unknown_hosted_tool_keeps_its_own_name() {
+        assert_eq!(
+            search_line("news_search", "budget"),
+            "[news_search: budget]\n"
+        );
+    }
+
+    #[test]
+    fn an_empty_query_drops_the_colon() {
+        // Grok emits follow-up search events with no query of their own.
+        assert_eq!(search_line("web_search", "   "), "[web search]\n");
+    }
+}

--- a/src/providers/grok/translate/stream.rs
+++ b/src/providers/grok/translate/stream.rs
@@ -1,5 +1,7 @@
 use super::reducer::{Reducer, ReducerEvent};
+use super::search_text::search_line;
 use crate::anthropic::sse::{SseEvent, encode_sse_event};
+use crate::config::GrokSearchBlocks;
 
 pub const MAX_SSE_FRAME_BYTES: usize = 1024 * 1024;
 
@@ -96,6 +98,7 @@ pub struct StreamTranslator {
     model: String,
     started: bool,
     finished: bool,
+    search_blocks: GrokSearchBlocks,
 }
 
 pub struct LiveStreamTranslator {
@@ -134,11 +137,21 @@ impl LiveStreamTranslator {
 
 impl StreamTranslator {
     pub fn new(message_id: String, model: String) -> Self {
+        Self::with_search_blocks(message_id, model, crate::config::grok_search_blocks())
+    }
+
+    /// Tests choose the shape directly rather than through the environment.
+    pub fn with_search_blocks(
+        message_id: String,
+        model: String,
+        search_blocks: GrokSearchBlocks,
+    ) -> Self {
         Self {
             message_id,
             model,
             started: false,
             finished: false,
+            search_blocks,
         }
     }
 
@@ -168,7 +181,7 @@ impl StreamTranslator {
             if matches!(event, ReducerEvent::Finish { .. }) {
                 self.finished = true;
             }
-            render(&mut out, event);
+            render(&mut out, event, self.search_blocks);
         }
         Ok(out)
     }
@@ -179,9 +192,26 @@ pub fn translate_stream_bytes(
     message_id: &str,
     model: &str,
 ) -> anyhow::Result<Vec<u8>> {
+    translate_stream_bytes_with_blocks(
+        upstream,
+        message_id,
+        model,
+        crate::config::grok_search_blocks(),
+    )
+}
+
+/// Tests choose the hosted-search block shape directly rather than through the
+/// environment.
+pub fn translate_stream_bytes_with_blocks(
+    upstream: &[u8],
+    message_id: &str,
+    model: &str,
+    search_blocks: GrokSearchBlocks,
+) -> anyhow::Result<Vec<u8>> {
     let mut decoder = SseDecoder::default();
     let mut reducer = Reducer::default();
-    let mut translator = StreamTranslator::new(message_id.into(), model.into());
+    let mut translator =
+        StreamTranslator::with_search_blocks(message_id.into(), model.into(), search_blocks);
     let mut out = Vec::new();
     for event in decoder.push(upstream)? {
         let value = serde_json::from_str(&event.data)
@@ -204,7 +234,7 @@ fn emit(out: &mut Vec<u8>, event: &str, data: serde_json::Value) {
     out.extend(encode_sse_event(Some(event), &data.to_string()));
 }
 
-fn render(out: &mut Vec<u8>, event: ReducerEvent) {
+fn render(out: &mut Vec<u8>, event: ReducerEvent, search_blocks: GrokSearchBlocks) {
     match event {
         ReducerEvent::ThinkingStart(i) => emit(
             out,
@@ -243,6 +273,44 @@ fn render(out: &mut Vec<u8>, event: ReducerEvent) {
             "content_block_delta",
             serde_json::json!({"type":"content_block_delta","index":i,"delta":{"type":"input_json_delta","partial_json":t}}),
         ),
+        ReducerEvent::HostedSearch {
+            index,
+            result_index,
+            id,
+            name,
+            query,
+        } if search_blocks == GrokSearchBlocks::Text => {
+            // Two text blocks, because the reducer already allocated two
+            // indices for this search and a gap in the sequence would leave a
+            // hole in the client's block array. The line goes in the first;
+            // the second stays empty and draws as nothing.
+            emit(
+                out,
+                "content_block_start",
+                serde_json::json!({"type":"content_block_start","index":index,"content_block":{"type":"text","text":""}}),
+            );
+            emit(
+                out,
+                "content_block_delta",
+                serde_json::json!({"type":"content_block_delta","index":index,"delta":{"type":"text_delta","text":search_line(&name,&query)}}),
+            );
+            emit(
+                out,
+                "content_block_stop",
+                serde_json::json!({"type":"content_block_stop","index":index}),
+            );
+            emit(
+                out,
+                "content_block_start",
+                serde_json::json!({"type":"content_block_start","index":result_index,"content_block":{"type":"text","text":""}}),
+            );
+            emit(
+                out,
+                "content_block_stop",
+                serde_json::json!({"type":"content_block_stop","index":result_index}),
+            );
+            let _ = id;
+        }
         ReducerEvent::HostedSearch {
             index,
             result_index,
@@ -370,26 +438,94 @@ mod tests {
     #[test]
     fn stream_translates_hosted_web_search_and_citations() {
         let input = b"data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\"}}\n\ndata: {\"type\":\"response.web_search_call.in_progress\",\"item_id\":\"ws_1\"}\n\ndata: {\"type\":\"response.web_search_call.searching\",\"item_id\":\"ws_1\"}\n\ndata: {\"type\":\"response.web_search_call.completed\",\"item_id\":\"ws_1\"}\n\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"action\":{\"query\":\"rust news\"}}}\n\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Result\"}\n\ndata: {\"type\":\"response.output_text.annotation.added\",\"annotation\":{\"type\":\"url_citation\",\"url\":\"https://example.com\",\"title\":\"Example\"}}\n\ndata: {\"type\":\"response.output_text.done\"}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n\n";
-        let output =
-            String::from_utf8(translate_stream_bytes(input, "msg_1", "grok-4.5").unwrap()).unwrap();
+        let output = String::from_utf8(
+            translate_stream_bytes_with_blocks(
+                input,
+                "msg_1",
+                "grok-4.5",
+                GrokSearchBlocks::Native,
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert!(output.contains("server_tool_use"));
         assert!(output.contains("web_search_tool_result"));
         assert!(output.contains("citations_delta"));
         assert!(output.contains("https://example.com"));
         assert!(output.contains("\"web_search_requests\":1"));
+
+        // The default shape says the same thing in a block every client draws.
+        let text = String::from_utf8(
+            translate_stream_bytes_with_blocks(input, "msg_1", "grok-4.5", GrokSearchBlocks::Text)
+                .unwrap(),
+        )
+        .unwrap();
+        // The usage object legitimately carries a `server_tool_use` counter, so
+        // match the block type rather than the bare word.
+        assert!(!text.contains("\"type\":\"server_tool_use\""));
+        assert!(!text.contains("web_search_tool_result"));
+        assert!(text.contains("[web search: rust news]"));
+        // Citations and usage are untouched by the block shape.
+        assert!(text.contains("citations_delta"));
+        assert!(text.contains("https://example.com"));
+        assert!(text.contains("\"web_search_requests\":1"));
+    }
+
+    #[test]
+    fn text_search_blocks_keep_the_block_index_sequence_contiguous() {
+        let input = b"data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\"}}\n\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"action\":{\"query\":\"rust news\"}}}\n\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Result\"}\n\ndata: {\"type\":\"response.output_text.done\"}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n\n";
+        let output = String::from_utf8(
+            translate_stream_bytes_with_blocks(input, "msg_1", "grok-4.5", GrokSearchBlocks::Text)
+                .unwrap(),
+        )
+        .unwrap();
+        // The reducer allocates two indices per search. A client that stores
+        // blocks by index would be left with a hole if only one were emitted.
+        let started: Vec<u64> = output
+            .lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter_map(|data| serde_json::from_str::<serde_json::Value>(data).ok())
+            .filter(|event| event["type"] == "content_block_start")
+            .filter_map(|event| event["index"].as_u64())
+            .collect();
+        assert_eq!(started, vec![0, 1, 2], "block indices are not contiguous");
     }
 
     #[test]
     fn stream_translates_hosted_x_search_usage_and_citations() {
         let input = b"data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"custom_tool_call\",\"name\":\"x_search\",\"id\":\"xs_1\"}}\n\ndata: {\"type\":\"response.custom_tool_call_input.delta\",\"item_id\":\"xs_1\",\"delta\":\"{\\\"query\\\":\\\"claude-code-proxy\\\"}\"}\n\ndata: {\"type\":\"response.custom_tool_call_input.done\",\"item_id\":\"xs_1\"}\n\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"custom_tool_call\",\"name\":\"x_search\",\"id\":\"xs_1\"}}\n\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"Recent post\"}\n\ndata: {\"type\":\"response.output_text.annotation.added\",\"annotation\":{\"type\":\"url_citation\",\"url\":\"https://x.com/example/status/1\",\"title\":\"Example post\"}}\n\ndata: {\"type\":\"response.output_text.done\"}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":4,\"output_tokens\":3}}}\n\n";
-        let output =
-            String::from_utf8(translate_stream_bytes(input, "msg_1", "grok-4.5").unwrap()).unwrap();
+        let output = String::from_utf8(
+            translate_stream_bytes_with_blocks(
+                input,
+                "msg_1",
+                "grok-4.5",
+                GrokSearchBlocks::Native,
+            )
+            .unwrap(),
+        )
+        .unwrap();
         assert!(output.contains("\"name\":\"x_search\""));
         assert!(output.contains("x_search_tool_result"));
         assert!(output.contains("https://x.com/example/status/1"));
         assert!(output.contains("\"web_search_requests\":1"));
         assert!(output.contains("\"x_search_requests\":1"));
         assert!(!output.contains("\"name\":\"Bash\""));
+
+        // X search stays fully usable under the default shape. It is the one
+        // hosted tool with no client-side equivalent, so losing it would cost
+        // a real capability rather than a rendering.
+        let text = String::from_utf8(
+            translate_stream_bytes_with_blocks(input, "msg_1", "grok-4.5", GrokSearchBlocks::Text)
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(!text.contains("x_search_tool_result"));
+        // The usage object legitimately carries a `server_tool_use` counter, so
+        // match the block type rather than the bare word.
+        assert!(!text.contains("\"type\":\"server_tool_use\""));
+        assert!(text.contains("[X search: claude-code-proxy]"));
+        assert!(text.contains("https://x.com/example/status/1"));
+        assert!(text.contains("\"x_search_requests\":1"));
     }
 
     #[test]

--- a/src/providers/grok/translate/stream.rs
+++ b/src/providers/grok/translate/stream.rs
@@ -454,7 +454,6 @@ mod tests {
         assert!(output.contains("https://example.com"));
         assert!(output.contains("\"web_search_requests\":1"));
 
-        // The default shape says the same thing in a block every client draws.
         let text = String::from_utf8(
             translate_stream_bytes_with_blocks(input, "msg_1", "grok-4.5", GrokSearchBlocks::Text)
                 .unwrap(),
@@ -511,9 +510,6 @@ mod tests {
         assert!(output.contains("\"x_search_requests\":1"));
         assert!(!output.contains("\"name\":\"Bash\""));
 
-        // X search stays fully usable under the default shape. It is the one
-        // hosted tool with no client-side equivalent, so losing it would cost
-        // a real capability rather than a rendering.
         let text = String::from_utf8(
             translate_stream_bytes_with_blocks(input, "msg_1", "grok-4.5", GrokSearchBlocks::Text)
                 .unwrap(),


### PR DESCRIPTION
Fixes #107
Fixes #108
Fixes #109
Fixes #110
Fixes #111

Five defects on the Grok provider, all found by running Claude Code against
the proxy and capturing the traffic. Two of them stop web search working at
all. One commit, 981 tests, docs updated.

### 1. Hosted-search blocks no client draws (#107)

**Symptom.** `Unsupported content type: server_tool_use` and
`Unsupported content type: web_search_tool_result`, two lines per search.

**Cause.** The proxy reports a hosted search as `server_tool_use` plus
`web_search_tool_result`, or an `x_search_tool_result` that is not an Anthropic
type at all. No Anthropic client I can find draws these today.

**Fix.** Report a hosted search as a text block naming the query. Every client
draws text. `CCP_GROK_SEARCH_BLOCKS=native` keeps the previous block types for
a client that does render them.

### 2. `max_uses` failed the request (#108)

**Symptom.** `400 unsupported tool field: max_uses`, no search runs.

**Cause.** Claude Code caps its own `WebSearch` with `max_uses`.
`parse_tools` whitelists five fields and bails on anything else.

**Fix.** Accept it and drop it. That matches the position already documented
for Codex in `reference/compatibility-and-limitations.md` -- the Anthropic cap
is not enforced because the provider exposes no equivalent.

### 3. Anthropic's server `web_search` declaration failed the request (#109)

**Symptom.** `400 unsupported tool field: type`, on every search attempt.

**Cause.** Claude Code escalates to `{"type":"web_search_20250305",
"name":"web_search","max_uses":8}` when the model searches. The declaration
carries no `input_schema`, so it could not take the function path either.

**Fix.** Accept it and map it to Grok hosted `web_search` -- the mapping
`providers/grok.md` already advertised. The match is exact on both type and
name, so a future version, or another tool carrying such a type, is still
rejected.

### 4. Searches on turns that asked for nothing (#110)

**Symptom.** A bare `hi`, sent with no tools and no system prompt, sometimes
answers with an `x_search` for the word "hi". Three times in 25 identical
requests against v0.1.34; zero results, one billed search request, and two
content blocks from #107.

**Cause.** `x_search` was pushed onto every request, including one that
declared no tools, and two directives were appended to the caller's system
prompt telling the model to use the hosted tools.

**Fix.** Gated behind `CCP_GROK_HOSTED_SEARCH`, off by default. By default the
caller's tools and system prompt are left alone. An X-intent turn is still
offered `x_search` as one additional tool, never in place of anything else, so
xAI's index stays reachable -- Claude Code has no X tool of its own.

### 5. Asking for a search deleted the caller's other tools (#111)

**Symptom.** With `Bash` and `WebSearch` declared, `hi, do pwd in the bash`
runs `pwd`. Add `also search the web for cat pictures` and `Bash` is gone from
the request, so `pwd` never runs. Reproduced five times out of five.

**Cause.** A turn matching one of fourteen substrings had its whole `tools`
array replaced with a single hosted tool and `tool_choice: required`. Nine
substrings route to `x_search`, five to `web_search`. Matching is
`text.contains`, so "uni**x search** for files" triggers it too.

**Fix.** Same gate as #110. On the default path nothing is removed from
the tool list and `tool_choice` stays whatever the caller sent.

#110 and #111 are the changes here that alter behaviour you chose
deliberately, so they are the ones to push back on if any. Commits 259f2cc and
7ad36f7 say the forcing exists so shell tools cannot become a search fallback,
which is a real problem -- I have kept the whole mechanism intact behind
`CCP_GROK_HOSTED_SEARCH=1`, which restores the old behaviour exactly.

### Verification

`cargo fmt --check`, `clippy -D warnings`, `build --all`, `test --all` all
pass. 962 tests before, 981 after: 19 new, none removed, none ignored.

Verified end to end against live Grok, on this commit:

- Anthropic's server `web_search` declaration carrying `max_uses` returns 200.
  The search runs, and the response contains no `server_tool_use` and no
  `web_search_tool_result` -- the queries arrive as text.
- `hi, do pwd in the bash. also search the web for cat pictures`, with `Bash`
  and `WebSearch` declared, calls both: `Bash` for `pwd` and the caller's own
  `WebSearch` for the search. Both halves of the message are answered.
- A bare `hi` with no tools answers the greeting and runs no search.

Every defect above was reproduced against the released v0.1.34 binary first,
so these are fixes rather than regressions.

`providers/grok.md` and `reference/configuration.md` are updated -- that
provider page described the old search behaviour as current. `CHANGELOG.md` is
untouched.

Happy to split this into separate PRs if you'd prefer.
