### PR TITLE
feat(codex): allow gpt-daybreak-blue

### DIFF
--- a/src/providers/codex/translate/model_allowlist.rs
+++ b/src/providers/codex/translate/model_allowlist.rs
@@ -14,6 +14,7 @@ pub const ALLOWED_MODELS: &[&str] = &[
     "gpt-5.6-luna",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
+    "gpt-daybreak-blue",
 ];
 
 pub const MODEL_ALIASES: &[(&str, &str)] = &[

--- a/src/providers/codex/translate/model_allowlist.rs
+++ b/src/providers/codex/translate/model_allowlist.rs
@@ -118,7 +118,10 @@ pub fn assert_allowed_model(model: &str) -> Result<(), ModelNotAllowedError> {
 }
 
 pub fn uses_responses_lite(model: &str) -> bool {
-    matches!(model, "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra")
+    matches!(
+        model,
+        "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-daybreak-blue"
+    )
 }
 
 /// `gpt-5.6-luna` exists only behind the Responses Lite lane; the full


### PR DESCRIPTION
Adds `gpt-daybreak-blue` to the Codex provider.

- Registered in `ALLOWED_MODELS`, so it can be selected by name and via the `-fast` priority-tier alias.
- Added to `uses_responses_lite`, since it serves from the Responses Lite lane alongside `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.

Not changed: `MODEL_ALIASES` (no Claude-name alias points at it yet) and `full_lane_web_search_model` (the luna → sol upgrade is specific to luna being lite-only; daybreak-blue has no full-lane sibling to fall back to).

`cargo fmt --check` and `cargo test --lib model_allowlist` (21 passed) are clean.
