### PR TITLE
feat(codex): allow gpt-daybreak-blue

### DIFF
--- a/src/providers/codex/translate/model_allowlist.rs
+++ b/src/providers/codex/translate/model_allowlist.rs
@@ -14,6 +14,7 @@ pub const ALLOWED_MODELS: &[&str] = &[
     "gpt-5.6-luna",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
+    "gpt-daybreak-blue",
 ];
 
 pub const MODEL_ALIASES: &[(&str, &str)] = &[
@@ -117,7 +118,10 @@ pub fn assert_allowed_model(model: &str) -> Result<(), ModelNotAllowedError> {
 }
 
 pub fn uses_responses_lite(model: &str) -> bool {
-    matches!(model, "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra")
+    matches!(
+        model,
+        "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-daybreak-blue"
+    )
 }
 
 /// `gpt-5.6-luna` exists only behind the Responses Lite lane; the full

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -47,6 +47,7 @@ pub(crate) const CODEX_MODELS: &[&str] = &[
     "gpt-5.6-luna",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
+    "gpt-daybreak-blue",
 ];
 
 pub(crate) const KIMI_MODELS: &[&str] = &["kimi-for-coding", "kimi-k2.6", "kimi-k3", "k2.6", "k3"];


### PR DESCRIPTION
Adds `gpt-daybreak-blue` to the Codex provider.

- `ALLOWED_MODELS` (`translate/model_allowlist.rs`) — selectable by name and via the `-fast` priority-tier alias.
- `uses_responses_lite` — it serves from the Responses Lite lane alongside `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- `CODEX_MODELS` (`registry.rs`) — so the model and its `-fast` sibling show up in `supported_models()`.

Not changed: `MODEL_ALIASES` (no Claude-name alias points at it yet) and `full_lane_web_search_model` (the luna → sol upgrade exists because luna is lite-only; daybreak-blue has no full-lane sibling to fall back to).

`cargo fmt --check` clean. `cargo test --lib` passes 828/828, skipping the two `keepalive_*` websocket tests, which are wall-clock timing tests that fail on this machine independently of this change.
