### PR TITLE
test(codex): give the blocked-replacement handshake a workable deadline

### DIFF
--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -2527,7 +2527,7 @@ mod tests {
             .await
         });
 
-        tokio::time::timeout(std::time::Duration::from_secs(2), replacement_accepted_rx)
+        tokio::time::timeout(std::time::Duration::from_secs(5), replacement_accepted_rx)
             .await
             .expect("replacement startup did not reach the blocked handshake")
             .expect("replacement startup acknowledgement sender dropped");


### PR DESCRIPTION
Fixes #124.

## Problem

`cancellation_while_replacement_startup_is_blocked_aborts_request_state` waits for the replacement WebSocket handshake before it asserts anything. That wait had a two-second deadline:

```rust
tokio::time::timeout(std::time::Duration::from_secs(2), replacement_accepted_rx)
    .await
    .expect("replacement startup did not reach the blocked handshake")
```

The handshake takes about 2.5 seconds here, so the wait expired every time and the test failed before reaching its assertions:

```text
panicked at src/providers/codex/mod.rs:2532:14:
replacement startup did not reach the blocked handshake: Elapsed(())
```

## Change

Raise that one deadline to five seconds.

The assertion under test is cancellation cleanup, not handshake latency, so the deadline only needs enough headroom to stop deciding the result.

## Verification

- The test passes 5 runs out of 5, each completing in about 2.6 seconds.
- `cargo test --lib`: 861 passed, 0 failed.
- `cargo fmt --check` clean.

Tested on Linux 6.18 (WSL2), rustc 1.97.1. The margin is now roughly double the observed handshake time, so a slower machine has room as well.
