### PR TITLE
feat(codex): allow gpt-6-astra

### DIFF
--- a/src/providers/codex/translate/model_allowlist.rs
+++ b/src/providers/codex/translate/model_allowlist.rs
@@ -14,6 +14,7 @@ pub const ALLOWED_MODELS: &[&str] = &[
     "gpt-5.6-luna",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
+    "gpt-6-astra",
 ];
 
 pub const MODEL_ALIASES: &[(&str, &str)] = &[
@@ -117,7 +118,10 @@ pub fn assert_allowed_model(model: &str) -> Result<(), ModelNotAllowedError> {
 }
 
 pub fn uses_responses_lite(model: &str) -> bool {
-    matches!(model, "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra")
+    matches!(
+        model,
+        "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-6-astra"
+    )
 }
 
 /// `gpt-5.6-luna` exists only behind the Responses Lite lane; the full
@@ -207,6 +211,7 @@ mod tests {
         assert!(assert_allowed_model("gpt-5.4").is_ok());
         assert!(assert_allowed_model("gpt-5.6-sol").is_ok());
         assert!(assert_allowed_model("gpt-5.6-terra").is_ok());
+        assert!(assert_allowed_model("gpt-6-astra").is_ok());
         assert!(assert_allowed_model("gpt-5.6-luna").is_ok());
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -47,6 +47,7 @@ pub(crate) const CODEX_MODELS: &[&str] = &[
     "gpt-5.6-luna",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
+    "gpt-6-astra",
 ];
 
 pub(crate) const KIMI_MODELS: &[&str] = &["kimi-for-coding", "kimi-k2.6", "kimi-k3", "k2.6", "k3"];


### PR DESCRIPTION
Adds `gpt-6-astra` (released 3 September) to the Codex provider.

- `ALLOWED_MODELS` (`translate/model_allowlist.rs`): selectable by name and via the `-fast` priority-tier alias.
- `uses_responses_lite`: it serves from the Responses Lite lane alongside the gpt-5.6 tier. Verified with a ChatGPT-authenticated Codex account: a request through the proxy returns 200 with `stop_reason: end_turn`, and a full Claude Code turn with `ANTHROPIC_MODEL=gpt-6-astra` completes.
- `CODEX_MODELS` (`registry.rs`): so the model and its `-fast` sibling appear in `GET /v1/models`.

Not changed: `MODEL_ALIASES`. The Claude aliases keep pointing at the gpt-5.6 tier; anyone who wants opus or fable on Astra can set `ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-6-astra` on the Claude Code side. `full_lane_web_search_model` is also untouched, as Astra is not lite-only.

Via Codex the model reports a 272k context window (872k max), so the 1M hint does not apply.

`cargo fmt --check` clean. `cargo test --lib`: 853 of 854 pass in the full parallel run; the one failure, `cancellation_while_replacement_startup_is_blocked_aborts_request_state`, is a timing test that passes in isolation on both this branch and unpatched v0.1.35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
