### PR TITLE
feat(codex): extend the model allowlist from the Codex CLI's model cache

### DIFF
--- a/src/providers/codex/chat_completions/request.rs
+++ b/src/providers/codex/chat_completions/request.rs
@@ -3,7 +3,7 @@ use serde_json::{Map, Value, json};
 
 use crate::providers::codex::translate::{
     model_allowlist::{
-        ALLOWED_MODELS, assert_allowed_model, resolve_model_request, uses_responses_lite,
+        allowed_models_display, assert_allowed_model, resolve_model_request, uses_responses_lite,
     },
     request::{Effort, resolve_effort_override, to_codex_effort},
 };
@@ -55,7 +55,7 @@ fn translate_request_with_override(
             format!(
                 "Model '{requested_model}' resolves to unsupported model '{}'. Supported: {}",
                 error.model,
-                ALLOWED_MODELS.join(", ")
+                allowed_models_display()
             ),
             Some("model"),
             Some("model_not_supported"),

--- a/src/providers/codex/native.rs
+++ b/src/providers/codex/native.rs
@@ -19,8 +19,8 @@ use crate::traffic::{
 
 use super::client::{CodexError, CodexHttpClient};
 use super::translate::model_allowlist::{
-    ALLOWED_MODELS, MODEL_ALIASES, assert_allowed_model, full_lane_web_search_model,
-    uses_responses_lite,
+    MODEL_ALIASES, allowed_models_display, assert_allowed_model, full_lane_web_search_model,
+    is_allowed_model, uses_responses_lite,
 };
 
 pub struct CodexNativeBackend {
@@ -102,7 +102,7 @@ pub fn validate_native_request_model(body: &Value) -> Result<String, Response> {
             format!(
                 "Model '{requested}' resolves to unsupported model '{}'. Supported: {}",
                 error.model,
-                ALLOWED_MODELS.join(", ")
+                allowed_models_display()
             ),
             Some("model"),
             Some("model_not_supported"),
@@ -141,7 +141,7 @@ fn shape_native_request(body: &mut Value) -> Result<NativeResolved, Response> {
 
 fn resolve_native_model(requested: &str) -> (String, bool) {
     let (requested, priority) = match requested.strip_suffix("-fast") {
-        Some(base) if ALLOWED_MODELS.contains(&base) => (base, true),
+        Some(base) if is_allowed_model(base) => (base, true),
         _ => (requested, false),
     };
     let model = MODEL_ALIASES

--- a/src/providers/codex/translate/mod.rs
+++ b/src/providers/codex/translate/mod.rs
@@ -1,6 +1,7 @@
 pub mod accumulate;
 pub mod live_stream;
 pub mod model_allowlist;
+pub mod model_catalog;
 pub mod read_rewrite;
 pub mod reasoning_signature;
 pub mod reducer;

--- a/src/providers/codex/translate/model_allowlist.rs
+++ b/src/providers/codex/translate/model_allowlist.rs
@@ -2,8 +2,12 @@ use std::collections::HashSet;
 
 use crate::config;
 
+use super::model_catalog::{catalog_model, catalog_models};
 use super::request::ServiceTier;
 
+/// Baseline allowlist compiled into the binary. At runtime the Codex CLI's
+/// model cache (`model_catalog`) extends it, so models OpenAI ships to Codex
+/// work before a proxy release lists them.
 pub const ALLOWED_MODELS: &[&str] = &[
     "gpt-5.2",
     "gpt-5.3-codex",
@@ -38,8 +42,47 @@ pub struct ResolvedModel {
     pub service_tier: Option<ServiceTier>,
 }
 
+/// True for baseline models and for API-supported models from the Codex
+/// model cache.
+pub fn is_allowed_model(model: &str) -> bool {
+    ALLOWED_MODELS.contains(&model)
+        || catalog_model(model).is_some_and(|entry| entry.supported_in_api)
+}
+
+/// Baseline ∪ API-supported catalog models, sorted and de-duplicated —
+/// for listings and error messages.
+pub fn allowed_models() -> Vec<String> {
+    let mut set: HashSet<String> = ALLOWED_MODELS.iter().map(|m| (*m).to_string()).collect();
+    for entry in catalog_models() {
+        if entry.supported_in_api {
+            set.insert(entry.slug);
+        }
+    }
+    let mut out: Vec<String> = set.into_iter().collect();
+    out.sort_unstable();
+    out
+}
+
+/// Catalog models advertised by the Codex picker (`visibility == "list"`)
+/// and usable through the API — what `models` and the unknown-model hint
+/// should show in addition to the baseline.
+pub fn listed_catalog_models() -> Vec<String> {
+    catalog_models()
+        .into_iter()
+        .filter(|entry| entry.listed && entry.supported_in_api)
+        .map(|entry| entry.slug)
+        .collect()
+}
+
+pub fn allowed_models_display() -> String {
+    allowed_models().join(", ")
+}
+
 fn fast_model_aliases() -> HashSet<String> {
-    ALLOWED_MODELS.iter().map(|m| format!("{m}-fast")).collect()
+    allowed_models()
+        .iter()
+        .map(|m| format!("{m}-fast"))
+        .collect()
 }
 
 fn resolve_fast_model_alias(model: &str) -> ResolvedModel {
@@ -108,7 +151,7 @@ impl std::fmt::Display for ModelNotAllowedError {
 }
 
 pub fn assert_allowed_model(model: &str) -> Result<(), ModelNotAllowedError> {
-    if ALLOWED_MODELS.contains(&model) {
+    if is_allowed_model(model) {
         Ok(())
     } else {
         Err(ModelNotAllowedError {
@@ -121,7 +164,7 @@ pub fn uses_responses_lite(model: &str) -> bool {
     matches!(
         model,
         "gpt-5.6-luna" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-6-astra"
-    )
+    ) || catalog_model(model).is_some_and(|entry| entry.use_responses_lite)
 }
 
 /// `gpt-5.6-luna` exists only behind the Responses Lite lane; the full
@@ -137,7 +180,7 @@ pub fn full_lane_web_search_model(model: &str) -> &str {
 }
 
 pub fn is_valid_model_for_codex(model: &str) -> bool {
-    if ALLOWED_MODELS.contains(&model) {
+    if is_allowed_model(model) {
         return true;
     }
     let fast_set = fast_model_aliases();
@@ -218,5 +261,15 @@ mod tests {
     #[test]
     fn not_allowed_rejected() {
         assert!(assert_allowed_model("gpt-7").is_err());
+        assert!(assert_allowed_model("gpt-7-fast").is_err());
+    }
+
+    #[test]
+    fn allowed_models_listing_contains_baseline() {
+        let listing = allowed_models();
+        for baseline in ALLOWED_MODELS {
+            assert!(listing.iter().any(|m| m == baseline), "{baseline} missing");
+        }
+        assert!(allowed_models_display().contains("gpt-6-astra"));
     }
 }

--- a/src/providers/codex/translate/model_catalog.rs
+++ b/src/providers/codex/translate/model_catalog.rs
@@ -1,0 +1,184 @@
+//! Model knowledge from the Codex CLI's own model cache
+//! (`$CODEX_HOME/models_cache.json`, default `~/.codex/models_cache.json`).
+//!
+//! The Codex CLI refreshes that file from the server (ETag fetch), so a model
+//! that OpenAI ships to Codex shows up there before this proxy can ship a
+//! release that lists it. The static allowlist in `model_allowlist` stays the
+//! baseline; the catalog extends it at runtime.
+//!
+//! Only the fields the proxy needs are read. Each model object is decoded
+//! leniently on its own, so one unexpected entry never discards the file.
+//! The parsed result is cached per (mtime, len) of the file; a missing or
+//! unreadable file keeps the last good parse (or yields nothing).
+
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{Mutex, OnceLock},
+    time::SystemTime,
+};
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogModel {
+    pub slug: String,
+    /// `use_responses_lite` — the model exists behind the Responses Lite lane.
+    pub use_responses_lite: bool,
+    /// `supported_in_api` — false for TUI-only models the backend rejects.
+    pub supported_in_api: bool,
+    /// `visibility == "list"` — shown in the Codex picker (hidden models are
+    /// still accepted when requested explicitly, just not advertised).
+    pub listed: bool,
+}
+
+#[derive(Deserialize)]
+struct CacheFile {
+    #[serde(default)]
+    models: Vec<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct CacheModel {
+    slug: String,
+    #[serde(default)]
+    use_responses_lite: bool,
+    #[serde(default = "default_true")]
+    supported_in_api: bool,
+    #[serde(default = "default_visibility")]
+    visibility: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_visibility() -> String {
+    "list".to_string()
+}
+
+struct CacheState {
+    key: Option<(SystemTime, u64)>,
+    models: Vec<CatalogModel>,
+}
+
+static CACHE: OnceLock<Mutex<CacheState>> = OnceLock::new();
+
+pub fn catalog_path() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("CODEX_HOME") {
+        return Some(PathBuf::from(dir).join("models_cache.json"));
+    }
+    std::env::var_os("HOME")
+        .map(|home| PathBuf::from(home).join(".codex").join("models_cache.json"))
+}
+
+/// Parses the cache file bytes. Returns `None` only if the top level is not
+/// the expected object; individual malformed models are skipped.
+pub fn parse_catalog(bytes: &[u8]) -> Option<Vec<CatalogModel>> {
+    let value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    if !value.is_object() {
+        return None;
+    }
+    let file: CacheFile = serde_json::from_value(value).ok()?;
+    let models = file
+        .models
+        .into_iter()
+        .filter_map(|value| serde_json::from_value::<CacheModel>(value).ok())
+        .filter(|model| !model.slug.is_empty())
+        .map(|model| CatalogModel {
+            listed: model.visibility == "list",
+            slug: model.slug,
+            use_responses_lite: model.use_responses_lite,
+            supported_in_api: model.supported_in_api,
+        })
+        .collect();
+    Some(models)
+}
+
+/// Current catalog snapshot (cached per file mtime/len).
+pub fn catalog_models() -> Vec<CatalogModel> {
+    let mutex = CACHE.get_or_init(|| {
+        Mutex::new(CacheState {
+            key: None,
+            models: Vec::new(),
+        })
+    });
+    let mut state = mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let Some(path) = catalog_path() else {
+        return state.models.clone();
+    };
+    let Some(key) = fs::metadata(&path)
+        .ok()
+        .and_then(|meta| Some((meta.modified().ok()?, meta.len())))
+    else {
+        return state.models.clone();
+    };
+    if state.key == Some(key) {
+        return state.models.clone();
+    }
+    if let Some(models) = fs::read(&path).ok().and_then(|bytes| parse_catalog(&bytes)) {
+        state.key = Some(key);
+        state.models = models;
+    }
+    state.models.clone()
+}
+
+pub fn catalog_model(slug: &str) -> Option<CatalogModel> {
+    catalog_models()
+        .into_iter()
+        .find(|model| model.slug == slug)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"{
+        "fetched_at": "2026-09-04T20:07:48Z",
+        "models": [
+            {"slug": "gpt-6-astra", "use_responses_lite": true, "supported_in_api": true, "visibility": "list"},
+            {"slug": "gpt-reserve", "use_responses_lite": true, "supported_in_api": true, "visibility": "hide"},
+            {"slug": "gpt-5.3-codex-spark", "use_responses_lite": false, "supported_in_api": false, "visibility": "list"},
+            {"slug": "gpt-7-minimal"},
+            {"nonsense": true},
+            {"slug": ""}
+        ]
+    }"#;
+
+    #[test]
+    fn parses_only_needed_fields_and_skips_broken_entries() {
+        let models = parse_catalog(FIXTURE.as_bytes()).expect("fixture parses");
+        assert_eq!(models.len(), 4);
+        assert_eq!(
+            models[0],
+            CatalogModel {
+                slug: "gpt-6-astra".into(),
+                use_responses_lite: true,
+                supported_in_api: true,
+                listed: true,
+            }
+        );
+        assert!(!models[1].listed, "hidden models are kept but not listed");
+        assert!(!models[2].supported_in_api);
+        // Missing fields fall back to: full lane, API-supported, listed.
+        assert_eq!(
+            models[3],
+            CatalogModel {
+                slug: "gpt-7-minimal".into(),
+                use_responses_lite: false,
+                supported_in_api: true,
+                listed: true,
+            }
+        );
+    }
+
+    #[test]
+    fn garbage_yields_none_and_empty_models_yields_empty() {
+        assert!(parse_catalog(b"not json").is_none());
+        assert!(parse_catalog(b"[]").is_none());
+        assert_eq!(parse_catalog(b"{}").unwrap(), Vec::<CatalogModel>::new());
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -315,9 +315,16 @@ const GROK_CLI: PlaceholderCli = PlaceholderCli { provider: "grok" };
 fn expand_codex_models() -> Vec<String> {
     let mut set = HashSet::new();
     let mut out = Vec::new();
-    for model in CODEX_MODELS {
-        if set.insert((*model).to_string()) {
-            out.push((*model).to_string());
+    // Baseline ∪ models the Codex CLI advertises in its own model cache, so a
+    // model OpenAI ships to Codex routes here before a proxy release lists it.
+    let catalog = crate::providers::codex::translate::model_allowlist::listed_catalog_models();
+    for model in CODEX_MODELS
+        .iter()
+        .map(|model| (*model).to_string())
+        .chain(catalog)
+    {
+        if set.insert(model.clone()) {
+            out.push(model.clone());
         }
         let fast = format!("{model}-fast");
         if set.insert(fast.clone()) {


### PR DESCRIPTION
## Why

Every new Codex model currently needs a code change plus a release before the proxy accepts it (#129 for `gpt-6-astra`, #113/#114 for `gpt-daybreak-blue`). Meanwhile the Codex CLI already knows the model: it keeps `~/.codex/models_cache.json` fresh from the server, including `supported_in_api`, `use_responses_lite` and `visibility` per model.

## What

Read that cache at runtime (`$CODEX_HOME/models_cache.json`, default `~/.codex/`) and treat it as an extension of the static allowlist:

- `is_allowed_model` / `assert_allowed_model` accept catalog models with `supported_in_api`.
- `uses_responses_lite` honours the catalog's `use_responses_lite`, so a new Lite-lane model is not sent down the full Responses API.
- `-fast` aliases, `models --full`, the unknown-model hint and registry routing (`expand_codex_models`) include catalog models with `visibility == "list"`.

The static lists remain the baseline for machines without a cache. The file is parsed leniently per model entry and cached by `(mtime, len)`; an unreadable file keeps the last good parse.

## Verification

- `cargo test` (864 + integration suites) green, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- Manual: with a cache entry `gpt-7-test` (`supported_in_api: true`) the binary lists `gpt-7-test` and `gpt-7-test-fast` and routes requests to Codex without any code change; an entry with `supported_in_api: false` stays rejected.
- Live: `gpt-6-astra` requests through the patched binary against the Codex backend (Subscription/OAuth) succeed, including a 905k-token input.
