### PR TITLE
fix(codex): isolate standalone search per Claude Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ title: Changelog
 description: Release notes for claude-code-proxy.
 ---
 
+## Unreleased
+
+- Codex standalone searches keep stable per-Agent sessions without colliding
+  with sibling Agents that share a Claude Code session, and align all upstream
+  search identity headers with the request body owner.
+
 ## v0.1.35 (2026-08-19)
 
 - Grok web search works reliably with Claude Code, preserves other tools, and

--- a/docs/src/content/docs/providers/codex.md
+++ b/docs/src/content/docs/providers/codex.md
@@ -49,6 +49,13 @@ Claude Code summary compaction requests are capped at low effort by default beca
   Structured result DTOs map back to Anthropic `server_tool_use` and
   `web_search_tool_result` blocks, while standalone text output remains text.
   The proxy locally estimates input and output tokens and reports search usage.
+  Standalone search sessions use the same ownership identity as continuation:
+  Main keeps its Claude Code session ID, while each direct Agent gets a stable,
+  opaque owner derived from its session and Agent IDs. The parent Agent ID is
+  validation-only. Missing, malformed, or ambiguous identity headers use a fresh
+  random search ID instead of sharing state. The search body ID and upstream
+  `session_id`, `x-client-request-id`, and `x-codex-window-id` headers all carry
+  that same search owner (with the window header's required `:0` suffix).
 - Top-level base64 user images map to `input_image`.
 - Supported base64 images nested in tool results also map to `input_image`.
 - Remote image URLs, malformed images, and unsupported tool-result image forms remain textual placeholders.

--- a/src/providers/codex/client.rs
+++ b/src/providers/codex/client.rs
@@ -185,8 +185,19 @@ pub fn build_native_codex_headers(
 pub fn build_codex_search_headers(
     auth: &StoredAuth,
     ctx: &RequestContext,
+    search_session_id: &str,
 ) -> Result<http::HeaderMap, CodexError> {
     let mut headers = build_codex_headers(auth, ctx, false)?;
+    headers.insert("session_id", header_value("session_id", search_session_id)?);
+    headers.insert(
+        "x-client-request-id",
+        header_value("x-client-request-id", search_session_id)?,
+    );
+    let window_id = format!("{search_session_id}:0");
+    headers.insert(
+        "x-codex-window-id",
+        header_value("x-codex-window-id", &window_id)?,
+    );
     headers.insert(
         http::header::ACCEPT,
         header_value("accept", "application/json")?,
@@ -1082,7 +1093,9 @@ impl CodexHttpClient {
         let mut retries = 0_u32;
 
         loop {
-            let response = self.attempt_post_search(&auth, &body_json, ctx).await?;
+            let response = self
+                .attempt_post_search(&auth, &body_json, ctx, &body.id)
+                .await?;
             if response.status == 401 && !auth_refresh_attempted {
                 auth_refresh_attempted = true;
                 auth = self
@@ -2419,9 +2432,10 @@ impl CodexHttpClient {
         auth: &StoredAuth,
         body_json: &str,
         ctx: &RequestContext,
+        search_session_id: &str,
     ) -> Result<CodexResponse, CodexError> {
         let url = search_endpoint(&self.base_url);
-        let headers = build_codex_search_headers(auth, ctx)?;
+        let headers = build_codex_search_headers(auth, ctx, search_session_id)?;
 
         if let Some(traffic) = ctx.traffic.as_deref() {
             write_codex_http_request_capture(traffic, &url, &headers, body_json);

--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -120,7 +120,7 @@ impl CodexProvider {
             let (search_request, query) = match search::build_search_request(
                 &body,
                 &resolved.model,
-                ctx.session_id.as_deref(),
+                conversation_identity.as_ref(),
             ) {
                 Ok(request) => request,
                 Err(error) => {

--- a/src/providers/codex/search.rs
+++ b/src/providers/codex/search.rs
@@ -5,6 +5,7 @@ use serde_json::{Value, json};
 
 use crate::anthropic::schema::MessagesRequest;
 use crate::anthropic::sse::encode_sse_event;
+use crate::request_identity::ConversationIdentity;
 use crate::traffic::TrafficCapture;
 
 use super::count_tokens::{approx_token_count, truncate_to_token_budget};
@@ -91,14 +92,15 @@ pub fn is_standalone_search_request(req: &MessagesRequest) -> bool {
 pub fn build_search_request(
     req: &MessagesRequest,
     model: &str,
-    session_id: Option<&str>,
+    owner: Option<&ConversationIdentity>,
 ) -> Result<(SearchRequest, String), anyhow::Error> {
     let query = extract_search_query(req)
         .ok_or_else(|| anyhow::anyhow!("web_search request does not contain a text query"))?;
     let input = search_input(req);
     let filters = search_filters(req);
-    let id = session_id
-        .map(str::to_owned)
+    let id = owner
+        .map(ConversationIdentity::search_session_id)
+        .map(Into::into)
         .unwrap_or_else(|| format!("search-{}", uuid::Uuid::new_v4()));
 
     Ok((
@@ -504,6 +506,7 @@ fn emit(out: &mut Vec<u8>, traffic: Option<&TrafficCapture>, event: &str, data: 
 mod tests {
     use super::*;
     use crate::anthropic::sse::parse_sse_events;
+    use crate::request_identity::ConversationIdentity;
 
     fn request() -> MessagesRequest {
         serde_json::from_value(json!({
@@ -528,9 +531,10 @@ mod tests {
     }
 
     #[test]
-    fn request_preserves_luna_and_omits_reasoning() {
+    fn request_preserves_luna_and_main_search_owner() {
+        let owner = ConversationIdentity::Main("session-1".into());
         let (request, query) =
-            build_search_request(&request(), "gpt-5.6-luna", Some("session-1")).unwrap();
+            build_search_request(&request(), "gpt-5.6-luna", Some(&owner)).unwrap();
         assert_eq!(request.model, "gpt-5.6-luna");
         assert_eq!(request.reasoning, None);
         assert_eq!(request.id, "session-1");
@@ -544,6 +548,36 @@ mod tests {
     }
 
     #[test]
+    fn request_uses_stable_isolated_agent_search_owners() {
+        let agent = ConversationIdentity::Agent("session-a".into(), "agent-a".into());
+        let same_agent = ConversationIdentity::Agent("session-a".into(), "agent-a".into());
+        let sibling = ConversationIdentity::Agent("session-a".into(), "agent-b".into());
+        let other_session = ConversationIdentity::Agent("session-b".into(), "agent-a".into());
+
+        let id = build_search_request(&request(), "gpt-5.6-luna", Some(&agent))
+            .unwrap()
+            .0
+            .id;
+        let same_id = build_search_request(&request(), "gpt-5.6-luna", Some(&same_agent))
+            .unwrap()
+            .0
+            .id;
+        let sibling_id = build_search_request(&request(), "gpt-5.6-luna", Some(&sibling))
+            .unwrap()
+            .0
+            .id;
+        let other_session_id =
+            build_search_request(&request(), "gpt-5.6-luna", Some(&other_session))
+                .unwrap()
+                .0
+                .id;
+
+        assert_eq!(id, same_id);
+        assert_ne!(id, sibling_id);
+        assert_ne!(id, other_session_id);
+    }
+
+    #[test]
     fn only_forced_claude_search_uses_standalone_endpoint() {
         let forced = request();
         assert!(is_standalone_search_request(&forced));
@@ -553,6 +587,22 @@ mod tests {
             .extra
             .insert("tool_choice".to_string(), json!({"type": "auto"}));
         assert!(!is_standalone_search_request(&automatic));
+    }
+
+    #[test]
+    fn absent_owner_uses_a_fresh_stateless_search_id() {
+        let first = build_search_request(&request(), "gpt-5.6-luna", None)
+            .unwrap()
+            .0
+            .id;
+        let second = build_search_request(&request(), "gpt-5.6-luna", None)
+            .unwrap()
+            .0
+            .id;
+
+        assert!(first.starts_with("search-"));
+        assert!(second.starts_with("search-"));
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/src/request_identity.rs
+++ b/src/request_identity.rs
@@ -1,4 +1,8 @@
+use std::borrow::Cow;
+use std::fmt::Write as _;
+
 use http::HeaderMap;
+use sha2::{Digest, Sha256};
 
 pub const CLAUDE_SESSION_HEADER: &str = "x-claude-code-session-id";
 pub const CLAUDE_AGENT_HEADER: &str = "x-claude-code-agent-id";
@@ -28,6 +32,26 @@ impl ConversationIdentity {
             }
             (Some(session_id), None, None) => Some(Self::Main(session_id.to_string())),
             _ => None,
+        }
+    }
+
+    pub fn search_session_id(&self) -> Cow<'_, str> {
+        match self {
+            Self::Main(session_id) => Cow::Borrowed(session_id),
+            Self::Agent(session_id, agent_id) => {
+                let mut digest = Sha256::new();
+                digest.update(b"claude-code-proxy:search-agent:v1\0");
+                for value in [session_id, agent_id] {
+                    digest.update((value.len() as u64).to_be_bytes());
+                    digest.update(value.as_bytes());
+                }
+                let digest = digest.finalize();
+                let mut encoded = String::with_capacity(digest.len() * 2);
+                for byte in digest {
+                    write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+                }
+                Cow::Owned(format!("search-agent-v1-{encoded}"))
+            }
         }
     }
 }
@@ -179,6 +203,42 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    #[test]
+    fn search_owner_is_stable_and_isolates_identity_tuples() {
+        let agent = ConversationIdentity::Agent("session-a".into(), "agent-a".into());
+        let sibling = ConversationIdentity::Agent("session-a".into(), "agent-b".into());
+        let other_session = ConversationIdentity::Agent("session-b".into(), "agent-a".into());
+        let shifted_boundary = ConversationIdentity::Agent("session-aa".into(), "gent-a".into());
+
+        assert_eq!(agent.search_session_id(), agent.search_session_id());
+        assert_ne!(agent.search_session_id(), sibling.search_session_id());
+        assert_ne!(agent.search_session_id(), other_session.search_session_id());
+        assert_ne!(
+            agent.search_session_id(),
+            shifted_boundary.search_session_id()
+        );
+    }
+
+    #[test]
+    fn agent_search_owner_is_bounded_and_does_not_disclose_raw_ids() {
+        let session = "s".repeat(MAX_IDENTITY_LEN);
+        let agent = "a".repeat(MAX_IDENTITY_LEN);
+        let owner = ConversationIdentity::Agent(session.clone(), agent.clone())
+            .search_session_id()
+            .into_owned();
+
+        assert_eq!(owner.len(), "search-agent-v1-".len() + 64);
+        assert!(!owner.contains(&session));
+        assert!(!owner.contains(&agent));
+    }
+
+    #[test]
+    fn main_search_owner_preserves_the_raw_session_id() {
+        let main = ConversationIdentity::Main("session-main".into());
+
+        assert_eq!(main.search_session_id(), "session-main");
     }
 
     #[test]

--- a/tests/smoke_cutover.rs
+++ b/tests/smoke_cutover.rs
@@ -105,6 +105,21 @@ async fn call_messages_body(body: Value) -> Response {
         .unwrap()
 }
 
+async fn call_messages_body_with_headers(body: Value, headers: &[(&str, &str)]) -> Response {
+    let _no_proxy_env = EnvGuard::set("NO_PROXY", "127.0.0.1,localhost");
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/v1/messages")
+        .header("content-type", "application/json");
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    app(Arc::new(Registry::with_default_alias()))
+        .oneshot(request.body(Body::from(body.to_string())).unwrap())
+        .await
+        .unwrap()
+}
+
 async fn call_responses_body(body: Value) -> Response {
     let _no_proxy_env = EnvGuard::set("NO_PROXY", "127.0.0.1,localhost");
     app_with_options(Arc::new(Registry::with_default_alias()), None, true)
@@ -170,17 +185,25 @@ where
     F: Fn(Value) -> Vec<u8> + Send + Sync + 'static,
 {
     let handler = Arc::new(handler);
+    spawn_http_upstream_with_headers(move |_, body| handler(body)).await
+}
+
+async fn spawn_http_upstream_with_headers<F>(handler: F) -> String
+where
+    F: Fn(http::HeaderMap, Value) -> Vec<u8> + Send + Sync + 'static,
+{
+    let handler = Arc::new(handler);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let addr_str = format!("http://{addr}");
 
     let app = axum::Router::new().fallback({
         let handler = handler.clone();
-        move |body: String| {
+        move |headers: http::HeaderMap, body: String| {
             let handler = handler.clone();
             async move {
                 let json: Value = serde_json::from_str(&body).unwrap_or_default();
-                let response_bytes = handler(json);
+                let response_bytes = handler(headers, json);
                 http::Response::builder()
                     .status(StatusCode::OK)
                     .header("content-type", "text/event-stream")
@@ -882,6 +905,121 @@ async fn spawn_websocket_always_empty_completion_upstream(
 // ---------------------------------------------------------------------------
 // Health and routing smoke tests (no env var mutation needed)
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn codex_standalone_search_uses_conversation_identity_owner() {
+    let _guard = env_lock();
+    let config = TempDir::new().unwrap();
+    write_auth(config.path(), "codex");
+    let captured = Arc::new(Mutex::new(Vec::<[String; 4]>::new()));
+    let upstream = spawn_http_upstream_with_headers({
+        let captured = captured.clone();
+        move |headers, body| {
+            captured.lock().unwrap().push([
+                body["id"].as_str().unwrap().to_string(),
+                headers
+                    .get("session_id")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                headers
+                    .get("x-client-request-id")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                headers
+                    .get("x-codex-window-id")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            ]);
+            serde_json::to_vec(&json!({
+                "encrypted_output": null,
+                "output": "search ok",
+                "results": []
+            }))
+            .unwrap()
+        }
+    })
+    .await;
+    let _config_env = EnvGuard::set("CCP_CONFIG_DIR", config.path());
+    let _base_url_env = EnvGuard::set("CCP_CODEX_BASE_URL", &upstream);
+    let body = json!({
+        "model": "gpt-5.6-luna",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": "Perform a web search for the query: identity owner"
+        }],
+        "tools": [{"type": "web_search_20250305", "name": "web_search"}],
+        "tool_choice": {"type": "tool", "name": "web_search"}
+    });
+    let cases: &[&[(&str, &str)]] = &[
+        &[
+            ("x-claude-code-session-id", "session-a"),
+            ("x-claude-code-agent-id", "agent-a"),
+            ("x-claude-code-parent-agent-id", "parent-one"),
+        ],
+        &[
+            ("x-claude-code-session-id", "session-a"),
+            ("x-claude-code-agent-id", "agent-a"),
+            ("x-claude-code-parent-agent-id", "parent-two"),
+        ],
+        &[
+            ("x-claude-code-session-id", "session-a"),
+            ("x-claude-code-agent-id", "agent-b"),
+        ],
+        &[
+            ("x-claude-code-session-id", "session-b"),
+            ("x-claude-code-agent-id", "agent-a"),
+        ],
+        &[("x-claude-code-session-id", "session-main")],
+        &[],
+        &[
+            ("x-claude-code-session-id", "session-malformed"),
+            ("x-claude-code-agent-id", "bad agent"),
+        ],
+    ];
+    for headers in cases {
+        let response = call_messages_body_with_headers(body.clone(), headers).await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    let identities = captured.lock().unwrap();
+    assert_eq!(identities.len(), cases.len());
+    for carriers in identities.iter() {
+        assert_eq!(carriers[1], carriers[0], "session_id must match body id");
+        assert_eq!(
+            carriers[2], carriers[0],
+            "x-client-request-id must match body id"
+        );
+        assert_eq!(
+            carriers[3],
+            format!("{}:0", carriers[0]),
+            "x-codex-window-id must use the body id"
+        );
+    }
+    assert_eq!(
+        identities[0][0], identities[1][0],
+        "same direct agent must keep its owner"
+    );
+    assert_ne!(
+        identities[0][0], identities[2][0],
+        "siblings must not share an owner"
+    );
+    assert_ne!(
+        identities[0][0], identities[3][0],
+        "sessions must not share an owner"
+    );
+    assert_eq!(identities[4][0], "session-main");
+    assert!(identities[5][0].starts_with("search-"));
+    assert!(identities[6][0].starts_with("search-"));
+    assert_ne!(identities[5][0], identities[6][0]);
+}
 
 #[tokio::test]
 async fn smoke_healthz_returns_ok() {


### PR DESCRIPTION
## Summary

Codex standalone WebSearch identified its upstream search session only by the Claude Code session ID. Claude Code Workflow children share that parent session while carrying distinct direct Agent IDs, so sibling searches contended on one upstream search session and returned `409 Search session is busy` after the proxy's internal wait.

This applies the ownership contract already established for continuation in #95/#96 to the standalone-search path.

Fixes #131.

## Ownership model

- Main: the Claude Code session ID, byte-identical to current behavior.
- Agent: a stable, bounded, domain-separated SHA-256 owner derived from the validated `(session ID, direct Agent ID)` pair, length-prefixed so no delimiter shift can alias two different tuples.
- Nested Agent: keyed by its own direct Agent ID; the parent Agent ID remains validation-only.
- Missing, malformed, duplicated, or ambiguous identity: unchanged stateless `search-<uuid>` fallback.

The raw session and Agent IDs are never sent in the derived owner, and the owner has fixed length regardless of input size.

## Change

`CodexProvider::handle_messages_inner` already receives the parsed `ConversationIdentity`; the standalone-search branch now passes it to `search::build_search_request` instead of `ctx.session_id`.

The same owner also had to reach the wire headers. `post_search` threads `SearchRequest.id` through `attempt_post_search` into `build_codex_search_headers`, which overrides `session_id`, `x-client-request-id`, and `x-codex-window-id` (`<id>:0`) for search requests only. Without that, the body was agent-scoped while the headers still carried the shared parent session.

Ordinary generation, continuation, compaction, count-tokens, model routing, and other providers are untouched.

## Tests

- `request_identity`: same agent stable; siblings distinct; same agent across sessions distinct; length-prefix boundary case (`session-aa`/`gent-a` vs `session-a`/`agent-a`); bounded length; no raw ID disclosure; Main preserved.
- `providers::codex::search`: Main preserves the raw session ID; agent owners stable and isolated; absent identity yields fresh distinct IDs; the existing forced-vs-automatic negative control is unchanged.
- `tests/smoke_cutover.rs::codex_standalone_search_uses_conversation_identity_owner`: drives `/v1/messages` end to end against a mock upstream and asserts all four identity carriers agree, siblings differ, differing parents do not change the owner, Main stays raw, and missing/malformed identity stays stateless.

## Validation

`just check-ci` on the committed tree:

- `format-check` ✓
- `clippy` (`-D warnings`) ✓
- `build` ✓
- `test` ✓ (866 lib + 5 bin + all integration suites, including `codex_agent_continuation` 12/12)

## Measured effect

Local fleet, three authenticated Codex accounts, several concurrent research workflows.

Before, five-minute window: 644 completions, 478 `409`, 163 `200`; 409 latency p50 15.1 s, p95 24.5 s.

After, running this build: an eight-agent Workflow issued 24 `WebSearch` and 8 `WebFetch` calls across 8 distinct Agent IDs with 0 tool errors, and the proxy log after cutover shows 964 completions, 0 failures, 31 completed searches at p50 2.0 s, p95 3.0 s.

No credentials, request bodies, or target data are included.
