### PR TITLE
fix(opencode): refresh Go catalog and accept terminal pings

### DIFF
--- a/docs/src/content/docs/providers/opencode-go.md
+++ b/docs/src/content/docs/providers/opencode-go.md
@@ -34,9 +34,9 @@ ANTHROPIC_SMALL_FAST_MODEL=opencode-go/glm-5.2 \
   claude --model opencode-go/glm-5.2
 ```
 
-The bare IDs `gpt-5.6-luna`, `grok-4.5`, `kimi-k3`, and `kimi-k2.6` remain
-owned by the existing Codex, Grok, or Kimi providers. Prefix those IDs with
-`opencode-go/` to select the OpenCode Go version.
+The bare IDs `gpt-5.6-luna`, `grok-4.5`, `grok-4.6`, `kimi-k3`, and `kimi-k2.6`
+remain owned by the existing Codex, Grok, or Kimi providers. Prefix those IDs
+with `opencode-go/` to select the OpenCode Go version.
 
 ## Tools and streaming
 
@@ -46,10 +46,9 @@ streamed incrementally and reassembled into Anthropic `tool_use` blocks.
 Upstream tool behavior remains model-dependent.
 
 Models served through the Anthropic-compatible endpoint retain their native
-messages stream. GPT 5.6 Luna uses OpenCode Go's Responses endpoint and is
-translated to the same Anthropic event stream as other providers. The proxy
-handles `/v1/messages/count_tokens` locally and does not send that request to
-OpenCode Go.
+messages stream. Responses-backed models are translated to the same Anthropic
+event stream as other providers. The proxy handles `/v1/messages/count_tokens`
+locally and does not send that request to OpenCode Go.
 
 ## Configuration
 

--- a/src/providers/codex/translate/reducer.rs
+++ b/src/providers/codex/translate/reducer.rs
@@ -340,6 +340,13 @@ pub(crate) fn reduce_upstream_bytes_with_policy(
         event_count += 1;
         last_event_type = Some(t.clone());
 
+        // OpenCode Go's Responses endpoint may append a billing/keepalive ping
+        // after response.completed. It carries no model output and is safe to
+        // ignore, while all other JSON events after a terminal remain invalid.
+        if _saw_terminal && t == "ping" {
+            continue;
+        }
+
         if _saw_terminal {
             let message = if t == "response.completed"
                 || t == "response.incomplete"
@@ -1438,6 +1445,24 @@ mod tests {
                 "response.completed",
                 json!({"response":{"id":"resp_1","status":"completed","usage":{}}}),
             ),
+        );
+
+        let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();
+        let Some(ReducerEvent::Finish { stop_reason, .. }) = out.last() else {
+            panic!("expected Finish");
+        };
+        assert_eq!(*stop_reason, STOP_END_TURN);
+    }
+
+    #[test]
+    fn completed_terminal_followed_by_ping_remains_valid() {
+        let upstream = format!(
+            "{}{}",
+            sse(
+                "response.completed",
+                json!({"response":{"id":"resp_1","status":"completed","usage":{}}}),
+            ),
+            sse("ping", json!({"cost":"0"})),
         );
 
         let out = reduce_upstream_bytes(upstream.as_bytes()).unwrap();

--- a/src/providers/opencode/chat.rs
+++ b/src/providers/opencode/chat.rs
@@ -350,9 +350,11 @@ fn map_reasoning_effort(req: &MessagesRequest, model: &str) -> anyhow::Result<Op
         return Ok(None);
     };
     let id = model.to_ascii_lowercase();
-    if ["glm-5.2", "glm-5-2", "glm-5p2"]
-        .iter()
-        .any(|needle| id.contains(needle))
+    if [
+        "glm-5.2", "glm-5-2", "glm-5p2", "glm-5.3", "glm-5-3", "glm-5p3",
+    ]
+    .iter()
+    .any(|needle| id.contains(needle))
     {
         return match effort {
             "high" => Ok(Some("high".into())),

--- a/src/providers/opencode/model.rs
+++ b/src/providers/opencode/model.rs
@@ -15,6 +15,10 @@ pub struct ModelSpec {
 
 pub const MODELS: &[ModelSpec] = &[
     ModelSpec {
+        id: "grok-4.6",
+        endpoint: EndpointKind::Responses,
+    },
+    ModelSpec {
         id: "grok-4.5",
         endpoint: EndpointKind::ChatCompletions,
     },
@@ -24,6 +28,14 @@ pub const MODELS: &[ModelSpec] = &[
     },
     ModelSpec {
         id: "glm-5.2",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "glm-5.3-flash",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "glm-5.3",
         endpoint: EndpointKind::ChatCompletions,
     },
     ModelSpec {
@@ -51,11 +63,31 @@ pub const MODELS: &[ModelSpec] = &[
         endpoint: EndpointKind::ChatCompletions,
     },
     ModelSpec {
+        id: "longcat-2.0",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
         id: "deepseek-v4-pro",
         endpoint: EndpointKind::ChatCompletions,
     },
     ModelSpec {
         id: "deepseek-v4-flash",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "deepseek-flash",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "deepseek-v4-flash-vision-exp",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "mimo-v2-pro",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "mimo-v2-omni",
         endpoint: EndpointKind::ChatCompletions,
     },
     ModelSpec {
@@ -83,6 +115,10 @@ pub const MODELS: &[ModelSpec] = &[
         endpoint: EndpointKind::Messages,
     },
     ModelSpec {
+        id: "qwen3.8-flash",
+        endpoint: EndpointKind::Messages,
+    },
+    ModelSpec {
         id: "qwen3.7-max",
         endpoint: EndpointKind::Messages,
     },
@@ -102,6 +138,26 @@ pub const MODELS: &[ModelSpec] = &[
         id: "hy3",
         endpoint: EndpointKind::ChatCompletions,
     },
+    ModelSpec {
+        id: "hy4-preview",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "hy3-preview",
+        endpoint: EndpointKind::ChatCompletions,
+    },
+    ModelSpec {
+        id: "muse-spark-1.3-contributor",
+        endpoint: EndpointKind::Responses,
+    },
+    ModelSpec {
+        id: "muse-spark-1.2-contributor",
+        endpoint: EndpointKind::Responses,
+    },
+    ModelSpec {
+        id: "omen-alpha",
+        endpoint: EndpointKind::ChatCompletions,
+    },
 ];
 
 pub fn resolve(raw: &str) -> Option<ModelSpec> {
@@ -114,7 +170,7 @@ pub fn advertised_models() -> Vec<String> {
     for model in MODELS {
         if !matches!(
             model.id,
-            "gpt-5.6-luna" | "grok-4.5" | "kimi-k3" | "kimi-k2.6"
+            "gpt-5.6-luna" | "grok-4.6" | "grok-4.5" | "kimi-k3" | "kimi-k2.6"
         ) {
             result.push(model.id.to_string());
         }
@@ -142,19 +198,35 @@ mod tests {
             .iter()
             .filter(|model| model.endpoint == EndpointKind::Responses)
             .count();
-        assert_eq!(chat, 13);
-        assert_eq!(messages, 8);
-        assert_eq!(responses, 1);
+        assert_eq!(chat, 23);
+        assert_eq!(messages, 9);
+        assert_eq!(responses, 4);
     }
 
     #[test]
     fn refreshed_models_resolve_and_are_advertised() {
         let advertised = advertised_models();
         for (id, endpoint) in [
+            ("glm-5.3-flash", EndpointKind::ChatCompletions),
+            ("glm-5.3", EndpointKind::ChatCompletions),
             ("glm-5", EndpointKind::ChatCompletions),
+            ("longcat-2.0", EndpointKind::ChatCompletions),
             ("kimi-k2.5", EndpointKind::ChatCompletions),
+            ("deepseek-flash", EndpointKind::ChatCompletions),
+            (
+                "deepseek-v4-flash-vision-exp",
+                EndpointKind::ChatCompletions,
+            ),
+            ("mimo-v2-pro", EndpointKind::ChatCompletions),
+            ("mimo-v2-omni", EndpointKind::ChatCompletions),
             ("qwen3.8-max", EndpointKind::Messages),
+            ("qwen3.8-flash", EndpointKind::Messages),
             ("qwen3.5-plus", EndpointKind::Messages),
+            ("hy4-preview", EndpointKind::ChatCompletions),
+            ("hy3-preview", EndpointKind::ChatCompletions),
+            ("muse-spark-1.3-contributor", EndpointKind::Responses),
+            ("muse-spark-1.2-contributor", EndpointKind::Responses),
+            ("omen-alpha", EndpointKind::ChatCompletions),
         ] {
             let qualified = format!("{MODEL_PREFIX}{id}");
             assert_eq!(
@@ -187,7 +259,14 @@ mod tests {
     #[test]
     fn conflicting_provider_ids_are_only_advertised_with_prefix() {
         let models = advertised_models();
-        for id in ["gpt-5.6-luna", "grok-4.5", "kimi-k3", "kimi-k2.6"] {
+        for id in [
+            "gpt-5.6-luna",
+            "grok-4.6",
+            "grok-4.5",
+            "kimi-k3",
+            "kimi-k2.6",
+        ] {
+            assert!(resolve(id).is_some());
             assert!(!models.iter().any(|model| model == id));
             assert!(
                 models

--- a/src/providers/opencode/responses.rs
+++ b/src/providers/opencode/responses.rs
@@ -137,15 +137,19 @@ where
                     done_seen = true;
                     continue;
                 }
-                if completion_seen || done_seen {
-                    return Some(self.fail_at("protocol", "event_after_completion"));
-                }
                 let value: serde_json::Value = match serde_json::from_str(data) {
                     Ok(value) => value,
                     Err(_) => return Some(self.fail_at("json", "malformed_event")),
                 };
+                let event_type = value.get("type").and_then(serde_json::Value::as_str);
+                if completion_seen || done_seen {
+                    if event_type == Some("ping") {
+                        continue;
+                    }
+                    return Some(self.fail_at("protocol", "event_after_completion"));
+                }
                 completion_seen = matches!(
-                    value.get("type").and_then(serde_json::Value::as_str),
+                    event_type,
                     Some("response.completed" | "response.incomplete" | "response.done")
                 );
             }
@@ -337,5 +341,32 @@ mod tests {
         assert!(
             String::from_utf8_lossy(&output).contains("OpenCode Go Responses stream is invalid")
         );
+    }
+
+    #[tokio::test]
+    async fn live_stream_accepts_ping_after_completion() {
+        let upstream = futures_util::stream::iter([Ok::<Bytes, OpenCodeError>(
+            Bytes::from_static(
+                b"data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\nevent: ping\ndata: {\"type\":\"ping\",\"cost\":\"0\"}\n\n",
+            ),
+        )]);
+        let mut state = ResponsesStreamState {
+            upstream,
+            decoder: SseDecoder::default(),
+            translator: LiveStreamTranslator::new("msg_1", "grok-4.6"),
+            terminal: false,
+            error_sent: false,
+            monitor: None,
+            req_id: "req".into(),
+            bytes: 0,
+            chunks: 0,
+            stream_capture: None,
+            traffic: None,
+        };
+
+        let output = state.next_output().await.expect("completion event");
+        let text = String::from_utf8_lossy(&output);
+        assert!(text.contains("message_stop"));
+        assert!(!text.contains("OpenCode Go Responses stream is invalid"));
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -431,6 +431,7 @@ mod tests {
         for (model, owner) in [
             ("gpt-5.6-luna", "codex"),
             ("grok-4.5", "grok"),
+            ("grok-4.6", "grok"),
             ("kimi-k3", "kimi"),
         ] {
             assert_eq!(


### PR DESCRIPTION
OpenCode Go's live catalog includes models that the proxy does not yet recognize, so Claude Code rejects those model IDs before reaching the provider. This refreshes the catalog with the 14 missing models and their Chat Completions, Messages, or Responses routes. It also keeps `grok-4.6` provider-qualified so the bare ID remains owned by the native Grok provider, and extends GLM reasoning-effort handling to GLM 5.3.

Live testing exposed a second issue on the newly routed `opencode-go/grok-4.6`: OpenCode appends a billing `ping` after `response.completed`, which made both buffered and streaming translation fail with HTTP 502. The translator now ignores only that harmless trailing ping while continuing to reject duplicate terminal events, late content, and malformed trailing frames.

Added models:

- `grok-4.6`, `glm-5.3`, `glm-5.3-flash`, `longcat-2.0`
- `deepseek-flash`, `deepseek-v4-flash-vision-exp`
- `mimo-v2-pro`, `mimo-v2-omni`
- `qwen3.8-flash`, `hy4-preview`, `hy3-preview`
- `muse-spark-1.3-contributor`, `muse-spark-1.2-contributor`, `omen-alpha`

Validation:

- `cargo test` — all unit, integration, and smoke suites pass
- Live GLM 5.3 Flash request through the proxy — HTTP 200
- Live Qwen 3.8 Flash request through the proxy — HTTP 200
- Live Grok 4.6 buffered and streaming requests through the proxy — HTTP 200 with clean completion
